### PR TITLE
Fix sec-fetch-site authentication bypass

### DIFF
--- a/server.js
+++ b/server.js
@@ -139,19 +139,24 @@ app.use((req, res, next) => {
     next();
 });
 
+// Auth status endpoint (always accessible, no auth required)
+app.get('/api/auth/status', (req, res) => {
+    res.json({ authRequired: !!API_KEY });
+});
+
 // API key authentication for /api/* routes
 app.use('/api', (req, res, next) => {
-    // Skip auth for same-origin browser requests
-    const fetchSite = req.headers['sec-fetch-site'];
-    if (fetchSite === 'same-origin') {
+    // Auth status endpoint is always accessible
+    if (req.path === '/auth/status') {
         return next();
     }
 
-    // Require API key for external requests
+    // No API key configured = no auth required
     if (!API_KEY) {
-        return next(); // No API key configured = no auth required
+        return next();
     }
 
+    // Require valid API key for all requests
     const providedKey = req.headers['x-api-key'];
     if (providedKey !== API_KEY) {
         return res.status(401).json({ error: 'Unauthorized. Provide a valid X-API-Key header.' });

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -2,9 +2,40 @@
 const TaskAPI = {
     baseUrl: '/api',
 
+    getApiKey() {
+        try {
+            return localStorage.getItem('gardenplanner_api_key') || '';
+        } catch {
+            return '';
+        }
+    },
+
+    setApiKey(key) {
+        try {
+            if (key) {
+                localStorage.setItem('gardenplanner_api_key', key);
+            } else {
+                localStorage.removeItem('gardenplanner_api_key');
+            }
+        } catch {
+            // localStorage unavailable
+        }
+    },
+
+    async checkAuthRequired() {
+        const res = await fetch(this.baseUrl + '/auth/status');
+        const data = await res.json();
+        return data.authRequired;
+    },
+
     async _fetch(url, options = {}) {
+        const headers = { 'Content-Type': 'application/json', ...options.headers };
+        const apiKey = this.getApiKey();
+        if (apiKey) {
+            headers['X-API-Key'] = apiKey;
+        }
         const res = await fetch(this.baseUrl + url, {
-            headers: { 'Content-Type': 'application/json', ...options.headers },
+            headers,
             ...options
         });
         if (!res.ok) {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -307,13 +307,20 @@ describe('Security', () => {
         expect(res.headers['x-content-type-options']).toBe('nosniff');
     });
 
-    test('rejects API request with wrong API key', async () => {
-        const originalKey = process.env.API_KEY;
-        process.env.API_KEY = 'secret123';
+    test('auth status endpoint is always accessible', async () => {
+        const res = await request(app).get('/api/auth/status');
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty('authRequired');
+    });
 
-        // Reimport not possible, but the middleware reads API_KEY at startup
-        // This test verifies the header check logic is present
-        process.env.API_KEY = originalKey;
+    test('does not bypass auth via sec-fetch-site header', async () => {
+        // This verifies the sec-fetch-site bypass has been removed.
+        // Since API_KEY is not set in tests, all requests are allowed,
+        // but the header should have no special effect on auth logic.
+        const res = await request(app)
+            .get('/api/tasks')
+            .set('sec-fetch-site', 'same-origin');
+        expect(res.status).toBe(200);
     });
 
     test('sanitizes XSS in task input', async () => {


### PR DESCRIPTION
## Summary
- **Removes spoofable `sec-fetch-site` header bypass** from API authentication middleware — any HTTP client could previously set this header to skip API key checks entirely
- **Adds `/api/auth/status` endpoint** (unauthenticated) so the frontend can detect whether API key auth is required
- **Updates `api.js`** to store and send API key via `X-API-Key` header from localStorage

Closes #56

## Test plan
- [ ] Verify API returns 401 when `API_KEY` is set and no key is provided
- [ ] Verify `sec-fetch-site: same-origin` header no longer bypasses auth
- [ ] Verify `/api/auth/status` returns `{ authRequired: true/false }` correctly
- [ ] Verify frontend API client sends stored API key in requests
- [ ] Verify all existing functionality works when `API_KEY` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)