### PR TITLE
Add history and progress tracking (#42)

### DIFF
--- a/public/statistics.html
+++ b/public/statistics.html
@@ -65,8 +65,14 @@
                     </div>
                 </div>
                 <div class="chart-container full-width">
-                    <h3>📈 Wöchentliche Aktivität</h3>
+                    <h3>📈 Wöchentliche Aktivität (Erstellt)</h3>
                     <div id="activityChart" class="chart-timeline">
+                        <!-- Wird dynamisch gefüllt -->
+                    </div>
+                </div>
+                <div class="chart-container full-width">
+                    <h3>✅ Abschluss-Trend (30 Tage)</h3>
+                    <div id="completionTrendChart" class="chart-timeline">
                         <!-- Wird dynamisch gefüllt -->
                     </div>
                 </div>
@@ -102,6 +108,20 @@
                         <div class="stat-content">
                             <h4>Diese Woche</h4>
                             <p class="stat-value" id="statThisWeek">0</p>
+                        </div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-icon">✅</div>
+                        <div class="stat-content">
+                            <h4>Diese Woche erledigt</h4>
+                            <p class="stat-value" id="statCompletedThisWeek">0</p>
+                        </div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-icon">⏱️</div>
+                        <div class="stat-content">
+                            <h4>Durchschn. Bearbeitungszeit</h4>
+                            <p class="stat-value" id="statAvgCompletionTime">-</p>
                         </div>
                     </div>
                 </div>

--- a/server.js
+++ b/server.js
@@ -101,6 +101,11 @@ function validateTask(taskData, partial = false) {
             errors.push('Beschreibung darf maximal 2000 Zeichen lang sein');
         }
     }
+    if (taskData.notes !== undefined && taskData.notes !== '') {
+        if (typeof taskData.notes !== 'string' || taskData.notes.length > 5000) {
+            errors.push('Notizen dürfen maximal 5000 Zeichen lang sein');
+        }
+    }
     if (taskData.status !== undefined) {
         const valid = ['pending', 'in-progress', 'completed'];
         if (!valid.includes(taskData.status)) {
@@ -139,6 +144,7 @@ function sanitizeTaskData(data) {
     if (data.employee !== undefined) sanitized.employee = escapeHtml(data.employee.trim());
     if (data.location !== undefined) sanitized.location = escapeHtml(data.location.trim());
     if (data.description !== undefined) sanitized.description = escapeHtml(data.description.trim());
+    if (data.notes !== undefined) sanitized.notes = escapeHtml(data.notes.trim());
     if (data.status !== undefined) sanitized.status = data.status;
     if (data.priority !== undefined) sanitized.priority = data.priority;
     if (data.recurrence !== undefined) sanitized.recurrence = data.recurrence;
@@ -289,6 +295,7 @@ app.post('/api/tasks', (req, res) => {
         employee: sanitized.employee,
         location: sanitized.location,
         description: sanitized.description || '',
+        notes: sanitized.notes || '',
         status: sanitized.status || 'pending',
         priority: sanitized.priority || 'medium',
         recurrence: sanitized.recurrence || 'none',
@@ -349,6 +356,10 @@ app.put('/api/tasks/:id', (req, res) => {
     if (sanitized.description !== undefined && sanitized.description !== task.description) {
         changes.push('Beschreibung geändert');
         task.description = sanitized.description;
+    }
+    if (sanitized.notes !== undefined && sanitized.notes !== task.notes) {
+        changes.push('Notizen geändert');
+        task.notes = sanitized.notes;
     }
     if (sanitized.status !== undefined && sanitized.status !== task.status) {
         const oldStatus = task.status;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1700,6 +1700,11 @@ textarea {
     white-space: nowrap;
 }
 
+.timeline-bar.completion-bar {
+    background: linear-gradient(to top, #27ae60, #2ecc71);
+    border: 1px solid #1e8449;
+}
+
 .chart-empty {
     text-align: center;
     padding: 2rem;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -44,6 +44,14 @@ class GartenPlaner {
 		this.renderTasks();
 		this.updateStatistics();
 		this.initWeather();
+
+		this._ready = true;
+		if (this._onReady) this._onReady();
+	}
+
+	whenReady() {
+		if (this._ready) return Promise.resolve();
+		return new Promise((resolve) => { this._onReady = resolve; });
 	}
 
 	// ===== WEATHER API INTEGRATION =====

--- a/src/js/statistics-init.js
+++ b/src/js/statistics-init.js
@@ -1,9 +1,9 @@
 // Statistiken-Seite Initialisierung (#71)
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     if (window.gartenPlaner) {
+        await window.gartenPlaner.whenReady();
         console.log('📊 Statistiken-Seite geladen');
 
-        // Initial laden
         window.gartenPlaner.updateStatistics();
         window.gartenPlaner.updateCharts();
         window.gartenPlaner.updateAdditionalStats();

--- a/src/js/task-renderer.js
+++ b/src/js/task-renderer.js
@@ -338,6 +338,7 @@ GartenPlaner.prototype.updateCharts = function () {
 	this.updateEmployeeChart();
 	this.updateLocationChart();
 	this.updateActivityChart();
+	this.updateCompletionTrendChart();
 };
 
 GartenPlaner.prototype.updateEmployeeChart = function () {
@@ -462,6 +463,56 @@ GartenPlaner.prototype.updateActivityChart = function () {
 		.join("");
 };
 
+GartenPlaner.prototype.updateCompletionTrendChart = function () {
+	var chartEl = document.getElementById("completionTrendChart");
+	if (!chartEl) return;
+
+	// Last 30 days
+	var days = [];
+	var today = new Date();
+	for (var i = 29; i >= 0; i--) {
+		var date = new Date(today);
+		date.setDate(date.getDate() - i);
+		days.push(date);
+	}
+
+	// Collect all completed tasks (active + archived)
+	var allTasks = this.tasks.concat(this.archivedTasks);
+
+	var dayCounts = days.map((day) => {
+		var dayStr = day.toISOString().split("T")[0];
+		return {
+			date: day,
+			label: day.toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit" }),
+			count: allTasks.filter((task) => {
+				if (!task.completedAt) return false;
+				var completedDate = new Date(task.completedAt).toISOString().split("T")[0];
+				return completedDate === dayStr;
+			}).length,
+		};
+	});
+
+	var maxCount = Math.max(...dayCounts.map((d) => d.count), 1);
+	var totalCompleted = dayCounts.reduce((sum, d) => sum + d.count, 0);
+
+	if (totalCompleted === 0) {
+		chartEl.innerHTML = '<div class="chart-empty">Noch keine erledigten Aufgaben in den letzten 30 Tagen</div>';
+		return;
+	}
+
+	chartEl.innerHTML = dayCounts
+		.map((day) => {
+			var height = (day.count / maxCount) * 100;
+			return `
+				<div class="timeline-bar completion-bar" style="height: ${height}%" title="${day.count} erledigt am ${day.label}">
+					${day.count > 0 ? `<div class="timeline-bar-value">${day.count}</div>` : ""}
+					<div class="timeline-bar-label">${day.label}</div>
+				</div>
+			`;
+		})
+		.join("");
+};
+
 GartenPlaner.prototype.updateAdditionalStats = function () {
 	var statArchived = document.getElementById("statArchived");
 	var statLocations = document.getElementById("statLocations");
@@ -495,6 +546,41 @@ GartenPlaner.prototype.updateAdditionalStats = function () {
 			return new Date(task.createdAt) >= weekAgo;
 		});
 		statThisWeek.textContent = weekTasks.length;
+	}
+
+	// Completed this week
+	var statCompletedThisWeek = document.getElementById("statCompletedThisWeek");
+	if (statCompletedThisWeek) {
+		var weekAgo = new Date();
+		weekAgo.setDate(weekAgo.getDate() - 7);
+		var allTasks = this.tasks.concat(this.archivedTasks);
+		var completedThisWeek = allTasks.filter((task) => {
+			return task.completedAt && new Date(task.completedAt) >= weekAgo;
+		});
+		statCompletedThisWeek.textContent = completedThisWeek.length;
+	}
+
+	// Average completion time
+	var statAvgCompletionTime = document.getElementById("statAvgCompletionTime");
+	if (statAvgCompletionTime) {
+		var allTasks = this.tasks.concat(this.archivedTasks);
+		var completedWithTime = allTasks.filter((t) => t.completedAt && t.createdAt);
+		if (completedWithTime.length > 0) {
+			var totalHours = completedWithTime.reduce((sum, t) => {
+				var diff = new Date(t.completedAt) - new Date(t.createdAt);
+				return sum + diff / (1000 * 60 * 60);
+			}, 0);
+			var avgHours = totalHours / completedWithTime.length;
+			if (avgHours < 1) {
+				statAvgCompletionTime.textContent = Math.round(avgHours * 60) + " Min.";
+			} else if (avgHours < 24) {
+				statAvgCompletionTime.textContent = avgHours.toFixed(1) + " Std.";
+			} else {
+				statAvgCompletionTime.textContent = (avgHours / 24).toFixed(1) + " Tage";
+			}
+		} else {
+			statAvgCompletionTime.textContent = "-";
+		}
 	}
 
 	// History-Timeline rendern

--- a/src/js/task-renderer.js
+++ b/src/js/task-renderer.js
@@ -293,7 +293,7 @@ GartenPlaner.prototype.updateStatistics = function () {
 	}
 
 	// Diagramme aktualisieren (nur auf Statistiken-Seite)
-	if (window.location.pathname.includes("statistics.html")) {
+	if (window.location.pathname.includes("statistics")) {
 		this.updateCharts();
 	}
 };


### PR DESCRIPTION
## Summary
- Add `notes` field to tasks (gardening journal, max 5000 chars)
- Add 30-day completion trend chart (green bars) on statistics page
- Add "completed this week" and "avg completion time" stats
- Fix statistics page not loading data on initial render (async timing)
- Fix pathname check for `/statistics` route (was checking `.html` only)

Closes #42

## Test plan
- [x] All 50 tests pass
- [x] Completion trend chart shows completed tasks correctly
- [x] Statistics page loads data on first visit
- [x] Notes field accepted via API
- [x] Backwards-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)