### PR TITLE
Add server-side structured logging and audit trail (#84)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "gartenplaner",
       "version": "1.0.0",
       "dependencies": {
+        "compression": "^1.7.5",
         "cors": "^2.8.5",
         "express": "^4.21.0",
         "express-rate-limit": "^8.3.1",
+        "pino": "^9.14.0",
+        "pino-pretty": "^13.1.3",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -1069,6 +1072,12 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1628,6 +1637,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "30.3.0",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/babel-jest/-/babel-jest-30.3.0.tgz",
@@ -2077,6 +2095,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2098,6 +2122,45 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -2187,6 +2250,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -2334,6 +2406,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -2564,6 +2645,12 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.2",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fast-copy/-/fast-copy-4.0.2.tgz",
+      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2575,7 +2662,6 @@
       "version": "2.1.1",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fb-watchman": {
@@ -2891,6 +2977,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -3771,6 +3863,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4006,6 +4107,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/minipass/-/minipass-7.1.3.tgz",
@@ -4112,6 +4222,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/on-finished/-/on-finished-2.4.1.tgz",
@@ -4124,11 +4243,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4320,6 +4447,88 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pirates/-/pirates-4.0.7.tgz",
@@ -4371,6 +4580,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4382,6 +4607,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/pure-rand": {
@@ -4416,6 +4651,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/range-parser/-/range-parser-1.2.1.tgz",
@@ -4446,6 +4687,15 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4500,11 +4750,36 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4685,6 +4960,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/source-map/-/source-map-0.6.1.tgz",
@@ -4704,6 +4988,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -5083,6 +5376,15 @@
         "node": "*"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/tmpl/-/tmpl-1.0.5.tgz",
@@ -5396,7 +5698,6 @@
       "version": "1.0.2",
       "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "cors": "^2.8.5",
     "express": "^4.21.0",
     "express-rate-limit": "^8.3.1",
+    "pino": "^9.14.0",
+    "pino-pretty": "^13.1.3",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const rateLimit = require('express-rate-limit');
 const { v4: uuidv4 } = require('uuid');
 const fs = require('fs');
 const path = require('path');
+const { logger, audit, requestLogger } = require('./src/server/logger');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -141,6 +142,9 @@ app.use((req, res, next) => {
     next();
 });
 
+// Request logging
+app.use(requestLogger);
+
 // Auth status endpoint (always accessible, no auth required)
 app.get('/api/auth/status', (req, res) => {
     res.json({ authRequired: !!API_KEY });
@@ -161,6 +165,11 @@ app.use('/api', (req, res, next) => {
     // Require valid API key for all requests
     const providedKey = req.headers['x-api-key'];
     if (providedKey !== API_KEY) {
+        audit('auth_failure', {
+            ip: req.ip || req.connection.remoteAddress,
+            path: req.originalUrl,
+            method: req.method
+        });
         return res.status(401).json({ error: 'Unauthorized. Provide a valid X-API-Key header.' });
     }
     next();
@@ -284,6 +293,7 @@ app.post('/api/tasks', (req, res) => {
     tasks.push(task);
     writeTasks(tasks);
 
+    audit('task_created', { taskId: task.id, title: sanitized.title, employee: sanitized.employee });
     res.status(201).json(task);
 });
 
@@ -351,6 +361,7 @@ app.put('/api/tasks/:id', (req, res) => {
     tasks[index] = task;
     writeTasks(tasks);
 
+    audit('task_updated', { taskId: task.id, changes });
     res.json(task);
 });
 
@@ -360,9 +371,10 @@ app.delete('/api/tasks/:id', (req, res) => {
     const index = tasks.findIndex(t => String(t.id) === String(req.params.id));
     if (index === -1) return res.status(404).json({ error: 'Task not found' });
 
-    tasks.splice(index, 1);
+    const deletedTask = tasks.splice(index, 1)[0];
     writeTasks(tasks);
 
+    audit('task_deleted', { taskId: deletedTask.id, title: deletedTask.title });
     res.status(204).send();
 });
 
@@ -388,6 +400,7 @@ app.post('/api/tasks/:id/archive', (req, res) => {
     writeTasks(tasks);
     writeArchivedTasks(archived);
 
+    audit('task_archived', { taskId: task.id, title: task.title });
     res.json(task);
 });
 
@@ -413,6 +426,7 @@ app.post('/api/tasks/:id/unarchive', (req, res) => {
     writeArchivedTasks(archived);
     writeTasks(tasks);
 
+    audit('task_unarchived', { taskId: task.id, title: task.title });
     res.json(task);
 });
 
@@ -427,9 +441,10 @@ app.delete('/api/archived-tasks/:id', (req, res) => {
     const index = archived.findIndex(t => String(t.id) === String(req.params.id));
     if (index === -1) return res.status(404).json({ error: 'Archived task not found' });
 
-    archived.splice(index, 1);
+    const deletedArchived = archived.splice(index, 1)[0];
     writeArchivedTasks(archived);
 
+    audit('archived_task_deleted', { taskId: deletedArchived.id, title: deletedArchived.title });
     res.status(204).send();
 });
 
@@ -437,11 +452,10 @@ app.delete('/api/archived-tasks/:id', (req, res) => {
 
 if (require.main === module) {
     app.listen(PORT, () => {
-        console.log(`Gartenplaner API running on port ${PORT}`);
-        if (API_KEY) {
-            console.log('API key authentication enabled for external requests');
-        } else {
-            console.log('Warning: No API_KEY set. API is open for all requests.');
+        logger.info({ port: PORT, auth: !!API_KEY }, 'Gartenplaner API started');
+        audit('server_started', { port: PORT, authEnabled: !!API_KEY });
+        if (!API_KEY) {
+            logger.warn('No API_KEY set. API is open for all requests.');
         }
     });
 }

--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -1,0 +1,113 @@
+const pino = require('pino');
+const path = require('path');
+const fs = require('fs');
+
+const LOG_DIR = process.env.LOG_DIR || path.join(__dirname, '..', '..', 'data', 'logs');
+const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
+const MAX_LOG_SIZE = parseInt(process.env.MAX_LOG_SIZE, 10) || 10 * 1024 * 1024; // 10MB
+
+// Ensure log directory exists
+if (!fs.existsSync(LOG_DIR)) {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+}
+
+const logFile = path.join(LOG_DIR, 'server.log');
+const auditFile = path.join(LOG_DIR, 'audit.log');
+
+// Rotate log file if it exceeds MAX_LOG_SIZE
+function rotateIfNeeded(filePath) {
+    try {
+        if (fs.existsSync(filePath)) {
+            const stats = fs.statSync(filePath);
+            if (stats.size >= MAX_LOG_SIZE) {
+                const rotated = filePath + '.' + new Date().toISOString().replace(/[:.]/g, '-');
+                fs.renameSync(filePath, rotated);
+
+                // Keep only last 5 rotated files
+                const dir = path.dirname(filePath);
+                const base = path.basename(filePath);
+                const rotatedFiles = fs.readdirSync(dir)
+                    .filter(f => f.startsWith(base + '.'))
+                    .sort()
+                    .reverse();
+
+                for (const old of rotatedFiles.slice(5)) {
+                    fs.unlinkSync(path.join(dir, old));
+                }
+            }
+        }
+    } catch (err) {
+        console.error('Log rotation failed:', err.message);
+    }
+}
+
+rotateIfNeeded(logFile);
+rotateIfNeeded(auditFile);
+
+// Main application logger
+const transport = process.env.NODE_ENV === 'test'
+    ? undefined
+    : pino.transport({
+        targets: [
+            {
+                target: 'pino/file',
+                options: { destination: logFile, mkdir: true },
+                level: LOG_LEVEL
+            },
+            {
+                target: 'pino-pretty',
+                options: { colorize: true, translateTime: 'SYS:yyyy-mm-dd HH:MM:ss' },
+                level: LOG_LEVEL
+            }
+        ]
+    });
+
+const logger = pino({ level: LOG_LEVEL }, transport);
+
+// Audit logger - separate file for security/data events
+const auditTransport = process.env.NODE_ENV === 'test'
+    ? undefined
+    : pino.transport({
+        target: 'pino/file',
+        options: { destination: auditFile, mkdir: true }
+    });
+
+const auditLogger = pino({ level: 'info' }, auditTransport);
+
+// Structured audit log entry
+function audit(event, details = {}) {
+    auditLogger.info({
+        event,
+        ...details,
+        timestamp: new Date().toISOString()
+    });
+}
+
+// Express request logging middleware
+function requestLogger(req, res, next) {
+    const start = Date.now();
+
+    res.on('finish', () => {
+        const duration = Date.now() - start;
+        const logData = {
+            method: req.method,
+            url: req.originalUrl,
+            status: res.statusCode,
+            duration: duration + 'ms',
+            ip: req.ip || req.connection.remoteAddress,
+            userAgent: req.get('user-agent') || '-'
+        };
+
+        if (res.statusCode >= 500) {
+            logger.error(logData, 'request error');
+        } else if (res.statusCode >= 400) {
+            logger.warn(logData, 'request warning');
+        } else {
+            logger.info(logData, 'request');
+        }
+    });
+
+    next();
+}
+
+module.exports = { logger, audit, requestLogger, LOG_DIR };


### PR DESCRIPTION
## Summary
- Add pino-based structured JSON logging (`data/logs/server.log` + `data/logs/audit.log`)
- Request logging middleware tracking method, URL, status, duration, IP
- Audit trail for all task CRUD operations, archive/unarchive, auth failures, and server startup
- Log rotation at 10MB with 5 rotated files retained
- Configurable via `LOG_DIR`, `LOG_LEVEL`, `MAX_LOG_SIZE` environment variables

## Test plan
- [x] All 38 existing tests pass
- [x] Docker container runs and is healthy on test host
- [x] Logs are written correctly (server.log + audit.log)

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)