### PR TITLE
Add weather-based garden reminders, make employee optional (#49)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
                         </div>
                         <div class="form-group">
                             <label for="taskEmployee">Mitarbeiter:</label>
-                            <input type="text" id="taskEmployee" required placeholder="Name des Mitarbeiters" aria-required="true">
+                            <input type="text" id="taskEmployee" placeholder="Name des Mitarbeiters (optional)">
                         </div>
                         <div class="form-group">
                             <label for="taskLocation">Standort:</label>

--- a/server.js
+++ b/server.js
@@ -86,9 +86,9 @@ function validateTask(taskData, partial = false) {
             errors.push('Titel muss zwischen 1 und 200 Zeichen lang sein');
         }
     }
-    if (!partial || taskData.employee !== undefined) {
-        if (typeof taskData.employee !== 'string' || taskData.employee.trim().length < 1 || taskData.employee.trim().length > 100) {
-            errors.push('Mitarbeiter muss angegeben werden (max 100 Zeichen)');
+    if (taskData.employee !== undefined && taskData.employee !== '') {
+        if (typeof taskData.employee !== 'string' || taskData.employee.trim().length > 100) {
+            errors.push('Mitarbeiter darf maximal 100 Zeichen lang sein');
         }
     }
     if (!partial || taskData.location !== undefined) {
@@ -292,7 +292,7 @@ app.post('/api/tasks', (req, res) => {
     const task = {
         id: uuidv4(),
         title: sanitized.title,
-        employee: sanitized.employee,
+        employee: sanitized.employee || '',
         location: sanitized.location,
         description: sanitized.description || '',
         notes: sanitized.notes || '',

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,45 +1,45 @@
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 /* Screen Reader Only - Accessibility */
 .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }
 
 /* Skip to main content link */
 .skip-to-main {
-    position: absolute;
-    top: -40px;
-    left: 0;
-    background: var(--primary);
-    color: white;
-    padding: 8px 16px;
-    text-decoration: none;
-    z-index: 9999;
-    border-radius: 0 0 4px 0;
-    font-weight: 600;
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--primary);
+  color: white;
+  padding: 8px 16px;
+  text-decoration: none;
+  z-index: 9999;
+  border-radius: 0 0 4px 0;
+  font-weight: 600;
 }
 
 .skip-to-main:focus {
-    top: 0;
+  top: 0;
 }
 
 /* Focus visible improvements */
 :focus-visible {
-    outline: 3px solid var(--primary);
-    outline-offset: 2px;
-    border-radius: 4px;
+  outline: 3px solid var(--primary);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 button:focus-visible,
@@ -47,8 +47,8 @@ a:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-    outline: 3px solid var(--primary);
-    outline-offset: 2px;
+  outline: 3px solid var(--primary);
+  outline-offset: 2px;
 }
 
 [data-theme="dark"] :focus-visible,
@@ -57,769 +57,785 @@ textarea:focus-visible {
 [data-theme="dark"] input:focus-visible,
 [data-theme="dark"] select:focus-visible,
 [data-theme="dark"] textarea:focus-visible {
-    outline-color: var(--primary);
+  outline-color: var(--primary);
 }
 
 :root {
-    --primary: #1b5e3f;
-    --primary-light: #2d6a4f;
-    --primary-dark: #0f3725;
-    --accent: #2d6a4f;
-    --danger: #b91c1c;
-    --warning: #ea580c;
-    --info: #1e40af;
-    --text: #0a0a0a;
-    --text-light: #525252;
-    --bg: #f5f5f5;
-    --bg-secondary: #ffffff;
-    --border: #d4d4d4;
-    --shadow: rgba(0, 0, 0, 0.12);
-    --focus-ring: rgba(27, 94, 63, 0.5);
+  --primary: #1b5e3f;
+  --primary-light: #2d6a4f;
+  --primary-dark: #0f3725;
+  --accent: #2d6a4f;
+  --danger: #b91c1c;
+  --warning: #ea580c;
+  --info: #1e40af;
+  --text: #0a0a0a;
+  --text-light: #525252;
+  --bg: #f5f5f5;
+  --bg-secondary: #ffffff;
+  --border: #d4d4d4;
+  --shadow: rgba(0, 0, 0, 0.12);
+  --focus-ring: rgba(27, 94, 63, 0.5);
 }
 
 [data-theme="dark"] {
-    --primary: #4ade80;
-    --primary-light: #6ee7a0;
-    --primary-dark: #22c55e;
-    --accent: #4ade80;
-    --success: #4ade80;
-    --success-light: rgba(74, 222, 128, 0.15);
-    --danger: #f87171;
-    --warning: #fb923c;
-    --info: #60a5fa;
-    --text: #f5f5f5;
-    --text-light: #a3a3a3;
-    --bg: #0f0f0f;
-    --focus-ring: rgba(74, 222, 128, 0.6);
-    --bg-secondary: #1c1c1c;
-    --bg-tertiary: #262626;
-    --border: #333333;
-    --border-light: #404040;
-    --shadow: rgba(0, 0, 0, 0.5);
-    --shadow-heavy: rgba(0, 0, 0, 0.8);
+  --primary: #4ade80;
+  --primary-light: #6ee7a0;
+  --primary-dark: #22c55e;
+  --accent: #4ade80;
+  --success: #4ade80;
+  --success-light: rgba(74, 222, 128, 0.15);
+  --danger: #f87171;
+  --warning: #fb923c;
+  --info: #60a5fa;
+  --text: #f5f5f5;
+  --text-light: #a3a3a3;
+  --bg: #0f0f0f;
+  --focus-ring: rgba(74, 222, 128, 0.6);
+  --bg-secondary: #1c1c1c;
+  --bg-tertiary: #262626;
+  --border: #333333;
+  --border-light: #404040;
+  --shadow: rgba(0, 0, 0, 0.5);
+  --shadow-heavy: rgba(0, 0, 0, 0.8);
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', 'Helvetica Neue', Arial, sans-serif;
-    background: var(--bg);
-    min-height: 100vh;
-    color: var(--text);
-    line-height: 1.6;
-    -webkit-font-smoothing: antialiased;
-    transition: background-color 0.3s ease, color 0.3s ease;
-    /* Smooth scrolling auf mobilen Geräten */
-    -webkit-overflow-scrolling: touch;
-    /* Verhindert ungewollte Zoom-Gesten */
-    touch-action: manipulation;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", "Helvetica Neue",
+    Arial, sans-serif;
+  background: var(--bg);
+  min-height: 100vh;
+  color: var(--text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
+  /* Smooth scrolling auf mobilen Geräten */
+  -webkit-overflow-scrolling: touch;
+  /* Verhindert ungewollte Zoom-Gesten */
+  touch-action: manipulation;
 }
 
 .container {
-    max-width: 100%;
-    width: 100%;
-    margin: 0;
-    background: var(--bg-secondary);
-    min-height: 100vh;
-    transition: background-color 0.3s ease;
-    /* Smooth scrolling */
-    scroll-behavior: smooth;
+  max-width: 100%;
+  width: 100%;
+  margin: 0;
+  background: var(--bg-secondary);
+  min-height: 100vh;
+  transition: background-color 0.3s ease;
+  /* Smooth scrolling */
+  scroll-behavior: smooth;
 }
 
 /* Dark Mode Toggle */
 .theme-toggle {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    z-index: 1000;
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 1000;
 }
 
 .theme-toggle-btn {
-    width: 56px;
-    height: 56px;
-    border-radius: 50%;
-    background: var(--primary);
-    color: white;
-    border: none;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: 0 4px 12px rgba(27, 94, 63, 0.3);
-    transition: all 0.3s ease;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: white;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(27, 94, 63, 0.3);
+  transition: all 0.3s ease;
 }
 
 .theme-icon {
-    width: 24px;
-    height: 24px;
-    transition: all 0.3s ease;
+  width: 24px;
+  height: 24px;
+  transition: all 0.3s ease;
 }
 
 .theme-toggle-btn:hover {
-    transform: scale(1.1) rotate(20deg);
-    box-shadow: 0 6px 16px rgba(27, 94, 63, 0.4);
+  transform: scale(1.1) rotate(20deg);
+  box-shadow: 0 6px 16px rgba(27, 94, 63, 0.4);
 }
 
 .theme-toggle-btn:hover .theme-icon {
-    transform: rotate(-20deg);
+  transform: rotate(-20deg);
 }
 
 .theme-toggle-btn:active {
-    transform: scale(0.95);
+  transform: scale(0.95);
 }
 
 [data-theme="dark"] .theme-toggle-btn {
-    background: var(--primary);
-    box-shadow: 0 4px 12px rgba(46, 204, 113, 0.3);
+  background: var(--primary);
+  box-shadow: 0 4px 12px rgba(46, 204, 113, 0.3);
 }
 
 [data-theme="dark"] .theme-toggle-btn:hover {
-    box-shadow: 0 6px 16px rgba(46, 204, 113, 0.4);
+  box-shadow: 0 6px 16px rgba(46, 204, 113, 0.4);
 }
 
 /* Header */
 header {
-    background: var(--bg-secondary);
-    padding: 2rem 3rem;
-    border-bottom: 3px solid var(--primary);
-    transition: background-color 0.3s ease;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  background: var(--bg-secondary);
+  padding: 2rem 3rem;
+  border-bottom: 3px solid var(--primary);
+  transition: background-color 0.3s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 [data-theme="dark"] header {
-    background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);
-    border-bottom-color: var(--primary);
-    box-shadow: 0 4px 12px var(--shadow);
+  background: linear-gradient(
+    135deg,
+    var(--bg-tertiary) 0%,
+    var(--bg-secondary) 100%
+  );
+  border-bottom-color: var(--primary);
+  box-shadow: 0 4px 12px var(--shadow);
 }
 
 header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    color: var(--primary);
-    margin-bottom: 0.25rem;
-    letter-spacing: -0.02em;
-    transition: color 0.3s ease;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--primary);
+  margin-bottom: 0.25rem;
+  letter-spacing: -0.02em;
+  transition: color 0.3s ease;
 }
 
 [data-theme="dark"] header h1 {
-    text-shadow: 0 0 20px rgba(74, 222, 128, 0.3);
+  text-shadow: 0 0 20px rgba(74, 222, 128, 0.3);
 }
 
 .subtitle {
-    font-size: 0.95rem;
-    color: var(--text-light);
-    font-weight: 400;
+  font-size: 0.95rem;
+  color: var(--text-light);
+  font-weight: 400;
 }
 
 /* Navigation */
 .main-nav {
-    display: flex;
-    gap: 0;
-    background: var(--bg-secondary);
-    padding: 0 3rem;
-    border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 0;
+  background: var(--bg-secondary);
+  padding: 0 3rem;
+  border-bottom: 1px solid var(--border);
 }
 
 .nav-link {
-    padding: 1rem 1.5rem;
-    text-decoration: none;
-    color: var(--text-light);
-    font-weight: 500;
-    font-size: 0.9rem;
-    transition: all 0.2s;
-    border-bottom: 3px solid transparent;
+  padding: 1rem 1.5rem;
+  text-decoration: none;
+  color: var(--text-light);
+  font-weight: 500;
+  font-size: 0.9rem;
+  transition: all 0.2s;
+  border-bottom: 3px solid transparent;
 }
 
 .nav-link:hover {
-    color: var(--primary);
-    border-bottom-color: var(--primary-light);
-    background: rgba(27, 94, 63, 0.05);
+  color: var(--primary);
+  border-bottom-color: var(--primary-light);
+  background: rgba(27, 94, 63, 0.05);
 }
 
 .nav-link.active {
-    color: var(--primary);
-    border-bottom-color: var(--primary);
-    background: rgba(27, 94, 63, 0.08);
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+  background: rgba(27, 94, 63, 0.08);
 }
 
 /* Main Content */
 @keyframes fadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 main {
-    padding: 2rem;
-    max-width: 100%;
-    width: 100%;
-    margin: 0;
-    animation: fadeIn 0.5s ease-out;
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
+  padding: 2rem;
+  max-width: 100%;
+  width: 100%;
+  margin: 0;
+  animation: fadeIn 0.5s ease-out;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
 }
 
 /* Spezielle Styles für index.html - volle Breite */
 body:has(.add-task-section) main {
-    padding: 2rem 2.5rem;
-    max-width: 100%;
-    width: 100%;
+  padding: 2rem 2.5rem;
+  max-width: 100%;
+  width: 100%;
 }
 
 body:has(.add-task-section) .container {
-    max-width: 100%;
-    padding: 0;
+  max-width: 100%;
+  padding: 0;
 }
 
 @media (min-width: 1200px) {
-    main {
-        grid-template-columns: 280px 1fr;
-        grid-template-areas:
-            "stats stats"
-            "filters filters"
-            "weather tasks"
-            "data data";
-        padding: 2rem 2.5rem;
-        gap: 1.5rem;
-        align-items: start;
-    }
-    
-    /* Volle Breite für index.html auch auf großen Bildschirmen */
-    body:has(.add-task-section) main {
-        grid-template-columns: 1fr;
-        padding: 2rem 4rem;
-    }
-    
-    /* Optimiertes Layout für Statistikenseite */
-    body:has(.history-section) main {
-        grid-template-columns: 1fr;
-        grid-template-areas:
-            "stats"
-            "charts"
-            "additional"
-            "history";
-        padding: 2rem 4rem;
-        gap: 3rem;
-        max-width: 1600px;
-        margin: 0 auto;
-    }
-    
-    body:has(.history-section) .stats-section {
-        grid-area: stats;
-    }
-    
-    body:has(.history-section) .charts-section {
-        grid-area: charts;
-    }
-    
-    body:has(.history-section) .additional-stats {
-        grid-area: additional;
-    }
-    
-    body:has(.history-section) .history-section {
-        grid-area: history;
-    }
-    
-    .stats-section {
-        grid-area: stats;
-    }
-    
-    .weather-section {
-        grid-area: weather;
-        position: sticky;
-        top: 1.5rem;
-        align-self: start;
-    }
-    
-    .filter-section {
-        grid-area: filters;
-        margin-bottom: 0;
-    }
-    
-    .filters {
-        margin-bottom: 0;
-    }
-    
-    .tasks-section {
-        grid-area: tasks;
-    }
-    
-    .tasks-section .search-section {
-        margin-bottom: 1.5rem;
-    }
-    
-    .data-management {
-        grid-area: data;
-    }
+  main {
+    grid-template-columns: 280px 1fr;
+    grid-template-areas:
+      "stats stats"
+      "filters filters"
+      "weather tasks"
+      "data data";
+    padding: 2rem 2.5rem;
+    gap: 1.5rem;
+    align-items: start;
+  }
+
+  /* Volle Breite für index.html auch auf großen Bildschirmen */
+  body:has(.add-task-section) main {
+    grid-template-columns: 1fr;
+    padding: 2rem 4rem;
+  }
+
+  /* Optimiertes Layout für Statistikenseite */
+  body:has(.history-section) main {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "stats"
+      "charts"
+      "additional"
+      "history";
+    padding: 2rem 4rem;
+    gap: 3rem;
+    max-width: 1600px;
+    margin: 0 auto;
+  }
+
+  body:has(.history-section) .stats-section {
+    grid-area: stats;
+  }
+
+  body:has(.history-section) .charts-section {
+    grid-area: charts;
+  }
+
+  body:has(.history-section) .additional-stats {
+    grid-area: additional;
+  }
+
+  body:has(.history-section) .history-section {
+    grid-area: history;
+  }
+
+  .stats-section {
+    grid-area: stats;
+  }
+
+  .weather-section {
+    grid-area: weather;
+    position: sticky;
+    top: 1.5rem;
+    align-self: start;
+  }
+
+  .filter-section {
+    grid-area: filters;
+    margin-bottom: 0;
+  }
+
+  .filters {
+    margin-bottom: 0;
+  }
+
+  .tasks-section {
+    grid-area: tasks;
+  }
+
+  .tasks-section .search-section {
+    margin-bottom: 1.5rem;
+  }
+
+  .data-management {
+    grid-area: data;
+  }
 }
 
 section {
-    margin-bottom: 3rem;
-    animation: fadeIn 0.6s ease-out;
+  margin-bottom: 3rem;
+  animation: fadeIn 0.6s ease-out;
 }
 
 section h2 {
-    color: var(--primary-dark);
-    margin-bottom: 1.5rem;
-    font-size: 1.25rem;
-    font-weight: 600;
-    letter-spacing: -0.01em;
-    border-left: 4px solid var(--primary);
-    padding-left: 1rem;
+  color: var(--primary-dark);
+  margin-bottom: 1.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  border-left: 4px solid var(--primary);
+  padding-left: 1rem;
 }
 
 /* Neue Aufgabe erstellen - Header Styling */
 .add-task-section {
-    max-width: 100%;
-    width: 100%;
-    margin: 0;
-    padding: 0;
+  max-width: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 .add-task-section #taskForm {
-    max-width: 100%;
-    width: 100%;
+  max-width: 100%;
+  width: 100%;
 }
 
 .add-task-section .form-row {
-    width: 100%;
-    grid-template-columns: repeat(4, 1fr);
+  width: 100%;
+  grid-template-columns: repeat(4, 1fr);
 }
 
 .add-task-section .form-row-two-cols {
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
 }
 
 .add-task-section .form-group {
-    width: 100%;
+  width: 100%;
 }
 
 .add-task-section button[type="submit"] {
-    width: 100%;
-    max-width: 100%;
-    padding: 1rem 2rem;
-    font-size: 1.1rem;
-    margin-top: 1rem;
+  width: 100%;
+  max-width: 100%;
+  padding: 1rem 2rem;
+  font-size: 1.1rem;
+  margin-top: 1rem;
 }
 
 #taskRecurrence {
-    width: 100%;
+  width: 100%;
 }
 
 #taskDescription {
-    width: 100%;
+  width: 100%;
 }
 
 #add-task-heading {
-    font-size: 2rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, var(--primary) 0%, #16a34a 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    border-left: none;
-    padding-left: 0;
-    margin-bottom: 2rem;
-    position: relative;
-    padding-bottom: 1rem;
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--primary) 0%, #16a34a 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  border-left: none;
+  padding-left: 0;
+  margin-bottom: 2rem;
+  position: relative;
+  padding-bottom: 1rem;
 }
 
 #add-task-heading::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 80px;
-    height: 4px;
-    background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
-    border-radius: 2px;
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 80px;
+  height: 4px;
+  background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
+  border-radius: 2px;
 }
 
 [data-theme="dark"] #add-task-heading {
-    background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 @media (min-width: 1200px) {
-    #filter-heading,
-    #tasksHeaderTitle {
-        font-size: 1rem;
-        margin-bottom: 1rem;
-    }
+  #filter-heading,
+  #tasksHeaderTitle {
+    font-size: 1rem;
+    margin-bottom: 1rem;
+  }
 }
 
 /* Form Styles */
 .form-row {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 1rem;
-    width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  width: 100%;
 }
 
 @media (min-width: 768px) {
-    .form-row {
-        grid-template-columns: repeat(3, 1fr);
-    }
+  .form-row {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .form-group {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .form-group:last-child {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 .form-group label {
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-    color: var(--text);
-    font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--text);
+  font-size: 0.9rem;
 }
 
 [data-theme="dark"] .form-group label {
-    color: var(--primary);
+  color: var(--primary);
 }
 
 .form-group input,
 .form-group select,
 .form-group textarea {
-    padding: 0.85rem 1rem;
-    border: 2px solid var(--border);
-    border-radius: 6px;
-    font-size: 1rem;
-    transition: all 0.3s;
-    background: var(--bg-secondary);
-    color: var(--text);
-    font-weight: 500;
+  padding: 0.85rem 1rem;
+  border: 2px solid var(--border);
+  border-radius: 6px;
+  font-size: 1rem;
+  transition: all 0.3s;
+  background: var(--bg-secondary);
+  color: var(--text);
+  font-weight: 500;
 }
 
 [data-theme="dark"] .form-group input,
 [data-theme="dark"] .form-group select,
 [data-theme="dark"] .form-group textarea {
-    background: var(--bg-tertiary);
-    border-color: var(--border-light);
-    color: var(--text);
+  background: var(--bg-tertiary);
+  border-color: var(--border-light);
+  color: var(--text);
 }
 
 .form-group input::placeholder,
 .form-group textarea::placeholder {
-    color: var(--text-light);
-    opacity: 0.6;
+  color: var(--text-light);
+  opacity: 0.6;
 }
 
 [data-theme="dark"] .form-group input::placeholder,
 [data-theme="dark"] .form-group textarea::placeholder {
-    color: var(--text-light);
-    opacity: 0.5;
+  color: var(--text-light);
+  opacity: 0.5;
 }
 
 .form-group input:focus,
 .form-group select:focus,
 .form-group textarea:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px rgba(27, 94, 63, 0.15);
-    background: var(--bg-secondary);
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(27, 94, 63, 0.15);
+  background: var(--bg-secondary);
 }
 
 [data-theme="dark"] .form-group input:focus,
 [data-theme="dark"] .form-group select:focus,
 [data-theme="dark"] .form-group textarea:focus {
-    border-color: var(--primary);
-    box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.25);
-    background: var(--bg-secondary);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.25);
+  background: var(--bg-secondary);
 }
 
 textarea {
-    resize: vertical;
-    font-family: inherit;
-    min-height: 100px;
+  resize: vertical;
+  font-family: inherit;
+  min-height: 100px;
 }
 
 /* Buttons */
 .btn {
-    padding: 0.85rem 1.75rem;
-    border: none;
-    border-radius: 6px;
-    font-size: 1rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s;
-    margin-top: 1rem;
-    /* Mindestgröße für Touch-Targets (44x44px WCAG) */
-    min-height: 44px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    /* Touch-optimiert */
-    -webkit-tap-highlight-color: transparent;
-    user-select: none;
+  padding: 0.85rem 1.75rem;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-top: 1rem;
+  /* Mindestgröße für Touch-Targets (44x44px WCAG) */
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  /* Touch-optimiert */
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
 }
 
 .btn-primary {
-    background: var(--primary);
-    color: white;
-    box-shadow: 0 2px 4px rgba(27, 94, 63, 0.2);
-    font-weight: 600;
+  background: var(--primary);
+  color: white;
+  box-shadow: 0 2px 4px rgba(27, 94, 63, 0.2);
+  font-weight: 600;
 }
 
 [data-theme="dark"] .btn-primary {
-    background: var(--primary);
-    box-shadow: 0 4px 12px rgba(74, 222, 128, 0.3);
+  background: var(--primary);
+  box-shadow: 0 4px 12px rgba(74, 222, 128, 0.3);
 }
 
 .btn-primary:hover {
-    background: var(--primary-dark);
-    box-shadow: 0 4px 8px rgba(27, 94, 63, 0.3);
-    transform: translateY(-1px);
+  background: var(--primary-dark);
+  box-shadow: 0 4px 8px rgba(27, 94, 63, 0.3);
+  transform: translateY(-1px);
 }
 
 [data-theme="dark"] .btn-primary:hover {
-    background: var(--primary-dark);
-    box-shadow: 0 6px 16px rgba(74, 222, 128, 0.4);
+  background: var(--primary-dark);
+  box-shadow: 0 6px 16px rgba(74, 222, 128, 0.4);
 }
 
 .btn-secondary {
-    background: var(--bg);
-    color: var(--text);
-    border: 2px solid var(--border);
-    margin-right: 10px;
+  background: var(--bg);
+  color: var(--text);
+  border: 2px solid var(--border);
+  margin-right: 10px;
 }
 
 [data-theme="dark"] .btn-secondary {
-    background: var(--bg-tertiary);
-    border-color: var(--border-light);
+  background: var(--bg-tertiary);
+  border-color: var(--border-light);
 }
 
 .btn-secondary:hover {
-    background: var(--border);
+  background: var(--border);
 }
 
 [data-theme="dark"] .btn-secondary:hover {
-    background: var(--bg-secondary);
-    border-color: var(--primary);
+  background: var(--bg-secondary);
+  border-color: var(--primary);
 }
 
 .btn-danger {
-    background: var(--danger);
-    color: white;
-    font-weight: 600;
+  background: var(--danger);
+  color: white;
+  font-weight: 600;
 }
 
 [data-theme="dark"] .btn-danger {
-    box-shadow: 0 4px 12px rgba(248, 113, 113, 0.3);
+  box-shadow: 0 4px 12px rgba(248, 113, 113, 0.3);
 }
 
 .btn-danger:hover {
-    background: #b91c1c;
+  background: #b91c1c;
 }
 
 [data-theme="dark"] .btn-danger:hover {
-    box-shadow: 0 6px 16px rgba(248, 113, 113, 0.4);
+  box-shadow: 0 6px 16px rgba(248, 113, 113, 0.4);
 }
 
 .btn-group {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 /* Weather Section */
 .weather-section {
-    padding: 1rem;
-    background: linear-gradient(135deg, 
-        rgba(135, 206, 250, 0.08) 0%, 
-        rgba(173, 216, 230, 0.04) 50%,
-        transparent 100%);
-    border-radius: 10px;
-    border: 2px solid var(--border);
-    position: relative;
-    overflow: hidden;
-    margin-bottom: 0;
+  padding: 1rem;
+  background: linear-gradient(
+    135deg,
+    rgba(135, 206, 250, 0.08) 0%,
+    rgba(173, 216, 230, 0.04) 50%,
+    transparent 100%
+  );
+  border-radius: 10px;
+  border: 2px solid var(--border);
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 0;
 }
 
 [data-theme="dark"] .weather-section {
-    border-color: var(--border-light);
+  border-color: var(--border-light);
 }
 
 .weather-section::before {
-    content: '';
-    position: absolute;
-    top: -30%;
-    right: -20%;
-    width: 150px;
-    height: 150px;
-    background: radial-gradient(circle, rgba(135, 206, 250, 0.12) 0%, transparent 70%);
-    pointer-events: none;
+  content: "";
+  position: absolute;
+  top: -30%;
+  right: -20%;
+  width: 150px;
+  height: 150px;
+  background: radial-gradient(
+    circle,
+    rgba(135, 206, 250, 0.12) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
 }
 
 .weather-header {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    margin-bottom: 0.75rem;
-    gap: 0.5rem;
-    position: relative;
-    z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+  gap: 0.5rem;
+  position: relative;
+  z-index: 1;
 }
 
 .weather-header h3 {
-    font-size: 1rem;
-    color: var(--text);
-    margin: 0;
-    font-weight: 700;
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  font-size: 1rem;
+  color: var(--text);
+  margin: 0;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .weather-location {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    background: rgba(255, 255, 255, 0.9);
-    padding: 0.375rem 0.625rem;
-    border-radius: 6px;
-    border: 1px solid rgba(27, 94, 63, 0.2);
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-    backdrop-filter: blur(10px);
-    transition: all 0.3s ease;
-    width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.375rem 0.625rem;
+  border-radius: 6px;
+  border: 1px solid rgba(27, 94, 63, 0.2);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(10px);
+  transition: all 0.3s ease;
+  width: 100%;
 }
 
 [data-theme="dark"] .weather-location {
-    background: var(--bg-secondary);
-    border-color: var(--primary);
-    box-shadow: 0 1px 8px rgba(74, 222, 128, 0.2);
+  background: var(--bg-secondary);
+  border-color: var(--primary);
+  box-shadow: 0 1px 8px rgba(74, 222, 128, 0.2);
 }
 
 .weather-location:hover {
-    border-color: var(--primary);
-    box-shadow: 0 2px 8px rgba(27, 94, 63, 0.15);
+  border-color: var(--primary);
+  box-shadow: 0 2px 8px rgba(27, 94, 63, 0.15);
 }
 
 [data-theme="dark"] .weather-location:hover {
-    box-shadow: 0 2px 12px rgba(74, 222, 128, 0.3);
+  box-shadow: 0 2px 12px rgba(74, 222, 128, 0.3);
 }
 
 .weather-location-name {
-    font-size: 0.75rem;
-    color: var(--text);
-    font-weight: 600;
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  font-size: 0.75rem;
+  color: var(--text);
+  font-weight: 600;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .btn-change-location {
-    background: var(--primary);
-    border: none;
-    color: white;
-    cursor: pointer;
-    padding: 0.25rem;
-    display: flex;
-    align-items: center;
-    transition: all 0.2s ease;
-    border-radius: 4px;
-    width: 24px;
-    height: 24px;
-    justify-content: center;
-    flex-shrink: 0;
+  background: var(--primary);
+  border: none;
+  color: white;
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  transition: all 0.2s ease;
+  border-radius: 4px;
+  width: 24px;
+  height: 24px;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .btn-change-location:hover {
-    background: var(--primary-dark);
-    transform: scale(1.1);
+  background: var(--primary-dark);
+  transform: scale(1.1);
 }
 
 .btn-change-location svg {
-    width: 12px;
-    height: 12px;
+  width: 12px;
+  height: 12px;
 }
 
 .weather-forecast {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin-top: 0.75rem;
-    position: relative;
-    z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  position: relative;
+  z-index: 1;
 }
 
 .weather-day-card {
-    background: rgba(255, 255, 255, 0.95);
-    border: 1px solid rgba(27, 94, 63, 0.15);
-    border-radius: 8px;
-    padding: 0.5rem;
-    display: grid;
-    grid-template-columns: 2.5rem 1fr;
-    gap: 0.5rem;
-    align-items: center;
-    text-align: left;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-    backdrop-filter: blur(10px);
-    position: relative;
-    overflow: hidden;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(27, 94, 63, 0.15);
+  border-radius: 8px;
+  padding: 0.5rem;
+  display: grid;
+  grid-template-columns: 2.5rem 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  text-align: left;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(10px);
+  position: relative;
+  overflow: hidden;
 }
 
 [data-theme="dark"] .weather-day-card {
-    background: var(--bg-tertiary);
-    border-color: var(--border-light);
-    box-shadow: 0 1px 4px var(--shadow);
+  background: var(--bg-tertiary);
+  border-color: var(--border-light);
+  box-shadow: 0 1px 4px var(--shadow);
 }
 
 .weather-day-card::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 3px;
-    background: linear-gradient(180deg, var(--primary), var(--success));
-    opacity: 0;
-    transition: opacity 0.3s ease;
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(180deg, var(--primary), var(--success));
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .weather-day-card:hover::before {
-    opacity: 1;
+  opacity: 1;
 }
 
 .weather-day-card:hover {
-    transform: translateX(2px);
-    box-shadow: 0 2px 8px rgba(27, 94, 63, 0.2);
-    border-color: var(--primary);
+  transform: translateX(2px);
+  box-shadow: 0 2px 8px rgba(27, 94, 63, 0.2);
+  border-color: var(--primary);
 }
 
 .weather-day-card.today {
-    background: linear-gradient(135deg, 
-        var(--primary) 0%, 
-        var(--primary-dark) 100%);
-    color: white;
-    border: none;
-    box-shadow: 0 2px 8px rgba(27, 94, 63, 0.35);
+  background: linear-gradient(
+    135deg,
+    var(--primary) 0%,
+    var(--primary-dark) 100%
+  );
+  color: white;
+  border: none;
+  box-shadow: 0 2px 8px rgba(27, 94, 63, 0.35);
 }
 
 .weather-day-card.today:hover {
-    transform: translateX(2px);
-    box-shadow: 0 4px 12px rgba(27, 94, 63, 0.4);
+  transform: translateX(2px);
+  box-shadow: 0 4px 12px rgba(27, 94, 63, 0.4);
 }
 
 .weather-day-card.today::before {
-    opacity: 0;
+  opacity: 0;
 }
 
 .weather-day-card.today .weather-day-name,
@@ -827,2750 +843,2916 @@ textarea {
 .weather-day-card.today .weather-temp,
 .weather-day-card.today .weather-description,
 .weather-day-card.today .weather-details {
-    color: white;
+  color: white;
 }
 
 .weather-icon-wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .weather-content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.125rem;
-    min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
 }
 
 .weather-day-name {
-    font-size: 0.7rem;
-    font-weight: 700;
-    color: var(--text);
-    margin: 0;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
 }
 
 .weather-day-date {
-    font-size: 0.625rem;
-    color: var(--text-light);
-    margin: 0;
-    opacity: 0.8;
+  font-size: 0.625rem;
+  color: var(--text-light);
+  margin: 0;
+  opacity: 0.8;
 }
 
 .weather-day-card.today .weather-day-date {
-    opacity: 0.95;
+  opacity: 0.95;
 }
 
 .weather-icon {
-    font-size: 2rem;
-    margin: 0;
-    display: block;
-    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1));
-    line-height: 1;
+  font-size: 2rem;
+  margin: 0;
+  display: block;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1));
+  line-height: 1;
 }
 
 .weather-day-card:hover .weather-icon {
-    transform: scale(1.05);
-    transition: transform 0.3s ease;
+  transform: scale(1.05);
+  transition: transform 0.3s ease;
 }
 
 .weather-temp {
-    font-size: 0.875rem;
-    font-weight: 800;
-    color: var(--text);
-    margin: 0;
-    line-height: 1.2;
+  font-size: 0.875rem;
+  font-weight: 800;
+  color: var(--text);
+  margin: 0;
+  line-height: 1.2;
 }
 
 .weather-temp-range {
-    font-size: 0.625rem;
-    color: var(--text-light);
-    margin: 0;
-    font-weight: 500;
-    opacity: 0.8;
+  font-size: 0.625rem;
+  color: var(--text-light);
+  margin: 0;
+  font-weight: 500;
+  opacity: 0.8;
 }
 
 .weather-day-card.today .weather-temp-range {
-    opacity: 0.9;
+  opacity: 0.9;
 }
 
 .weather-description {
-    font-size: 0.625rem;
-    color: var(--text-light);
-    margin: 0.125rem 0 0 0;
-    font-weight: 600;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  font-size: 0.625rem;
+  color: var(--text-light);
+  margin: 0.125rem 0 0 0;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Hide details and garden tips in sidebar layout */
 .weather-details,
 .weather-garden-tip {
-    display: none;
+  display: none;
 }
 
 .weather-error {
-    text-align: center;
-    padding: 3rem 2rem;
-    color: var(--text-light);
-    background: rgba(244, 67, 54, 0.05);
-    border-radius: 16px;
-    border: 2px dashed var(--danger);
+  text-align: center;
+  padding: 3rem 2rem;
+  color: var(--text-light);
+  background: rgba(244, 67, 54, 0.05);
+  border-radius: 16px;
+  border: 2px dashed var(--danger);
 }
 
 .weather-error-icon {
-    font-size: 4rem;
-    margin-bottom: 1rem;
-    opacity: 0.7;
+  font-size: 4rem;
+  margin-bottom: 1rem;
+  opacity: 0.7;
 }
 
 .weather-loading {
-    text-align: center;
-    padding: 3rem 2rem;
-    color: var(--text-light);
-    font-size: 1.1rem;
-    font-weight: 600;
+  text-align: center;
+  padding: 3rem 2rem;
+  color: var(--text-light);
+  font-size: 1.1rem;
+  font-weight: 600;
 }
 
 .weather-loading::after {
-    content: '...';
-    animation: dots 1.5s steps(4, end) infinite;
+  content: "...";
+  animation: dots 1.5s steps(4, end) infinite;
 }
 
 @keyframes dots {
-    0%, 20% { content: '.'; }
-    40% { content: '..'; }
-    60%, 100% { content: '...'; }
+  0%,
+  20% {
+    content: ".";
+  }
+  40% {
+    content: "..";
+  }
+  60%,
+  100% {
+    content: "...";
+  }
 }
 
 /* Dark Mode - Weather */
 .dark-mode .weather-section {
-    background: linear-gradient(135deg, 
-        rgba(74, 222, 128, 0.12) 0%, 
-        rgba(34, 197, 94, 0.08) 50%,
-        rgba(22, 163, 74, 0.04) 100%);
-    border-bottom-color: var(--border);
+  background: linear-gradient(
+    135deg,
+    rgba(74, 222, 128, 0.12) 0%,
+    rgba(34, 197, 94, 0.08) 50%,
+    rgba(22, 163, 74, 0.04) 100%
+  );
+  border-bottom-color: var(--border);
 }
 
 .dark-mode .weather-section::before {
-    background: radial-gradient(circle, rgba(74, 222, 128, 0.15) 0%, transparent 70%);
+  background: radial-gradient(
+    circle,
+    rgba(74, 222, 128, 0.15) 0%,
+    transparent 70%
+  );
 }
 
 .dark-mode .weather-location {
-    background: var(--bg-secondary);
-    border-color: var(--primary);
-    border-width: 2px;
-    backdrop-filter: blur(20px);
-    box-shadow: 0 4px 16px rgba(74, 222, 128, 0.2);
+  background: var(--bg-secondary);
+  border-color: var(--primary);
+  border-width: 2px;
+  backdrop-filter: blur(20px);
+  box-shadow: 0 4px 16px rgba(74, 222, 128, 0.2);
 }
 
 .dark-mode .weather-location:hover {
-    background: var(--bg-tertiary);
-    border-color: var(--primary);
-    box-shadow: 0 6px 20px rgba(74, 222, 128, 0.3);
+  background: var(--bg-tertiary);
+  border-color: var(--primary);
+  box-shadow: 0 6px 20px rgba(74, 222, 128, 0.3);
 }
 
 .dark-mode .weather-location-name {
-    color: var(--text);
+  color: var(--text);
 }
 
 .dark-mode .weather-day-card {
-    background: var(--bg-secondary);
-    border-color: var(--primary);
-    border-width: 2px;
-    backdrop-filter: blur(20px);
-    box-shadow: 0 4px 16px rgba(74, 222, 128, 0.2);
+  background: var(--bg-secondary);
+  border-color: var(--primary);
+  border-width: 2px;
+  backdrop-filter: blur(20px);
+  box-shadow: 0 4px 16px rgba(74, 222, 128, 0.2);
 }
 
 .dark-mode .weather-day-card::before {
-    background: linear-gradient(90deg, 
-        var(--primary) 0%, 
-        rgba(74, 222, 128, 0.8) 100%);
+  background: linear-gradient(
+    90deg,
+    var(--primary) 0%,
+    rgba(74, 222, 128, 0.8) 100%
+  );
 }
 
 .dark-mode .weather-day-card:hover {
-    background: var(--bg-tertiary);
-    border-color: var(--primary);
-    box-shadow: 0 12px 24px rgba(74, 222, 128, 0.35);
+  background: var(--bg-tertiary);
+  border-color: var(--primary);
+  box-shadow: 0 12px 24px rgba(74, 222, 128, 0.35);
 }
 
 .dark-mode .weather-day-name {
-    color: var(--primary);
-    font-weight: 800;
+  color: var(--primary);
+  font-weight: 800;
 }
 
 .dark-mode .weather-temp {
-    color: var(--text);
+  color: var(--text);
 }
 
 .dark-mode .weather-description {
-    color: var(--text);
-    font-weight: 600;
+  color: var(--text);
+  font-weight: 600;
 }
 
 .dark-mode .weather-day-date {
-    color: var(--text-light);
+  color: var(--text-light);
 }
 
 .dark-mode .weather-temp-range {
-    color: var(--text-light);
-    opacity: 0.9;
+  color: var(--text-light);
+  opacity: 0.9;
 }
 
 .dark-mode .weather-garden-tip {
-    background: linear-gradient(135deg, 
-        rgba(74, 222, 128, 0.25) 0%, 
-        rgba(34, 197, 94, 0.2) 100%);
-    color: #a7f3d0;
-    border-color: var(--primary);
-    box-shadow: 0 2px 8px rgba(74, 222, 128, 0.2);
-    font-weight: 700;
+  background: linear-gradient(
+    135deg,
+    rgba(74, 222, 128, 0.25) 0%,
+    rgba(34, 197, 94, 0.2) 100%
+  );
+  color: #a7f3d0;
+  border-color: var(--primary);
+  box-shadow: 0 2px 8px rgba(74, 222, 128, 0.2);
+  font-weight: 700;
 }
 
 .dark-mode .weather-error {
-    background: rgba(248, 113, 113, 0.1);
-    border-color: var(--danger);
+  background: rgba(248, 113, 113, 0.1);
+  border-color: var(--danger);
 }
 
 .dark-mode .weather-loading {
-    color: var(--text);
+  color: var(--text);
+}
+
+.garden-tip {
+  font-size: 0.7rem;
+  margin-top: 0.25rem;
+  padding: 2px 6px;
+  background: var(--bg-secondary);
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.weather-reminders {
+  grid-column: 1 / -1;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  margin-top: 0.5rem;
+}
+
+.weather-reminders h3 {
+  font-size: 1rem;
+  margin: 0 0 0.5rem 0;
+  color: var(--text);
+}
+
+.reminder-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.reminder-list li {
+  font-size: 0.9rem;
+  color: var(--text);
+  line-height: 1.4;
+}
+
+.reminder-icon {
+  margin-right: 0.25rem;
 }
 
 /* Responsive - Weather */
 @media (max-width: 1024px) {
-    .weather-forecast {
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    }
+  .weather-forecast {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
 }
 
 @media (max-width: 768px) {
-    .weather-section {
-        padding: 1.5rem;
-    }
-    
-    .weather-section::before {
-        width: 300px;
-        height: 300px;
-    }
-    
-    .weather-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 1rem;
-    }
-    
-    .weather-header h3 {
-        font-size: 1.5rem;
-    }
-    
-    .weather-location {
-        padding: 0.6rem 1rem;
-    }
-    
-    .weather-forecast {
-        grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-        gap: 1rem;
-    }
-    
-    .weather-day-card {
-        padding: 1rem 0.75rem;
-    }
-    
-    .weather-day-card.today {
-        transform: scale(1.02);
-    }
-    
-    .weather-day-card.today:hover {
-        transform: translateY(-6px) scale(1.04);
-    }
-    
-    .weather-icon {
-        font-size: 2.5rem;
-        margin: 0.75rem 0;
-    }
-    
-    .weather-temp {
-        font-size: 1.4rem;
-    }
-    
-    .weather-garden-tip {
-        font-size: 0.8rem;
-        padding: 0.6rem;
-    }
+  .weather-section {
+    padding: 1.5rem;
+  }
+
+  .weather-section::before {
+    width: 300px;
+    height: 300px;
+  }
+
+  .weather-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .weather-header h3 {
+    font-size: 1.5rem;
+  }
+
+  .weather-location {
+    padding: 0.6rem 1rem;
+  }
+
+  .weather-forecast {
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 1rem;
+  }
+
+  .weather-day-card {
+    padding: 1rem 0.75rem;
+  }
+
+  .weather-day-card.today {
+    transform: scale(1.02);
+  }
+
+  .weather-day-card.today:hover {
+    transform: translateY(-6px) scale(1.04);
+  }
+
+  .weather-icon {
+    font-size: 2.5rem;
+    margin: 0.75rem 0;
+  }
+
+  .weather-temp {
+    font-size: 1.4rem;
+  }
+
+  .weather-garden-tip {
+    font-size: 0.8rem;
+    padding: 0.6rem;
+  }
 }
 
 @media (max-width: 480px) {
-    .weather-section {
-        padding: 1rem;
-    }
-    
-    .weather-header h3 {
-        font-size: 1.25rem;
-    }
-    
-    .weather-forecast {
-        grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
-        gap: 0.75rem;
-    }
-    
-    .weather-day-card {
-        padding: 0.75rem 0.5rem;
-        border-radius: 12px;
-    }
-    
-    .weather-day-name {
-        font-size: 0.85rem;
-    }
-    
-    .weather-icon {
-        font-size: 2rem;
-    }
-    
-    .weather-temp {
-        font-size: 1.2rem;
-    }
-    
-    .weather-temp-range {
-        font-size: 0.8rem;
-    }
-    
-    .weather-description {
-        font-size: 0.8rem;
-    }
-    
-    .weather-details {
-        font-size: 0.7rem;
-        gap: 0.3rem;
-    }
-    
-    .weather-garden-tip {
-        font-size: 0.75rem;
-        padding: 0.5rem;
-    }
+  .weather-section {
+    padding: 1rem;
+  }
+
+  .weather-header h3 {
+    font-size: 1.25rem;
+  }
+
+  .weather-forecast {
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .weather-day-card {
+    padding: 0.75rem 0.5rem;
+    border-radius: 12px;
+  }
+
+  .weather-day-name {
+    font-size: 0.85rem;
+  }
+
+  .weather-icon {
+    font-size: 2rem;
+  }
+
+  .weather-temp {
+    font-size: 1.2rem;
+  }
+
+  .weather-temp-range {
+    font-size: 0.8rem;
+  }
+
+  .weather-description {
+    font-size: 0.8rem;
+  }
+
+  .weather-details {
+    font-size: 0.7rem;
+    gap: 0.3rem;
+  }
+
+  .weather-garden-tip {
+    font-size: 0.75rem;
+    padding: 0.5rem;
+  }
 }
 
 .search-section {
-    padding: 0;
-    margin-bottom: 0;
+  padding: 0;
+  margin-bottom: 0;
 }
 
 .search-container {
-    max-width: 100%;
-    margin: 0;
+  max-width: 100%;
+  margin: 0;
 }
 
 .search-input-wrapper {
-    position: relative;
-    display: flex;
-    align-items: center;
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .search-icon {
-    position: absolute;
-    left: 16px;
-    color: var(--text-light);
-    pointer-events: none;
-    transition: color 0.2s ease;
+  position: absolute;
+  left: 16px;
+  color: var(--text-light);
+  pointer-events: none;
+  transition: color 0.2s ease;
 }
 
 .search-input {
-    width: 100%;
-    padding: 14px 48px 14px 48px;
-    border: 2px solid var(--border);
-    border-radius: 12px;
-    font-size: 1rem;
-    background: var(--bg-secondary);
-    color: var(--text);
-    font-weight: 500;
-    transition: all 0.3s ease;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  width: 100%;
+  padding: 14px 48px 14px 48px;
+  border: 2px solid var(--border);
+  border-radius: 12px;
+  font-size: 1rem;
+  background: var(--bg-secondary);
+  color: var(--text);
+  font-weight: 500;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 .search-input:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 4px rgba(27, 94, 63, 0.1), 0 4px 8px rgba(0, 0, 0, 0.1);
+  outline: none;
+  border-color: var(--primary);
+  box-shadow:
+    0 0 0 4px rgba(27, 94, 63, 0.1),
+    0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .search-input:focus + .search-icon {
-    color: var(--primary);
+  color: var(--primary);
 }
 
 .search-input::placeholder {
-    color: var(--text-light);
-    opacity: 0.6;
+  color: var(--text-light);
+  opacity: 0.6;
 }
 
 [data-theme="dark"] .search-input {
-    background: var(--bg-tertiary);
-    border-color: var(--border-light);
-    color: var(--text);
-    box-shadow: 0 2px 8px var(--shadow);
+  background: var(--bg-tertiary);
+  border-color: var(--border-light);
+  color: var(--text);
+  box-shadow: 0 2px 8px var(--shadow);
 }
 
 [data-theme="dark"] .search-input:focus {
-    border-color: var(--primary);
-    box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.2), 0 4px 12px rgba(74, 222, 128, 0.15);
+  border-color: var(--primary);
+  box-shadow:
+    0 0 0 4px rgba(74, 222, 128, 0.2),
+    0 4px 12px rgba(74, 222, 128, 0.15);
 }
 
 [data-theme="dark"] .search-input::placeholder {
-    color: var(--text-light);
-    opacity: 0.5;
+  color: var(--text-light);
+  opacity: 0.5;
 }
 
 .clear-search-btn {
-    position: absolute;
-    right: 12px;
-    background: transparent;
-    border: none;
-    color: var(--text-light);
-    cursor: pointer;
-    padding: 8px;
-    border-radius: 6px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.2s ease;
+  position: absolute;
+  right: 12px;
+  background: transparent;
+  border: none;
+  color: var(--text-light);
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
 }
 
 .clear-search-btn:hover {
-    background: rgba(0, 0, 0, 0.05);
-    color: var(--danger);
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--danger);
 }
 
 [data-theme="dark"] .clear-search-btn:hover {
-    background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .search-results {
-    margin-top: 12px;
-    padding: 12px 16px;
-    background: var(--bg);
-    border-radius: 8px;
-    font-size: 0.9rem;
-    color: var(--text-light);
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    border: 1px solid var(--border);
+  margin-top: 12px;
+  padding: 12px 16px;
+  background: var(--bg);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  color: var(--text-light);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border);
 }
 
 [data-theme="dark"] .search-results {
-    background: #1a1a1a;
-    border-color: #2a2a2a;
+  background: #1a1a1a;
+  border-color: #2a2a2a;
 }
 
 #searchResultCount {
-    color: var(--primary);
-    font-weight: 700;
-    font-size: 1rem;
+  color: var(--primary);
+  font-weight: 700;
+  font-size: 1rem;
 }
 
 /* Filters */
 .filters {
-    display: flex;
-    flex-direction: row;
-    gap: 1.5rem;
-    margin-bottom: 0;
-    flex-wrap: wrap;
+  display: flex;
+  flex-direction: row;
+  gap: 1.5rem;
+  margin-bottom: 0;
+  flex-wrap: wrap;
 }
 
 .filter-group {
-    flex: 1;
-    min-width: 200px;
+  flex: 1;
+  min-width: 200px;
 }
 
 .filter-group label {
-    display: block;
-    font-weight: 600;
-    margin-bottom: 8px;
-    color: var(--text);
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: var(--text);
 }
 
 [data-theme="dark"] .filter-group label {
-    color: var(--primary);
+  color: var(--primary);
 }
 
 .filter-group select {
-    width: 100%;
-    padding: 10px;
-    border: 2px solid var(--border);
-    border-radius: 8px;
-    font-size: 1em;
-    background: var(--bg-secondary);
-    color: var(--text);
-    font-weight: 500;
-    transition: all 0.3s;
+  width: 100%;
+  padding: 10px;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  font-size: 1em;
+  background: var(--bg-secondary);
+  color: var(--text);
+  font-weight: 500;
+  transition: all 0.3s;
 }
 
 [data-theme="dark"] .filter-group select {
-    background: #252525;
-    border-color: #404040;
-    color: #e5e5e5;
+  background: #252525;
+  border-color: #404040;
+  color: #e5e5e5;
 }
 
 .filter-group select:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px rgba(27, 94, 63, 0.15);
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(27, 94, 63, 0.15);
 }
 
 [data-theme="dark"] .filter-group select:focus {
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px rgba(46, 204, 113, 0.2);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(46, 204, 113, 0.2);
 }
 
 .filter-group select option {
-    background: var(--bg-secondary);
-    color: var(--text);
-    padding: 8px;
+  background: var(--bg-secondary);
+  color: var(--text);
+  padding: 8px;
 }
 
 [data-theme="dark"] .filter-group select option {
-    background: #1a1a1a;
-    color: #e5e5e5;
+  background: #1a1a1a;
+  color: #e5e5e5;
 }
 
 /* Statistics */
 .stats-section {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1.5rem;
-    background: transparent;
-    padding: 0;
-    margin-bottom: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  background: transparent;
+  padding: 0;
+  margin-bottom: 0;
 }
 
 .stat-card {
-    background: var(--bg-secondary);
-    padding: 1.5rem;
-    border-radius: 12px;
-    border: 2px solid var(--border);
-    border-top: 4px solid var(--primary);
-    transition: all 0.3s ease;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  background: var(--bg-secondary);
+  padding: 1.5rem;
+  border-radius: 12px;
+  border: 2px solid var(--border);
+  border-top: 4px solid var(--primary);
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 [data-theme="dark"] .stat-card {
-    background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);
-    border-color: var(--border-light);
-    border-top-color: var(--primary);
-    box-shadow: 0 4px 12px var(--shadow);
+  background: linear-gradient(
+    135deg,
+    var(--bg-tertiary) 0%,
+    var(--bg-secondary) 100%
+  );
+  border-color: var(--border-light);
+  border-top-color: var(--primary);
+  box-shadow: 0 4px 12px var(--shadow);
 }
 
 .stat-card:hover {
-    border-color: var(--primary);
-    box-shadow: 0 4px 12px rgba(27, 94, 63, 0.2);
-    transform: translateY(-2px);
+  border-color: var(--primary);
+  box-shadow: 0 4px 12px rgba(27, 94, 63, 0.2);
+  transform: translateY(-2px);
 }
 
 [data-theme="dark"] .stat-card:hover {
-    box-shadow: 0 8px 20px rgba(74, 222, 128, 0.25);
-    border-color: var(--primary);
+  box-shadow: 0 8px 20px rgba(74, 222, 128, 0.25);
+  border-color: var(--primary);
 }
 
 .stat-card h3 {
-    color: var(--text-light);
-    font-size: 0.75rem;
-    margin-bottom: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
+  color: var(--text-light);
+  font-size: 0.75rem;
+  margin-bottom: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
 }
 
 [data-theme="dark"] .stat-card h3 {
-    color: var(--text-light);
+  color: var(--text-light);
 }
 
 .stat-number {
-    font-size: 2.5rem;
-    font-weight: 700;
-    color: var(--primary);
-    margin-bottom: 0.75rem;
-    line-height: 1;
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--primary);
+  margin-bottom: 0.75rem;
+  line-height: 1;
 }
 
 [data-theme="dark"] .stat-number {
-    color: var(--primary);
-    text-shadow: 0 0 30px rgba(74, 222, 128, 0.4);
+  color: var(--primary);
+  text-shadow: 0 0 30px rgba(74, 222, 128, 0.4);
 }
 
 /* Progress Bar */
 .progress-bar {
-    width: 100%;
-    height: 10px;
-    background: var(--bg);
-    border-radius: 10px;
-    overflow: hidden;
-    margin: 0.75rem 0;
-    border: 1px solid var(--border);
+  width: 100%;
+  height: 10px;
+  background: var(--bg);
+  border-radius: 10px;
+  overflow: hidden;
+  margin: 0.75rem 0;
+  border: 1px solid var(--border);
 }
 
 [data-theme="dark"] .progress-bar {
-    background: #111;
-    border-color: #333;
+  background: #111;
+  border-color: #333;
 }
 
 .progress-fill {
-    height: 100%;
-    background: var(--primary);
-    border-radius: 10px;
-    transition: width 0.5s ease;
-    box-shadow: 0 0 8px rgba(27, 94, 63, 0.4);
+  height: 100%;
+  background: var(--primary);
+  border-radius: 10px;
+  transition: width 0.5s ease;
+  box-shadow: 0 0 8px rgba(27, 94, 63, 0.4);
 }
 
 [data-theme="dark"] .progress-fill {
-    box-shadow: 0 0 12px rgba(46, 204, 113, 0.6);
+  box-shadow: 0 0 12px rgba(46, 204, 113, 0.6);
 }
 
 .progress-fill.completed {
-    background: linear-gradient(90deg, var(--primary) 0%, var(--primary-dark) 100%);
+  background: linear-gradient(
+    90deg,
+    var(--primary) 0%,
+    var(--primary-dark) 100%
+  );
 }
 
 .progress-fill.employees {
-    background: linear-gradient(90deg, #4a90e2 0%, #357abd 100%);
+  background: linear-gradient(90deg, #4a90e2 0%, #357abd 100%);
 }
 
 [data-theme="dark"] .progress-fill.employees {
-    background: linear-gradient(90deg, #5b9def 0%, #4a8ed5 100%);
+  background: linear-gradient(90deg, #5b9def 0%, #4a8ed5 100%);
 }
 
 .progress-label {
-    font-size: 0.8rem;
-    color: var(--text-light);
-    margin-top: 0.5rem;
-    font-weight: 500;
+  font-size: 0.8rem;
+  color: var(--text-light);
+  margin-top: 0.5rem;
+  font-weight: 500;
 }
 
 [data-theme="dark"] .progress-label {
-    color: #999;
+  color: #999;
 }
 
 .progress-label span {
-    font-weight: 700;
-    color: var(--primary);
+  font-weight: 700;
+  color: var(--primary);
 }
 
 /* Charts Section */
 .charts-section {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
-    margin-bottom: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  margin-bottom: 0;
 }
 
 @media (max-width: 1024px) {
-    .charts-section {
-        grid-template-columns: 1fr;
-    }
+  .charts-section {
+    grid-template-columns: 1fr;
+  }
 }
 
 .chart-container {
-    background: linear-gradient(135deg, var(--bg-secondary) 0%, rgba(255, 255, 255, 0.5) 100%);
-    padding: 2rem;
-    border-radius: 16px;
-    border: 2px solid var(--border);
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-    position: relative;
-    overflow: hidden;
+  background: linear-gradient(
+    135deg,
+    var(--bg-secondary) 0%,
+    rgba(255, 255, 255, 0.5) 100%
+  );
+  padding: 2rem;
+  border-radius: 16px;
+  border: 2px solid var(--border);
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  position: relative;
+  overflow: hidden;
 }
 
 .chart-container::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 100px;
-    height: 100px;
-    background: radial-gradient(circle, rgba(34, 197, 94, 0.1) 0%, transparent 70%);
-    border-radius: 50%;
-    transform: translate(30%, -30%);
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100px;
+  height: 100px;
+  background: radial-gradient(
+    circle,
+    rgba(34, 197, 94, 0.1) 0%,
+    transparent 70%
+  );
+  border-radius: 50%;
+  transform: translate(30%, -30%);
 }
 
 .chart-container:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
-    border-color: var(--primary);
+  transform: translateY(-4px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  border-color: var(--primary);
 }
 
 [data-theme="dark"] .chart-container {
-    background: linear-gradient(135deg, #1c1c1c 0%, #262626 100%);
-    border-color: #404040;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  background: linear-gradient(135deg, #1c1c1c 0%, #262626 100%);
+  border-color: #404040;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 [data-theme="dark"] .chart-container::before {
-    background: radial-gradient(circle, rgba(74, 222, 128, 0.15) 0%, transparent 70%);
+  background: radial-gradient(
+    circle,
+    rgba(74, 222, 128, 0.15) 0%,
+    transparent 70%
+  );
 }
 
 [data-theme="dark"] .chart-container:hover {
-    border-color: var(--primary);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
+  border-color: var(--primary);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
 }
 
 .chart-container.full-width {
-    grid-column: 1 / -1;
+  grid-column: 1 / -1;
 }
 
 .chart-container h3 {
-    font-size: 1.1rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, var(--primary) 0%, #16a34a 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin-bottom: 1.5rem;
-    padding-bottom: 1rem;
-    border-bottom: 2px solid rgba(34, 197, 94, 0.2);
-    position: relative;
-    z-index: 1;
+  font-size: 1.1rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--primary) 0%, #16a34a 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 2px solid rgba(34, 197, 94, 0.2);
+  position: relative;
+  z-index: 1;
 }
 
 [data-theme="dark"] .chart-container h3 {
-    background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    border-bottom-color: rgba(74, 222, 128, 0.2);
+  background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  border-bottom-color: rgba(74, 222, 128, 0.2);
 }
 
 /* Bar Charts */
 .chart-bars {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
 .chart-bar-item {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    animation: slideInLeft 0.5s ease-out backwards;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  animation: slideInLeft 0.5s ease-out backwards;
 }
 
-.chart-bar-item:nth-child(1) { animation-delay: 0.1s; }
-.chart-bar-item:nth-child(2) { animation-delay: 0.2s; }
-.chart-bar-item:nth-child(3) { animation-delay: 0.3s; }
-.chart-bar-item:nth-child(4) { animation-delay: 0.4s; }
-.chart-bar-item:nth-child(5) { animation-delay: 0.5s; }
+.chart-bar-item:nth-child(1) {
+  animation-delay: 0.1s;
+}
+.chart-bar-item:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.chart-bar-item:nth-child(3) {
+  animation-delay: 0.3s;
+}
+.chart-bar-item:nth-child(4) {
+  animation-delay: 0.4s;
+}
+.chart-bar-item:nth-child(5) {
+  animation-delay: 0.5s;
+}
 
 @keyframes slideInLeft {
-    from {
-        opacity: 0;
-        transform: translateX(-20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 .chart-bar-label {
-    min-width: 140px;
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--text);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  min-width: 140px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 [data-theme="dark"] .chart-bar-label {
-    color: #e5e5e5;
+  color: #e5e5e5;
 }
 
 .chart-bar-container {
-    flex: 1;
-    height: 36px;
-    background: rgba(0, 0, 0, 0.03);
-    border-radius: 8px;
-    overflow: hidden;
-    position: relative;
-    border: 1px solid rgba(34, 197, 94, 0.1);
+  flex: 1;
+  height: 36px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+  border: 1px solid rgba(34, 197, 94, 0.1);
 }
 
 [data-theme="dark"] .chart-bar-container {
-    background: rgba(255, 255, 255, 0.03);
-    border-color: rgba(74, 222, 128, 0.15);
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(74, 222, 128, 0.15);
 }
 
 .chart-bar-fill {
-    height: 100%;
-    background: linear-gradient(90deg, var(--primary) 0%, #16a34a 100%);
-    border-radius: 8px;
-    transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    padding-right: 12px;
-    box-shadow: inset 0 2px 4px rgba(0,0,0,0.1), 0 2px 8px rgba(34, 197, 94, 0.3);
-    position: relative;
-    overflow: hidden;
+  height: 100%;
+  background: linear-gradient(90deg, var(--primary) 0%, #16a34a 100%);
+  border-radius: 8px;
+  transition: width 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 12px;
+  box-shadow:
+    inset 0 2px 4px rgba(0, 0, 0, 0.1),
+    0 2px 8px rgba(34, 197, 94, 0.3);
+  position: relative;
+  overflow: hidden;
 }
 
 .chart-bar-fill::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 50%;
-    background: linear-gradient(180deg, rgba(255,255,255,0.3) 0%, transparent 100%);
-    border-radius: 8px 8px 0 0;
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.3) 0%,
+    transparent 100%
+  );
+  border-radius: 8px 8px 0 0;
 }
 
 [data-theme="dark"] .chart-bar-fill {
-    background: linear-gradient(90deg, var(--primary) 0%, #86efac 100%);
-    box-shadow: inset 0 2px 4px rgba(0,0,0,0.3), 0 2px 12px rgba(74, 222, 128, 0.4);
+  background: linear-gradient(90deg, var(--primary) 0%, #86efac 100%);
+  box-shadow:
+    inset 0 2px 4px rgba(0, 0, 0, 0.3),
+    0 2px 12px rgba(74, 222, 128, 0.4);
 }
 
 .chart-bar-value {
-    font-size: 0.9rem;
-    font-weight: 700;
-    color: white;
-    text-shadow: 0 1px 3px rgba(0,0,0,0.3);
-    position: relative;
-    z-index: 1;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: white;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  position: relative;
+  z-index: 1;
 }
 
 .chart-bar-count {
-    min-width: 45px;
-    text-align: right;
-    font-size: 0.95rem;
-    font-weight: 700;
-    color: var(--primary);
+  min-width: 45px;
+  text-align: right;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--primary);
 }
 
 [data-theme="dark"] .chart-bar-count {
-    color: var(--primary);
+  color: var(--primary);
 }
 
 /* Timeline Chart */
 .chart-timeline {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    height: 200px;
-    gap: 0.5rem;
-    padding: 1rem 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  height: 200px;
+  gap: 0.5rem;
+  padding: 1rem 0;
 }
 
 .timeline-bar {
-    flex: 1;
-    background: linear-gradient(to top, var(--primary), var(--primary-light));
-    border-radius: 4px 4px 0 0;
-    min-height: 20px;
-    position: relative;
-    transition: all 0.3s ease;
-    cursor: pointer;
-    border: 1px solid var(--primary-dark);
+  flex: 1;
+  background: linear-gradient(to top, var(--primary), var(--primary-light));
+  border-radius: 4px 4px 0 0;
+  min-height: 20px;
+  position: relative;
+  transition: all 0.3s ease;
+  cursor: pointer;
+  border: 1px solid var(--primary-dark);
 }
 
 .timeline-bar:hover {
-    opacity: 0.8;
-    transform: translateY(-2px);
+  opacity: 0.8;
+  transform: translateY(-2px);
 }
 
 .timeline-bar-label {
-    position: absolute;
-    bottom: -25px;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 0.75rem;
-    color: var(--text-light);
-    white-space: nowrap;
-    font-weight: 500;
+  position: absolute;
+  bottom: -25px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  color: var(--text-light);
+  white-space: nowrap;
+  font-weight: 500;
 }
 
 .timeline-bar-value {
-    position: absolute;
-    top: -20px;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: var(--text);
-    background: var(--bg-secondary);
-    padding: 2px 6px;
-    border-radius: 4px;
-    white-space: nowrap;
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text);
+  background: var(--bg-secondary);
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
 }
 
 .timeline-bar.completion-bar {
-    background: linear-gradient(to top, #27ae60, #2ecc71);
-    border: 1px solid #1e8449;
+  background: linear-gradient(to top, #27ae60, #2ecc71);
+  border: 1px solid #1e8449;
 }
 
 .chart-empty {
-    text-align: center;
-    padding: 2rem;
-    color: var(--text-light);
-    font-style: italic;
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-light);
+  font-style: italic;
 }
 
 /* Stats Link Section */
 .stats-link-section {
-    margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 .stats-link-card {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-    background: linear-gradient(135deg, var(--bg-secondary) 0%, #f8faf9 100%);
-    padding: 2rem;
-    border-radius: 8px;
-    border: 2px solid var(--border);
-    border-left: 4px solid var(--primary);
-    text-decoration: none;
-    transition: all 0.3s ease;
-    cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, var(--bg-secondary) 0%, #f8faf9 100%);
+  padding: 2rem;
+  border-radius: 8px;
+  border: 2px solid var(--border);
+  border-left: 4px solid var(--primary);
+  text-decoration: none;
+  transition: all 0.3s ease;
+  cursor: pointer;
 }
 
 .stats-link-card:hover {
-    border-color: var(--primary);
-    box-shadow: 0 4px 12px rgba(27, 94, 63, 0.2);
-    transform: translateY(-2px);
-    background: linear-gradient(135deg, #f8faf9 0%, var(--bg-secondary) 100%);
+  border-color: var(--primary);
+  box-shadow: 0 4px 12px rgba(27, 94, 63, 0.2);
+  transform: translateY(-2px);
+  background: linear-gradient(135deg, #f8faf9 0%, var(--bg-secondary) 100%);
 }
 
 .stats-link-icon {
-    font-size: 3rem;
-    flex-shrink: 0;
+  font-size: 3rem;
+  flex-shrink: 0;
 }
 
 .stats-link-content {
-    flex: 1;
+  flex: 1;
 }
 
 .stats-link-content h3 {
-    color: var(--primary-dark);
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
+  color: var(--primary-dark);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
 }
 
 .stats-link-content p {
-    color: var(--text-light);
-    font-size: 0.95rem;
-    margin: 0;
+  color: var(--text-light);
+  font-size: 0.95rem;
+  margin: 0;
 }
 
 .stats-link-arrow {
-    font-size: 2rem;
-    color: var(--primary);
-    font-weight: 600;
-    transition: transform 0.3s ease;
+  font-size: 2rem;
+  color: var(--primary);
+  font-weight: 600;
+  transition: transform 0.3s ease;
 }
 
 .stats-link-card:hover .stats-link-arrow {
-    transform: translateX(5px);
+  transform: translateX(5px);
 }
 
 /* Section Titles für Statistikseite */
 main > section > h2 {
-    font-size: 2rem;
-    font-weight: 700;
-    margin-bottom: 2.5rem;
-    background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    position: relative;
-    padding-bottom: 1rem;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2.5rem;
+  background: linear-gradient(
+    135deg,
+    var(--primary-dark) 0%,
+    var(--primary) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  position: relative;
+  padding-bottom: 1rem;
 }
 
 main > section > h2::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100px;
-    height: 4px;
-    background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
-    border-radius: 2px;
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100px;
+  height: 4px;
+  background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
+  border-radius: 2px;
 }
 
 [data-theme="dark"] main > section > h2 {
-    background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 /* Additional Stats Grid */
 .additional-stats {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .additional-stats h2 {
-    font-size: 2rem;
-    font-weight: 700;
-    margin-bottom: 2.5rem;
-    background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    position: relative;
-    padding-bottom: 1rem;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2.5rem;
+  background: linear-gradient(
+    135deg,
+    var(--primary-dark) 0%,
+    var(--primary) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  position: relative;
+  padding-bottom: 1rem;
 }
 
 .additional-stats h2::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100px;
-    height: 4px;
-    background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
-    border-radius: 2px;
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100px;
+  height: 4px;
+  background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
+  border-radius: 2px;
 }
 
 [data-theme="dark"] .additional-stats h2 {
-    background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .stats-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 2rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2rem;
 }
 
 @media (max-width: 1200px) {
-    .stats-grid {
-        grid-template-columns: repeat(2, 1fr);
-    }
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 768px) {
-    .stats-grid {
-        grid-template-columns: 1fr;
-    }
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .stat-item {
-    background: linear-gradient(135deg, var(--bg-secondary) 0%, rgba(255, 255, 255, 0.5) 100%);
-    padding: 2rem;
-    border-radius: 16px;
-    border: 2px solid var(--border);
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-    position: relative;
-    overflow: hidden;
+  background: linear-gradient(
+    135deg,
+    var(--bg-secondary) 0%,
+    rgba(255, 255, 255, 0.5) 100%
+  );
+  padding: 2rem;
+  border-radius: 16px;
+  border: 2px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  position: relative;
+  overflow: hidden;
 }
 
 .stat-item::before {
-    content: '';
-    position: absolute;
-    top: -50%;
-    right: -50%;
-    width: 100%;
-    height: 100%;
-    background: radial-gradient(circle, rgba(34, 197, 94, 0.1) 0%, transparent 70%);
-    transform: rotate(45deg);
+  content: "";
+  position: absolute;
+  top: -50%;
+  right: -50%;
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(
+    circle,
+    rgba(34, 197, 94, 0.1) 0%,
+    transparent 70%
+  );
+  transform: rotate(45deg);
 }
 
 [data-theme="dark"] .stat-item {
-    background: linear-gradient(135deg, #1c1c1c 0%, #262626 100%);
-    border-color: #404040;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  background: linear-gradient(135deg, #1c1c1c 0%, #262626 100%);
+  border-color: #404040;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 [data-theme="dark"] .stat-item::before {
-    background: radial-gradient(circle, rgba(74, 222, 128, 0.15) 0%, transparent 70%);
+  background: radial-gradient(
+    circle,
+    rgba(74, 222, 128, 0.15) 0%,
+    transparent 70%
+  );
 }
 
 .stat-item:hover {
-    transform: translateY(-4px);
-    border-color: var(--primary);
-    box-shadow: 0 8px 20px rgba(34, 197, 94, 0.2);
+  transform: translateY(-4px);
+  border-color: var(--primary);
+  box-shadow: 0 8px 20px rgba(34, 197, 94, 0.2);
 }
 
 [data-theme="dark"] .stat-item:hover {
-    box-shadow: 0 8px 20px rgba(74, 222, 128, 0.3);
+  box-shadow: 0 8px 20px rgba(74, 222, 128, 0.3);
 }
 
 .stat-icon {
-    font-size: 3rem;
-    flex-shrink: 0;
-    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
-    position: relative;
-    z-index: 1;
+  font-size: 3rem;
+  flex-shrink: 0;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
+  position: relative;
+  z-index: 1;
 }
 
 .stat-content {
-    position: relative;
-    z-index: 1;
+  position: relative;
+  z-index: 1;
 }
 
 .stat-content h4 {
-    font-size: 0.8rem;
-    font-weight: 700;
-    color: var(--text-light);
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    margin-bottom: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.5rem;
 }
 
 [data-theme="dark"] .stat-content h4 {
-    color: #999;
+  color: #999;
 }
 
 .stat-value {
-    font-size: 2rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, var(--primary) 0%, #16a34a 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, var(--primary) 0%, #16a34a 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin: 0;
 }
 
 [data-theme="dark"] .stat-value {
-    background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    text-shadow: none;
+  background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  text-shadow: none;
 }
 
 /* Quick Actions */
 .quick-actions {
-    margin-top: 3rem;
-    margin-bottom: 3rem;
+  margin-top: 3rem;
+  margin-bottom: 3rem;
 }
 
 .quick-actions h2 {
-    font-size: 2rem;
-    font-weight: 700;
-    margin-bottom: 2.5rem;
-    background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    position: relative;
-    padding-bottom: 1rem;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2.5rem;
+  background: linear-gradient(
+    135deg,
+    var(--primary-dark) 0%,
+    var(--primary) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  position: relative;
+  padding-bottom: 1rem;
 }
 
 .quick-actions h2::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100px;
-    height: 4px;
-    background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
-    border-radius: 2px;
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100px;
+  height: 4px;
+  background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
+  border-radius: 2px;
 }
 
 [data-theme="dark"] .quick-actions h2 {
-    background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .quick-actions .btn-group {
-    display: flex;
-    gap: 1.5rem;
-    flex-wrap: wrap;
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
 }
 
 .quick-actions .btn {
-    flex: 1;
-    min-width: 200px;
-    padding: 1rem 2rem;
-    font-size: 1rem;
-    font-weight: 600;
+  flex: 1;
+  min-width: 200px;
+  padding: 1rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
 }
 
 /* History Section */
 .history-section {
-    background: linear-gradient(135deg, var(--bg-secondary) 0%, rgba(255, 255, 255, 0.8) 100%);
-    padding: 2.5rem;
-    border-radius: 16px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-    margin-top: 3rem;
-    border: 2px solid var(--border);
+  background: linear-gradient(
+    135deg,
+    var(--bg-secondary) 0%,
+    rgba(255, 255, 255, 0.8) 100%
+  );
+  padding: 2.5rem;
+  border-radius: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  margin-top: 3rem;
+  border: 2px solid var(--border);
 }
 
 [data-theme="dark"] .history-section {
-    background: linear-gradient(135deg, #1c1c1c 0%, #262626 100%);
-    border-color: #404040;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  background: linear-gradient(135deg, #1c1c1c 0%, #262626 100%);
+  border-color: #404040;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 .history-section h2 {
-    font-size: 2rem;
-    font-weight: 700;
-    margin-bottom: 1rem;
-    background: linear-gradient(135deg, var(--primary-dark) 0%, var(--primary) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    position: relative;
-    padding-bottom: 1rem;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  background: linear-gradient(
+    135deg,
+    var(--primary-dark) 0%,
+    var(--primary) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  position: relative;
+  padding-bottom: 1rem;
 }
 
 .history-section h2::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100px;
-    height: 4px;
-    background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
-    border-radius: 2px;
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100px;
+  height: 4px;
+  background: linear-gradient(90deg, var(--primary) 0%, transparent 100%);
+  border-radius: 2px;
 }
 
 [data-theme="dark"] .history-section h2 {
-    background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  background: linear-gradient(135deg, var(--primary) 0%, #86efac 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .history-section .subtitle {
-    color: var(--text-light);
-    margin-bottom: 2.5rem;
-    font-size: 1rem;
+  color: var(--text-light);
+  margin-bottom: 2.5rem;
+  font-size: 1rem;
 }
 
 .history-timeline {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    position: relative;
-    padding-left: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
+  padding-left: 2rem;
 }
 
 .history-timeline::before {
-    content: '';
-    position: absolute;
-    left: 19px;
-    top: 20px;
-    bottom: 20px;
-    width: 2px;
-    background: linear-gradient(180deg, var(--primary), transparent);
+  content: "";
+  position: absolute;
+  left: 19px;
+  top: 20px;
+  bottom: 20px;
+  width: 2px;
+  background: linear-gradient(180deg, var(--primary), transparent);
 }
 
 .history-item {
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
-    position: relative;
-    padding: 1rem;
-    background: var(--bg-secondary);
-    border-radius: 12px;
-    transition: all 0.3s ease;
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  position: relative;
+  padding: 1rem;
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  transition: all 0.3s ease;
 }
 
 .history-item:hover {
-    background: #f8f9fa;
-    transform: translateX(4px);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  background: #f8f9fa;
+  transform: translateX(4px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 .history-icon {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.2em;
-    flex-shrink: 0;
-    position: relative;
-    z-index: 1;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2em;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .history-content {
-    flex: 1;
+  flex: 1;
 }
 
 .history-header {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
-    flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .history-header strong {
-    color: var(--primary);
-    font-weight: 700;
+  color: var(--primary);
+  font-weight: 700;
 }
 
 .history-task-title {
-    color: var(--text-primary);
-    font-weight: 600;
+  color: var(--text-primary);
+  font-weight: 600;
 }
 
 .history-meta {
-    display: flex;
-    gap: 1rem;
-    font-size: 0.9em;
-    color: var(--text-light);
-    margin-bottom: 0.5rem;
+  display: flex;
+  gap: 1rem;
+  font-size: 0.9em;
+  color: var(--text-light);
+  margin-bottom: 0.5rem;
 }
 
 .history-employee {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .history-employee::before {
-    content: '👤';
-    font-size: 0.9em;
+  content: "👤";
+  font-size: 0.9em;
 }
 
 .history-time {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    cursor: help;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: help;
 }
 
 .history-time::before {
-    content: '🕐';
-    font-size: 0.9em;
+  content: "🕐";
+  font-size: 0.9em;
 }
 
 .history-details {
-    font-size: 0.9em;
-    color: var(--text-light);
-    margin-top: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: white;
-    border-radius: 8px;
-    border-left: 3px solid var(--primary);
+  font-size: 0.9em;
+  color: var(--text-light);
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: white;
+  border-radius: 8px;
+  border-left: 3px solid var(--primary);
 }
 
 /* Dark Mode - History */
 [data-theme="dark"] .history-section {
-    background: var(--bg-secondary);
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  background: var(--bg-secondary);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 
 [data-theme="dark"] .history-item {
-    background: var(--card-bg);
+  background: var(--card-bg);
 }
 
 [data-theme="dark"] .history-item:hover {
-    background: #2c3e50;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  background: #2c3e50;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 [data-theme="dark"] .history-details {
-    background: var(--bg-secondary);
-    border-left-color: #2ecc71;
+  background: var(--bg-secondary);
+  border-left-color: #2ecc71;
 }
 
 /* View Toggle */
 .section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
 }
 
 .view-toggle {
-    display: flex;
-    gap: 5px;
+  display: flex;
+  gap: 5px;
 }
 
 .view-btn {
-    padding: 8px 20px;
-    border: 2px solid var(--primary-color);
-    background: white;
-    color: var(--primary-color);
-    border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.3s;
-    font-weight: 600;
+  padding: 8px 20px;
+  border: 2px solid var(--primary-color);
+  background: white;
+  color: var(--primary-color);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s;
+  font-weight: 600;
 }
 
 .view-btn.active {
-    background: var(--primary-color);
-    color: white;
+  background: var(--primary-color);
+  color: white;
 }
 
 .view-btn:hover {
-    background: var(--primary-color);
-    color: white;
+  background: var(--primary-color);
+  color: white;
 }
 
 /* Tasks Header */
 .tasks-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
 }
 
 .tasks-header h2 {
-    margin-bottom: 0;
-    border-bottom: none;
+  margin-bottom: 0;
+  border-bottom: none;
 }
 
 .tasks-header-actions {
-    display: flex;
-    gap: 10px;
-    align-items: center;
+  display: flex;
+  gap: 10px;
+  align-items: center;
 }
 
 /* Bulk Actions Toolbar */
 .bulk-toolbar {
-    background: var(--light);
-    padding: 15px 20px;
-    border-radius: 10px;
-    margin-bottom: 20px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 15px;
-    border: 2px solid var(--primary-color);
+  background: var(--light);
+  padding: 15px 20px;
+  border-radius: 10px;
+  margin-bottom: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 15px;
+  border: 2px solid var(--primary-color);
 }
 
 .bulk-info {
-    font-weight: 600;
-    font-size: 1.1em;
-    color: var(--dark);
+  font-weight: 600;
+  font-size: 1.1em;
+  color: var(--dark);
 }
 
 .bulk-info span {
-    color: var(--primary-color);
-    font-size: 1.3em;
+  color: var(--primary-color);
+  font-size: 1.3em;
 }
 
 .bulk-actions {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 /* Tasks List */
 .tasks-list {
-    display: flex;
-    flex-direction: column;
-    gap: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
 }
 
 /* Task Card Animations */
 @keyframes slideInFromRight {
-    from {
-        opacity: 0;
-        transform: translateX(50px);
-    }
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateX(50px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 @keyframes fadeOut {
-    from {
-        opacity: 1;
-        transform: scale(1);
-    }
-    to {
-        opacity: 0;
-        transform: scale(0.9);
-    }
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.9);
+  }
 }
 
 @keyframes pulse {
-    0%, 100% {
-        transform: scale(1);
-    }
-    50% {
-        transform: scale(1.02);
-    }
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.02);
+  }
 }
 
 .task-card {
-    background: var(--bg-secondary);
-    padding: 1.25rem;
-    border-radius: 12px;
-    border: 2px solid var(--border);
-    border-left: 4px solid var(--primary);
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    cursor: move;
-    gap: 1rem;
-    margin-bottom: 0.75rem;
-    animation: slideInFromRight 0.4s ease-out;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  background: var(--bg-secondary);
+  padding: 1.25rem;
+  border-radius: 12px;
+  border: 2px solid var(--border);
+  border-left: 4px solid var(--primary);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: move;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  animation: slideInFromRight 0.4s ease-out;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
 
 [data-theme="dark"] .task-card {
-    background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);
-    border-color: var(--border-light);
-    border-left-color: var(--primary);
-    box-shadow: 0 2px 8px var(--shadow);
+  background: linear-gradient(
+    135deg,
+    var(--bg-tertiary) 0%,
+    var(--bg-secondary) 100%
+  );
+  border-color: var(--border-light);
+  border-left-color: var(--primary);
+  box-shadow: 0 2px 8px var(--shadow);
 }
 
 .task-card.task-removing {
-    animation: fadeOut 0.4s ease-out forwards;
+  animation: fadeOut 0.4s ease-out forwards;
 }
 
 .task-card.task-completing {
-    animation: pulse 0.5s ease-in-out;
+  animation: pulse 0.5s ease-in-out;
 }
 
 .task-card:hover {
-    border-color: var(--primary);
-    box-shadow: 0 4px 12px rgba(27, 94, 63, 0.2);
-    background: linear-gradient(to right, #f8faf9, var(--bg-secondary));
-    transform: translateY(-2px);
+  border-color: var(--primary);
+  box-shadow: 0 4px 12px rgba(27, 94, 63, 0.2);
+  background: linear-gradient(to right, #f8faf9, var(--bg-secondary));
+  transform: translateY(-2px);
 }
 
 [data-theme="dark"] .task-card:hover {
-    box-shadow: 0 6px 16px rgba(74, 222, 128, 0.25);
-    background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%);
-    border-color: var(--primary);
+  box-shadow: 0 6px 16px rgba(74, 222, 128, 0.25);
+  background: linear-gradient(
+    135deg,
+    var(--bg-secondary) 0%,
+    var(--bg-tertiary) 100%
+  );
+  border-color: var(--primary);
 }
 
 .task-card.completed {
-    opacity: 0.6;
-    background: var(--bg);
-    transition: opacity 0.4s ease;
+  opacity: 0.6;
+  background: var(--bg);
+  transition: opacity 0.4s ease;
 }
 
 [data-theme="dark"] .task-card.completed {
-    background: var(--bg-secondary);
-    opacity: 0.5;
+  background: var(--bg-secondary);
+  opacity: 0.5;
 }
 
 .task-card.selected {
-    border-left-color: var(--info);
-    background: #f0f9ff;
+  border-left-color: var(--info);
+  background: #f0f9ff;
 }
 
 [data-theme="dark"] .task-card.selected {
-    background: linear-gradient(135deg, rgba(96, 165, 250, 0.15) 0%, var(--bg-secondary) 100%);
-    border-left-color: var(--info);
+  background: linear-gradient(
+    135deg,
+    rgba(96, 165, 250, 0.15) 0%,
+    var(--bg-secondary) 100%
+  );
+  border-left-color: var(--info);
 }
 
 .task-card.archived {
-    background: var(--bg);
-    border-left-color: #9ca3af;
-    opacity: 0.7;
+  background: var(--bg);
+  border-left-color: #9ca3af;
+  opacity: 0.7;
 }
 
 .task-card.archived .drag-handle {
-    display: none;
+  display: none;
 }
 
 .archived-badge {
-    display: inline-block;
-    background: #95a5a6;
-    color: white;
-    padding: 3px 10px;
-    border-radius: 12px;
-    font-size: 0.85em;
-    margin-left: 10px;
+  display: inline-block;
+  background: #95a5a6;
+  color: white;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.85em;
+  margin-left: 10px;
 }
 
 /* Recurrence Badge */
 .recurrence-badge {
-    display: inline-flex;
-    align-items: center;
-    background: linear-gradient(135deg, #3498db, #2980b9);
-    color: white;
-    padding: 4px 10px;
-    border-radius: 14px;
-    font-size: 0.8em;
-    margin-left: 10px;
-    font-weight: 600;
-    box-shadow: 0 2px 4px rgba(52, 152, 219, 0.3);
-    transition: all 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+  background: linear-gradient(135deg, #3498db, #2980b9);
+  color: white;
+  padding: 4px 10px;
+  border-radius: 14px;
+  font-size: 0.8em;
+  margin-left: 10px;
+  font-weight: 600;
+  box-shadow: 0 2px 4px rgba(52, 152, 219, 0.3);
+  transition: all 0.3s ease;
 }
 
 .recurrence-badge:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(52, 152, 219, 0.4);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(52, 152, 219, 0.4);
 }
 
 .recurrence-badge svg {
-    flex-shrink: 0;
+  flex-shrink: 0;
 }
 
 /* Task Checkbox */
 .task-checkbox {
-    display: flex;
-    align-items: center;
-    margin-right: 10px;
+  display: flex;
+  align-items: center;
+  margin-right: 10px;
 }
 
 .task-select-checkbox {
-    width: 20px;
-    height: 20px;
-    cursor: pointer;
-    accent-color: var(--primary-color);
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  accent-color: var(--primary-color);
 }
 
 /* Drag & Drop States */
 .task-card.dragging {
-    opacity: 0.6;
-    transform: scale(1.02) rotate(2deg);
-    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
-    cursor: grabbing;
-    z-index: 1000;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-    border: 2px solid var(--primary-color);
+  opacity: 0.6;
+  transform: scale(1.02) rotate(2deg);
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
+  cursor: grabbing;
+  z-index: 1000;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  border: 2px solid var(--primary-color);
 }
 
 [data-theme="dark"] .task-card.dragging {
-    box-shadow: 0 15px 40px rgba(46, 204, 113, 0.3);
+  box-shadow: 0 15px 40px rgba(46, 204, 113, 0.3);
 }
 
 .task-card.drag-over {
-    border-top: 3px dashed var(--primary-color);
-    margin-top: 15px;
-    background: linear-gradient(135deg, rgba(27, 94, 63, 0.05), rgba(46, 204, 113, 0.05));
-    transform: translateY(5px);
-    transition: all 0.2s ease;
+  border-top: 3px dashed var(--primary-color);
+  margin-top: 15px;
+  background: linear-gradient(
+    135deg,
+    rgba(27, 94, 63, 0.05),
+    rgba(46, 204, 113, 0.05)
+  );
+  transform: translateY(5px);
+  transition: all 0.2s ease;
 }
 
 [data-theme="dark"] .task-card.drag-over {
-    background: linear-gradient(135deg, rgba(46, 204, 113, 0.1), rgba(46, 204, 113, 0.05));
+  background: linear-gradient(
+    135deg,
+    rgba(46, 204, 113, 0.1),
+    rgba(46, 204, 113, 0.05)
+  );
 }
 
 [data-theme="dark"] .recurrence-badge {
-    background: linear-gradient(135deg, #2980b9, #1f6391);
-    box-shadow: 0 2px 4px rgba(52, 152, 219, 0.5);
+  background: linear-gradient(135deg, #2980b9, #1f6391);
+  box-shadow: 0 2px 4px rgba(52, 152, 219, 0.5);
 }
 
 [data-theme="dark"] .recurrence-badge:hover {
-    box-shadow: 0 4px 8px rgba(52, 152, 219, 0.6);
+  box-shadow: 0 4px 8px rgba(52, 152, 219, 0.6);
 }
 
 .task-info {
-    flex: 1;
+  flex: 1;
 }
 
 .task-header {
-    display: flex;
-    align-items: center;
-    gap: 15px;
-    margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  margin-bottom: 10px;
 }
 
 .drag-handle {
-    color: #95a5a6;
-    cursor: grab;
-    user-select: none;
-    transition: all 0.2s ease;
-    padding: 5px;
-    border-radius: 4px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  color: #95a5a6;
+  cursor: grab;
+  user-select: none;
+  transition: all 0.2s ease;
+  padding: 5px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .drag-handle svg {
-    width: 18px;
-    height: 18px;
-    transition: all 0.2s ease;
+  width: 18px;
+  height: 18px;
+  transition: all 0.2s ease;
 }
 
 .drag-handle:hover {
-    color: var(--primary-color);
-    background: rgba(0, 0, 0, 0.05);
-    transform: scale(1.1);
+  color: var(--primary-color);
+  background: rgba(0, 0, 0, 0.05);
+  transform: scale(1.1);
 }
 
 [data-theme="dark"] .drag-handle:hover {
-    background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .drag-handle:active {
-    cursor: grabbing;
-    transform: scale(0.95);
+  cursor: grabbing;
+  transform: scale(0.95);
 }
 
 .task-title {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--text);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text);
 }
 
 .task-meta {
-    display: flex;
-    gap: 20px;
-    margin-bottom: 10px;
-    color: var(--text-light);
-    font-size: 0.95rem;
-    font-weight: 500;
+  display: flex;
+  gap: 20px;
+  margin-bottom: 10px;
+  color: var(--text-light);
+  font-size: 0.95rem;
+  font-weight: 500;
 }
 
 .task-meta span {
-    display: flex;
-    align-items: center;
-    gap: 5px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }
 
 .task-meta svg {
-    flex-shrink: 0;
+  flex-shrink: 0;
 }
 
 .task-description {
-    color: var(--primary-color);
-    line-height: 1.6;
-    font-weight: 500;
+  color: var(--primary-color);
+  line-height: 1.6;
+  font-weight: 500;
 }
 
 .task-actions {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .task-btn {
-    padding: 8px 15px;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.9em;
-    font-weight: 600;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    transform-origin: center;
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    /* Touch-optimiert: 44x44px WCAG 2.5.8 */
-    min-height: 44px;
-    min-width: 44px;
-    -webkit-tap-highlight-color: transparent;
-    user-select: none;
-    position: relative;
+  padding: 8px 15px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9em;
+  font-weight: 600;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transform-origin: center;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  /* Touch-optimiert: 44x44px WCAG 2.5.8 */
+  min-height: 44px;
+  min-width: 44px;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  position: relative;
 }
 
 .task-btn svg {
-    flex-shrink: 0;
-    transition: all 0.2s ease;
+  flex-shrink: 0;
+  transition: all 0.2s ease;
 }
 
 /* Icon-Only Buttons - 44x44px WCAG Touch Target */
 .task-btn-icon {
-    padding: 10px;
-    min-width: 44px;
-    width: 44px;
-    height: 44px;
-    justify-content: center;
-    border-radius: 8px;
-    gap: 0;
+  padding: 10px;
+  min-width: 44px;
+  width: 44px;
+  height: 44px;
+  justify-content: center;
+  border-radius: 8px;
+  gap: 0;
 }
 
 .task-btn-icon svg {
-    margin: 0;
+  margin: 0;
 }
 
 /* Touch Feedback */
 .task-btn:active {
-    transform: scale(0.96);
+  transform: scale(0.96);
 }
 
 .task-btn:hover {
-    transform: translateY(-2px) scale(1.05);
+  transform: translateY(-2px) scale(1.05);
 }
 
 .task-btn:active {
-    transform: translateY(0) scale(0.98);
+  transform: translateY(0) scale(0.98);
 }
 
 .edit-btn {
-    background: var(--info);
-    color: white;
+  background: var(--info);
+  color: white;
 }
 
 .edit-btn:hover {
-    background: #1e3a8a;
-    box-shadow: 0 4px 12px rgba(30, 64, 175, 0.3);
+  background: #1e3a8a;
+  box-shadow: 0 4px 12px rgba(30, 64, 175, 0.3);
 }
 
 .complete-btn {
-    background: var(--primary);
-    color: white;
+  background: var(--primary);
+  color: white;
 }
 
 .complete-btn:hover {
-    background: var(--primary-dark);
-    box-shadow: 0 4px 12px rgba(27, 94, 63, 0.3);
+  background: var(--primary-dark);
+  box-shadow: 0 4px 12px rgba(27, 94, 63, 0.3);
 }
 
 [data-theme="dark"] .complete-btn:hover {
-    box-shadow: 0 4px 12px rgba(46, 204, 113, 0.4);
+  box-shadow: 0 4px 12px rgba(46, 204, 113, 0.4);
 }
 
 .delete-btn {
-    background: var(--danger);
-    color: white;
+  background: var(--danger);
+  color: white;
 }
 
 .delete-btn:hover {
-    background: #991b1b;
-    box-shadow: 0 4px 12px rgba(185, 28, 28, 0.3);
+  background: #991b1b;
+  box-shadow: 0 4px 12px rgba(185, 28, 28, 0.3);
 }
 
 .uncomplete-btn {
-    background: var(--warning-color);
-    color: white;
+  background: var(--warning-color);
+  color: white;
 }
 
 .uncomplete-btn:hover {
-    background: #e67e22;
+  background: #e67e22;
 }
 
 .archive-btn {
-    background: #95a5a6;
-    color: white;
+  background: #95a5a6;
+  color: white;
 }
 
 .archive-btn:hover {
-    background: #7f8c8d;
+  background: #7f8c8d;
 }
 
 .unarchive-btn {
-    background: var(--info-color);
-    color: white;
+  background: var(--info-color);
+  color: white;
 }
 
 .unarchive-btn:hover {
-    background: #2980b9;
+  background: #2980b9;
 }
 
 /* Calendar View */
 .tasks-calendar {
-    background: white;
-    padding: 20px;
-    border-radius: 10px;
+  background: white;
+  padding: 20px;
+  border-radius: 10px;
 }
 
 #calendarView {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    gap: 10px;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 10px;
 }
 
 .calendar-day {
-    border: 2px solid var(--border);
-    border-radius: 8px;
-    padding: 10px;
-    min-height: 120px;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+  min-height: 120px;
 }
 
 .calendar-day-header {
-    font-weight: bold;
-    margin-bottom: 8px;
-    color: var(--dark);
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: var(--dark);
 }
 
 .calendar-task {
-    background: var(--primary-color);
-    color: white;
-    padding: 5px;
-    margin-bottom: 5px;
-    border-radius: 4px;
-    font-size: 0.85em;
+  background: var(--primary-color);
+  color: white;
+  padding: 5px;
+  margin-bottom: 5px;
+  border-radius: 4px;
+  font-size: 0.85em;
 }
 
 /* Empty State */
 .empty-state {
-    text-align: center;
-    padding: 80px 40px;
-    color: #7f8c8d;
-    background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
-    border-radius: 15px;
-    margin: 20px 0;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  text-align: center;
+  padding: 80px 40px;
+  color: #7f8c8d;
+  background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
+  border-radius: 15px;
+  margin: 20px 0;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
 }
 
 .empty-state-icon {
-    font-size: 5em;
-    margin-bottom: 20px;
-    animation: float 3s ease-in-out infinite;
-    display: inline-block;
+  font-size: 5em;
+  margin-bottom: 20px;
+  animation: float 3s ease-in-out infinite;
+  display: inline-block;
 }
 
 @keyframes float {
-    0%, 100% {
-        transform: translateY(0px);
-    }
-    50% {
-        transform: translateY(-20px);
-    }
+  0%,
+  100% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-20px);
+  }
 }
 
 .empty-state h3 {
-    font-size: 1.8em;
-    margin-bottom: 15px;
-    color: var(--dark);
+  font-size: 1.8em;
+  margin-bottom: 15px;
+  color: var(--dark);
 }
 
 .empty-state p {
-    font-size: 1.1em;
-    line-height: 1.6;
-    margin-bottom: 25px;
-    color: #7f8c8d;
+  font-size: 1.1em;
+  line-height: 1.6;
+  margin-bottom: 25px;
+  color: #7f8c8d;
 }
 
 .empty-state-btn {
-    display: inline-block;
-    margin-top: 10px;
-    text-decoration: none;
-    padding: 12px 30px;
-    border-radius: 8px;
-    font-weight: 600;
-    transition: all 0.3s;
+  display: inline-block;
+  margin-top: 10px;
+  text-decoration: none;
+  padding: 12px 30px;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: all 0.3s;
 }
 
 .empty-state-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 5px 15px rgba(46, 204, 113, 0.3);
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(46, 204, 113, 0.3);
 }
 
 /* Dashboard CTA Section */
 .dashboard-link-section {
-    background: linear-gradient(135deg, var(--info-color), #2980b9);
-    padding: 40px;
-    border-radius: 10px;
-    text-align: center;
+  background: linear-gradient(135deg, var(--info-color), #2980b9);
+  padding: 40px;
+  border-radius: 10px;
+  text-align: center;
 }
 
 .dashboard-cta {
-    color: white;
+  color: white;
 }
 
 .dashboard-cta h3 {
-    font-size: 1.8em;
-    margin-bottom: 15px;
+  font-size: 1.8em;
+  margin-bottom: 15px;
 }
 
 .dashboard-cta p {
-    font-size: 1.1em;
-    margin-bottom: 25px;
-    opacity: 0.95;
+  font-size: 1.1em;
+  margin-bottom: 25px;
+  opacity: 0.95;
 }
 
 .dashboard-cta .btn {
-    background: white;
-    color: var(--info-color);
-    font-size: 1.1em;
-    padding: 15px 40px;
+  background: white;
+  color: var(--info-color);
+  font-size: 1.1em;
+  padding: 15px 40px;
 }
 
 .dashboard-cta .btn:hover {
-    background: var(--light);
-    transform: scale(1.05);
+  background: var(--light);
+  transform: scale(1.05);
 }
 
 /* Footer */
 footer {
-    background: var(--bg-secondary);
-    color: var(--text-light);
-    text-align: center;
-    padding: 2rem;
-    border-top: 1px solid var(--border);
-    font-size: 0.875rem;
+  background: var(--bg-secondary);
+  color: var(--text-light);
+  text-align: center;
+  padding: 2rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.875rem;
 }
 
 /* Edit Modal */
 .modal {
-    display: none;
-    position: fixed;
-    z-index: 1000;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    align-items: center;
-    justify-content: center;
-    backdrop-filter: blur(4px);
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
 }
 
 [data-theme="dark"] .modal {
-    background-color: rgba(0, 0, 0, 0.85);
-    backdrop-filter: blur(8px);
+  background-color: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(8px);
 }
 
 .modal-content {
-    background-color: var(--bg-secondary);
-    border-radius: 16px;
-    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
-    max-width: 600px;
-    width: 90%;
-    max-height: 90vh;
-    overflow-y: auto;
-    animation: modalSlideIn 0.3s ease-out;
-    transition: background-color 0.3s ease;
-    border: 1px solid var(--border);
+  background-color: var(--bg-secondary);
+  border-radius: 16px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  max-width: 600px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: modalSlideIn 0.3s ease-out;
+  transition: background-color 0.3s ease;
+  border: 1px solid var(--border);
 }
 
 [data-theme="dark"] .modal-content {
-    box-shadow: 0 20px 60px var(--shadow-heavy);
-    background: linear-gradient(135deg, var(--bg-tertiary) 0%, var(--bg-secondary) 100%);
-    border-color: var(--border-light);
+  box-shadow: 0 20px 60px var(--shadow-heavy);
+  background: linear-gradient(
+    135deg,
+    var(--bg-tertiary) 0%,
+    var(--bg-secondary) 100%
+  );
+  border-color: var(--border-light);
 }
 
 @keyframes modalSlideIn {
-    from {
-        opacity: 0;
-        transform: translateY(-50px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(-50px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .modal-header {
-    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
-    color: white;
-    padding: 25px 30px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-radius: 15px 15px 0 0;
+  background: linear-gradient(
+    135deg,
+    var(--primary-color),
+    var(--secondary-color)
+  );
+  color: white;
+  padding: 25px 30px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 15px 15px 0 0;
 }
 
 .modal-header h2 {
-    margin: 0;
-    font-size: 1.5em;
+  margin: 0;
+  font-size: 1.5em;
 }
 
 .modal-close {
-    font-size: 2em;
-    font-weight: bold;
-    color: white;
-    cursor: pointer;
-    transition: transform 0.2s;
-    line-height: 1;
+  font-size: 2em;
+  font-weight: bold;
+  color: white;
+  cursor: pointer;
+  transition: transform 0.2s;
+  line-height: 1;
 }
 
 .modal-close:hover {
-    transform: scale(1.2);
+  transform: scale(1.2);
 }
 
 .modal-content form {
-    padding: 30px;
+  padding: 30px;
 }
 
 .modal-content form .form-group input,
 .modal-content form .form-group textarea {
-    background: var(--bg);
-    border: 2px solid var(--border);
+  background: var(--bg);
+  border: 2px solid var(--border);
 }
 
 [data-theme="dark"] .modal-content form .form-group input,
 [data-theme="dark"] .modal-content form .form-group textarea {
-    background: #252525;
-    border-color: #404040;
-    color: #e5e5e5;
+  background: #252525;
+  border-color: #404040;
+  color: #e5e5e5;
 }
 
 .modal-content form .form-group input:focus,
 .modal-content form .form-group textarea:focus {
-    background: var(--bg-secondary);
-    border-color: var(--primary);
+  background: var(--bg-secondary);
+  border-color: var(--primary);
 }
 
 [data-theme="dark"] .modal-content form .form-group input:focus,
 [data-theme="dark"] .modal-content form .form-group textarea:focus {
-    background: #2a2a2a;
-    border-color: var(--primary);
+  background: #2a2a2a;
+  border-color: var(--primary);
 }
 
 /* Subtask Manager Styles */
 .subtask-manager {
-    margin-top: 10px;
+  margin-top: 10px;
 }
 
 .subtask-input-wrapper {
-    display: flex;
-    gap: 10px;
-    margin-bottom: 15px;
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
 }
 
 .subtask-input {
-    flex: 1;
-    padding: 10px 14px;
-    border: 2px solid var(--border);
-    border-radius: 8px;
-    font-size: 0.95em;
-    transition: all 0.3s ease;
+  flex: 1;
+  padding: 10px 14px;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  font-size: 0.95em;
+  transition: all 0.3s ease;
 }
 
 .subtask-input:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px rgba(27, 94, 63, 0.1);
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(27, 94, 63, 0.1);
 }
 
 [data-theme="dark"] .subtask-input {
-    background: #2a2a2a;
-    border-color: #444;
-    color: var(--text-light);
+  background: #2a2a2a;
+  border-color: #444;
+  color: var(--text-light);
 }
 
 [data-theme="dark"] .subtask-input:focus {
-    background: #2a2a2a;
-    border-color: var(--primary);
+  background: #2a2a2a;
+  border-color: var(--primary);
 }
 
 .btn-add-subtask {
-    padding: 10px 15px;
-    background: var(--primary);
-    color: white;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  padding: 10px 15px;
+  background: var(--primary);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .btn-add-subtask:hover {
-    background: #145a3f;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(27, 94, 63, 0.3);
+  background: #145a3f;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(27, 94, 63, 0.3);
 }
 
 [data-theme="dark"] .btn-add-subtask {
-    background: #2ecc71;
+  background: #2ecc71;
 }
 
 [data-theme="dark"] .btn-add-subtask:hover {
-    background: #27ae60;
+  background: #27ae60;
 }
 
 .subtasks-list {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    max-height: 300px;
-    overflow-y: auto;
-    padding: 10px;
-    background: var(--bg-secondary);
-    border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 10px;
+  background: var(--bg-secondary);
+  border-radius: 8px;
 }
 
 [data-theme="dark"] .subtasks-list {
-    background: #1a1a1a;
+  background: #1a1a1a;
 }
 
 .no-subtasks {
-    text-align: center;
-    color: var(--text-light);
-    font-size: 0.9em;
-    padding: 20px;
+  text-align: center;
+  color: var(--text-light);
+  font-size: 0.9em;
+  padding: 20px;
 }
 
 .subtask-item {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px;
-    background: white;
-    border-radius: 6px;
-    transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  background: white;
+  border-radius: 6px;
+  transition: all 0.3s ease;
 }
 
 .subtask-item:hover {
-    background: #f8f9fa;
-    transform: translateX(4px);
+  background: #f8f9fa;
+  transform: translateX(4px);
 }
 
 .subtask-item.completed {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 
 .subtask-item.completed .subtask-text {
-    text-decoration: line-through;
-    color: var(--text-light);
+  text-decoration: line-through;
+  color: var(--text-light);
 }
 
 [data-theme="dark"] .subtask-item {
-    background: #2a2a2a;
+  background: #2a2a2a;
 }
 
 [data-theme="dark"] .subtask-item:hover {
-    background: #333;
+  background: #333;
 }
 
 .subtask-checkbox {
-    width: 20px;
-    height: 20px;
-    cursor: pointer;
-    accent-color: var(--primary);
-    flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  accent-color: var(--primary);
+  flex-shrink: 0;
 }
 
 .subtask-text {
-    flex: 1;
-    font-size: 0.95em;
-    color: var(--text-primary);
+  flex: 1;
+  font-size: 0.95em;
+  color: var(--text-primary);
 }
 
 [data-theme="dark"] .subtask-text {
-    color: var(--text-light);
+  color: var(--text-light);
 }
 
 .btn-delete-subtask {
-    background: none;
-    border: none;
-    color: var(--danger);
-    cursor: pointer;
-    padding: 4px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
-    transition: all 0.3s ease;
-    opacity: 0.6;
+  background: none;
+  border: none;
+  color: var(--danger);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.3s ease;
+  opacity: 0.6;
 }
 
 .btn-delete-subtask:hover {
-    background: rgba(231, 76, 60, 0.1);
-    opacity: 1;
-    transform: scale(1.1);
+  background: rgba(231, 76, 60, 0.1);
+  opacity: 1;
+  transform: scale(1.1);
 }
 
 /* Subtasks Progress in Task Card */
 .subtasks-progress {
-    margin-top: 12px;
-    padding: 10px;
-    background: var(--bg-secondary);
-    border-radius: 8px;
+  margin-top: 12px;
+  padding: 10px;
+  background: var(--bg-secondary);
+  border-radius: 8px;
 }
 
 [data-theme="dark"] .subtasks-progress {
-    background: #1a1a1a;
+  background: #1a1a1a;
 }
 
 .subtasks-progress-header {
-    display: flex;
-    align-items: center;
-    margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
 }
 
 .subtasks-progress-text {
-    font-size: 0.9em;
-    color: var(--text-light);
-    font-weight: 600;
+  font-size: 0.9em;
+  color: var(--text-light);
+  font-weight: 600;
 }
 
 .subtasks-progress-text.completed {
-    color: var(--primary);
+  color: var(--primary);
 }
 
 [data-theme="dark"] .subtasks-progress-text.completed {
-    color: #2ecc71;
+  color: #2ecc71;
 }
 
 .subtasks-progress-bar {
-    height: 6px;
-    background: #e0e0e0;
-    border-radius: 10px;
-    overflow: hidden;
+  height: 6px;
+  background: #e0e0e0;
+  border-radius: 10px;
+  overflow: hidden;
 }
 
 [data-theme="dark"] .subtasks-progress-bar {
-    background: #333;
+  background: #333;
 }
 
 .subtasks-progress-fill {
-    height: 100%;
-    background: linear-gradient(90deg, var(--primary), #27ae60);
-    border-radius: 10px;
-    transition: width 0.5s ease;
+  height: 100%;
+  background: linear-gradient(90deg, var(--primary), #27ae60);
+  border-radius: 10px;
+  transition: width 0.5s ease;
 }
 
 [data-theme="dark"] .subtasks-progress-fill {
-    background: linear-gradient(90deg, #2ecc71, #27ae60);
+  background: linear-gradient(90deg, #2ecc71, #27ae60);
 }
 
 .modal-actions {
-    display: flex;
-    gap: 15px;
-    justify-content: flex-end;
-    margin-top: 25px;
-    padding-top: 20px;
-    border-top: 1px solid var(--border);
+  display: flex;
+  gap: 15px;
+  justify-content: flex-end;
+  margin-top: 25px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
 }
 
 [data-theme="dark"] .modal-actions {
-    border-top-color: #333;
+  border-top-color: #333;
 }
 
 .btn-secondary {
-    background-color: var(--light);
-    color: var(--dark);
+  background-color: var(--light);
+  color: var(--dark);
 }
 
 .btn-secondary:hover {
-    background-color: var(--border);
+  background-color: var(--border);
 }
 
 /* Confirm Modal Styles */
 .confirm-modal-content {
-    max-width: 500px;
+  max-width: 500px;
 }
 
 .confirm-modal-header {
-    background: linear-gradient(135deg, var(--warning-color), #e67e22);
+  background: linear-gradient(135deg, var(--warning-color), #e67e22);
 }
 
 .confirm-modal-body {
-    padding: 30px;
-    text-align: center;
+  padding: 30px;
+  text-align: center;
 }
 
 .confirm-modal-content .modal-actions {
-    padding: 20px 30px;
-    margin-top: 0;
-    border-top: 1px solid var(--border);
+  padding: 20px 30px;
+  margin-top: 0;
+  border-top: 1px solid var(--border);
 }
 
 .confirm-icon {
-    font-size: 4em;
-    margin-bottom: 20px;
-    animation: pulse 2s infinite;
+  font-size: 4em;
+  margin-bottom: 20px;
+  animation: pulse 2s infinite;
 }
 
 @keyframes pulse {
-    0%, 100% {
-        transform: scale(1);
-    }
-    50% {
-        transform: scale(1.1);
-    }
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
 }
 
 .confirm-modal-body p {
-    font-size: 1.1em;
-    line-height: 1.6;
-    color: var(--dark);
-    margin: 0;
+  font-size: 1.1em;
+  line-height: 1.6;
+  color: var(--dark);
+  margin: 0;
 }
 
 .modal-actions .btn-danger,
 #confirmOkBtn.btn-danger {
-    background-color: var(--danger-color);
-    color: white;
+  background-color: var(--danger-color);
+  color: white;
 }
 
 .modal-actions .btn-danger:hover,
 #confirmOkBtn.btn-danger:hover {
-    background-color: #c0392b;
+  background-color: #c0392b;
 }
 
 /* Responsive */
 @media (max-width: 768px) {
-    .form-row {
-        flex-direction: column;
-    }
-    
-    .filters {
-        flex-direction: column;
-    }
-    
-    .section-header {
-        flex-direction: column;
-        gap: 15px;
-    }
+  .form-row {
+    flex-direction: column;
+  }
 
-    .tasks-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 15px;
-    }
+  .filters {
+    flex-direction: column;
+  }
 
-    .bulk-toolbar {
-        flex-direction: column;
-        align-items: stretch;
-    }
+  .section-header {
+    flex-direction: column;
+    gap: 15px;
+  }
 
-    .bulk-actions {
-        flex-direction: column;
-    }
-    
-    .task-card {
-        flex-direction: column;
-        align-items: flex-start;
-        padding: 15px;
-        gap: 12px;
-    }
+  .tasks-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 15px;
+  }
 
-    .task-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 8px;
-        width: 100%;
-    }
+  .bulk-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-    .task-title {
-        font-size: 1rem;
-        word-break: break-word;
-    }
+  .bulk-actions {
+    flex-direction: column;
+  }
 
-    .task-meta {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 8px;
-        width: 100%;
-        font-size: 0.85rem;
-    }
+  .task-card {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 15px;
+    gap: 12px;
+  }
 
-    .task-meta span {
-        width: 100%;
-    }
+  .task-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    width: 100%;
+  }
 
-    .task-description {
-        font-size: 0.85rem;
-        width: 100%;
-    }
+  .task-title {
+    font-size: 1rem;
+    word-break: break-word;
+  }
 
-    .task-info {
-        width: 100%;
-    }
+  .task-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    width: 100%;
+    font-size: 0.85rem;
+  }
 
-    .task-actions {
-        width: 100%;
-        margin-top: 12px;
-        flex-direction: column;
-        gap: 8px;
-    }
-    
-    .task-btn {
-        justify-content: center;
-        padding: 10px 12px;
-        font-size: 0.9rem;
-    }
+  .task-meta span {
+    width: 100%;
+  }
 
-    .task-btn-icon {
-        width: 44px;
-        height: 44px;
-        padding: 10px;
-        flex: 0 0 44px;
-    }
+  .task-description {
+    font-size: 0.85rem;
+    width: 100%;
+  }
 
-    .task-btn svg {
-        width: 14px;
-        height: 14px;
-    }
+  .task-info {
+    width: 100%;
+  }
 
-    .task-btn-icon svg {
-        width: 18px;
-        height: 18px;
-    }
+  .task-actions {
+    width: 100%;
+    margin-top: 12px;
+    flex-direction: column;
+    gap: 8px;
+  }
 
-    /* Drag handle auf mobilen Geräten verstecken */
-    .drag-handle {
-        display: none;
-    }
+  .task-btn {
+    justify-content: center;
+    padding: 10px 12px;
+    font-size: 0.9rem;
+  }
 
-    .task-card[draggable="true"] {
-        cursor: default;
-    }
+  .task-btn-icon {
+    width: 44px;
+    height: 44px;
+    padding: 10px;
+    flex: 0 0 44px;
+  }
 
-    /* Task-Checkbox mobil optimiert */
-    .task-checkbox {
-        align-self: flex-start;
-        margin-bottom: 8px;
-    }
+  .task-btn svg {
+    width: 14px;
+    height: 14px;
+  }
 
-    .charts-section {
-        grid-template-columns: 1fr;
-    }
+  .task-btn-icon svg {
+    width: 18px;
+    height: 18px;
+  }
 
-    .chart-bar-label {
-        min-width: 80px;
-        font-size: 0.8rem;
-    }
+  /* Drag handle auf mobilen Geräten verstecken */
+  .drag-handle {
+    display: none;
+  }
 
-    .chart-timeline {
-        height: 150px;
-    }
+  .task-card[draggable="true"] {
+    cursor: default;
+  }
 
-    .timeline-bar-label {
-        font-size: 0.65rem;
-    }
+  /* Task-Checkbox mobil optimiert */
+  .task-checkbox {
+    align-self: flex-start;
+    margin-bottom: 8px;
+  }
 
-    .stats-link-card {
-        flex-direction: column;
-        text-align: center;
-    }
+  .charts-section {
+    grid-template-columns: 1fr;
+  }
 
-    .stats-link-arrow {
-        transform: rotate(90deg);
-    }
+  .chart-bar-label {
+    min-width: 80px;
+    font-size: 0.8rem;
+  }
 
-    .stats-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    #calendarView {
-        grid-template-columns: 1fr;
-    }
-    
-    .main-nav {
-        flex-direction: column;
-        padding: 10px;
-        gap: 8px;
-    }
-    
-    .nav-link {
-        text-align: center;
-        padding: 12px 16px;
-        font-size: 0.95rem;
-    }
+  .chart-timeline {
+    height: 150px;
+  }
 
-    /* Header mobil optimiert */
-    header {
-        padding: 1.5rem;
-    }
+  .timeline-bar-label {
+    font-size: 0.65rem;
+  }
+
+  .stats-link-card {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .stats-link-arrow {
+    transform: rotate(90deg);
+  }
+
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  #calendarView {
+    grid-template-columns: 1fr;
+  }
+
+  .main-nav {
+    flex-direction: column;
+    padding: 10px;
+    gap: 8px;
+  }
+
+  .nav-link {
+    text-align: center;
+    padding: 12px 16px;
+    font-size: 0.95rem;
+  }
+
+  /* Header mobil optimiert */
+  header {
+    padding: 1.5rem;
+  }
 }
 
 /* Tablet und mittlere Bildschirme */
 @media (min-width: 768px) and (max-width: 1199px) {
-    main {
-        padding: 1.5rem;
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-    }
-    
-    .weather-forecast {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-        gap: 0.75rem;
-    }
-    
-    .weather-day-card {
-        grid-template-columns: 1fr;
-        text-align: center;
-        padding: 0.75rem;
-    }
-    
-    .weather-content {
-        align-items: center;
-    }
-    
-    .filters {
-        flex-direction: row;
-        flex-wrap: wrap;
-    }
-    
-    .filter-group {
-        flex: 1;
-        min-width: 200px;
-    }
+  main {
+    padding: 1.5rem;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .weather-forecast {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .weather-day-card {
+    grid-template-columns: 1fr;
+    text-align: center;
+    padding: 0.75rem;
+  }
+
+  .weather-content {
+    align-items: center;
+  }
+
+  .filters {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .filter-group {
+    flex: 1;
+    min-width: 200px;
+  }
 }
 
 /* Desktop - kleiner Bildschirm */
 @media (max-width: 768px) {
-    header {
-        padding: 1.5rem;
-    }
+  header {
+    padding: 1.5rem;
+  }
 
-    header h1 {
-        font-size: 1.75rem;
-    }
+  header h1 {
+    font-size: 1.75rem;
+  }
 
-    header .subtitle {
-        font-size: 0.9rem;
-    }
+  header .subtitle {
+    font-size: 0.9rem;
+  }
 
-    /* Stats-Section mobil */
-    .stats-section {
-        grid-template-columns: 1fr;
-        gap: 12px;
-    }
+  /* Stats-Section mobil */
+  .stats-section {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
 
-    .stat-card {
-        padding: 15px;
-    }
+  .stat-card {
+    padding: 15px;
+  }
 
-    .stat-card h3 {
-        font-size: 0.9rem;
-    }
+  .stat-card h3 {
+    font-size: 0.9rem;
+  }
 
-    .stat-number {
-        font-size: 2rem;
-    }
+  .stat-number {
+    font-size: 2rem;
+  }
 
-    /* Filter Section mobil */
-    .filter-section {
-        padding: 15px;
-    }
+  /* Filter Section mobil */
+  .filter-section {
+    padding: 15px;
+  }
 
-    .filter-group {
-        width: 100%;
-    }
+  .filter-group {
+    width: 100%;
+  }
 
-    .filter-group label {
-        font-size: 0.9rem;
-    }
+  .filter-group label {
+    font-size: 0.9rem;
+  }
 
-    .filter-group select,
-    .filter-group input {
-        font-size: 0.9rem;
-        padding: 10px 12px;
-    }
+  .filter-group select,
+  .filter-group input {
+    font-size: 0.9rem;
+    padding: 10px 12px;
+  }
 
-    /* Section Headers mobil */
-    .section-header h2 {
-        font-size: 1.25rem;
-    }
+  /* Section Headers mobil */
+  .section-header h2 {
+    font-size: 1.25rem;
+  }
 
-    .section-actions {
-        width: 100%;
-    }
+  .section-actions {
+    width: 100%;
+  }
 
-    .section-actions .btn {
-        width: 100%;
-        justify-content: center;
-        font-size: 0.9rem;
-    }
+  .section-actions .btn {
+    width: 100%;
+    justify-content: center;
+    font-size: 0.9rem;
+  }
 
-    /* Modal mobil optimiert */
-    .modal-content {
-        width: 95%;
-        max-width: 95%;
-        margin: 10px;
-        max-height: 90vh;
-        overflow-y: auto;
-    }
+  /* Modal mobil optimiert */
+  .modal-content {
+    width: 95%;
+    max-width: 95%;
+    margin: 10px;
+    max-height: 90vh;
+    overflow-y: auto;
+  }
 
-    .modal h2 {
-        font-size: 1.25rem;
-    }
+  .modal h2 {
+    font-size: 1.25rem;
+  }
 
-    /* Archived Badge mobil */
-    .archived-badge {
-        font-size: 0.75rem;
-        padding: 4px 8px;
-    }
+  /* Archived Badge mobil */
+  .archived-badge {
+    font-size: 0.75rem;
+    padding: 4px 8px;
+  }
 
-    .empty-state {
-        padding: 60px 20px;
-    }
+  .empty-state {
+    padding: 60px 20px;
+  }
 
-    .empty-state-icon {
-        font-size: 4em;
-    }
+  .empty-state-icon {
+    font-size: 4em;
+  }
 
-    .empty-state h3 {
-        font-size: 1.5em;
-    }
+  .empty-state h3 {
+    font-size: 1.5em;
+  }
 
-    .empty-state p {
-        font-size: 1em;
-    }
+  .empty-state p {
+    font-size: 1em;
+  }
 
-    /* Theme Toggle mobil */
-    .theme-toggle-btn {
-        width: 48px;
-        height: 48px;
-    }
+  /* Theme Toggle mobil */
+  .theme-toggle-btn {
+    width: 48px;
+    height: 48px;
+  }
 
-    .theme-icon {
-        width: 20px;
-        height: 20px;
-    }
+  .theme-icon {
+    width: 20px;
+    height: 20px;
+  }
 
-    /* Container Padding mobil */
-    .container {
-        padding: 0;
-    }
+  /* Container Padding mobil */
+  .container {
+    padding: 0;
+  }
 
-    main {
-        padding: 1rem;
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-    }
+  main {
+    padding: 1rem;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
 
-    /* Form mobil optimiert */
-    .form-group input,
-    .form-group select,
-    .form-group textarea {
-        font-size: 16px; /* Verhindert Zoom auf iOS */
-    }
+  /* Form mobil optimiert */
+  .form-group input,
+  .form-group select,
+  .form-group textarea {
+    font-size: 16px; /* Verhindert Zoom auf iOS */
+  }
 }
 
 /* Sehr kleine Geräte (Smartphones im Portrait-Modus) */
 @media (max-width: 480px) {
-    header h1 {
-        font-size: 1.5rem;
-    }
+  header h1 {
+    font-size: 1.5rem;
+  }
 
-    .stat-number {
-        font-size: 1.75rem;
-    }
+  .stat-number {
+    font-size: 1.75rem;
+  }
 
-    .task-card {
-        padding: 12px;
-    }
+  .task-card {
+    padding: 12px;
+  }
 
-    .task-btn {
-        padding: 8px 10px;
-        font-size: 0.85rem;
-    }
+  .task-btn {
+    padding: 8px 10px;
+    font-size: 0.85rem;
+  }
 
-    .nav-link {
-        padding: 10px 12px;
-        font-size: 0.9rem;
-    }
+  .nav-link {
+    padding: 10px 12px;
+    font-size: 0.9rem;
+  }
 
-    .modal-content {
-        width: 98%;
-        padding: 15px;
-    }
+  .modal-content {
+    width: 98%;
+    padding: 15px;
+  }
 
-    .chart-bar-label {
-        font-size: 0.75rem;
-        min-width: 60px;
-    }
+  .chart-bar-label {
+    font-size: 0.75rem;
+    min-width: 60px;
+  }
 }
 
 /* Landscape-Modus für Tablets */
 @media (min-width: 769px) and (max-width: 1024px) {
-    .task-card {
-        padding: 18px;
-    }
+  .task-card {
+    padding: 18px;
+  }
 
-    .stats-section {
-        grid-template-columns: repeat(3, 1fr);
-    }
+  .stats-section {
+    grid-template-columns: repeat(3, 1fr);
+  }
 
-    .charts-section {
-        grid-template-columns: repeat(2, 1fr);
-    }
+  .charts-section {
+    grid-template-columns: repeat(2, 1fr);
+  }
 
-    .task-actions {
-        flex-wrap: wrap;
-    }
+  .task-actions {
+    flex-wrap: wrap;
+  }
 
-    .task-btn {
-        min-width: calc(50% - 5px);
-    }
+  .task-btn {
+    min-width: calc(50% - 5px);
+  }
 }
 
 /* ============================================
@@ -3578,29 +3760,31 @@ footer {
    ============================================ */
 
 .btn-spinner {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    border: 2px solid currentColor;
-    border-right-color: transparent;
-    border-radius: 50%;
-    animation: btn-spin 0.6s linear infinite;
-    vertical-align: middle;
-    flex-shrink: 0;
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: btn-spin 0.6s linear infinite;
+  vertical-align: middle;
+  flex-shrink: 0;
 }
 
 @keyframes btn-spin {
-    to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .btn-loading {
-    opacity: 0.75;
-    cursor: not-allowed;
-    pointer-events: none;
+  opacity: 0.75;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .btn-loading .btn-spinner {
-    margin-right: 6px;
+  margin-right: 6px;
 }
 
 /* ============================================
@@ -3608,386 +3792,436 @@ footer {
    ============================================ */
 
 .modal-close {
-    min-width: 44px;
-    min-height: 44px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: none;
-    border: none;
-    cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 
-.btn-add-subtask { min-width: 44px; min-height: 44px; }
-.btn-delete-subtask { min-width: 44px; min-height: 44px; }
-.btn-change-location { min-width: 44px; min-height: 44px; }
-.subtask-checkbox { width: 22px; height: 22px; min-width: 22px; }
-.task-select-checkbox { width: 22px; height: 22px; min-width: 22px; }
-.nav-link { min-height: 44px; display: inline-flex; align-items: center; }
-.filter-group select, .filter-group input { min-height: 44px; }
-.clear-search-btn { min-width: 44px; min-height: 44px; }
+.btn-add-subtask {
+  min-width: 44px;
+  min-height: 44px;
+}
+.btn-delete-subtask {
+  min-width: 44px;
+  min-height: 44px;
+}
+.btn-change-location {
+  min-width: 44px;
+  min-height: 44px;
+}
+.subtask-checkbox {
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+}
+.task-select-checkbox {
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+}
+.nav-link {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+.filter-group select,
+.filter-group input {
+  min-height: 44px;
+}
+.clear-search-btn {
+  min-width: 44px;
+  min-height: 44px;
+}
 
 /* ============================================
    #80 - UNDO NOTIFICATION
    ============================================ */
 
 .undo-notification {
-    position: fixed;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: #333;
-    color: white;
-    padding: 12px 20px;
-    border-radius: 10px;
-    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
-    z-index: 10001;
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    font-size: 0.95rem;
-    font-weight: 500;
-    animation: undoSlideUp 0.3s ease-out;
-    max-width: 90vw;
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: white;
+  padding: 12px 20px;
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  z-index: 10001;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  animation: undoSlideUp 0.3s ease-out;
+  max-width: 90vw;
 }
 
 [data-theme="dark"] .undo-notification {
-    background: #2a2a2a;
-    border: 1px solid #444;
-    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.6);
+  background: #2a2a2a;
+  border: 1px solid #444;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.6);
 }
 
 @keyframes undoSlideUp {
-    from { opacity: 0; transform: translateX(-50%) translateY(20px); }
-    to { opacity: 1; transform: translateX(-50%) translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
 }
 
 .undo-notification-hiding {
-    animation: undoSlideDown 0.3s ease-in forwards;
+  animation: undoSlideDown 0.3s ease-in forwards;
 }
 
 @keyframes undoSlideDown {
-    from { opacity: 1; transform: translateX(-50%) translateY(0); }
-    to { opacity: 0; transform: translateX(-50%) translateY(20px); }
+  from {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-50%) translateY(20px);
+  }
 }
 
-.undo-message { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.undo-message {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 .undo-btn {
-    background: transparent;
-    color: var(--primary, #4ade80);
-    border: 1px solid var(--primary, #4ade80);
-    padding: 6px 16px;
-    border-radius: 6px;
-    font-weight: 700;
-    font-size: 0.9rem;
-    cursor: pointer;
-    transition: all 0.2s;
-    white-space: nowrap;
-    min-height: 36px;
+  background: transparent;
+  color: var(--primary, #4ade80);
+  border: 1px solid var(--primary, #4ade80);
+  padding: 6px 16px;
+  border-radius: 6px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+  min-height: 36px;
 }
 
-.undo-btn:hover { background: var(--primary, #4ade80); color: #1a1a1a; }
+.undo-btn:hover {
+  background: var(--primary, #4ade80);
+  color: #1a1a1a;
+}
 
 .undo-close-btn {
-    background: transparent;
-    color: #999;
-    border: none;
-    font-size: 1.3rem;
-    cursor: pointer;
-    padding: 4px 8px;
-    line-height: 1;
-    min-width: 32px;
-    min-height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
-    transition: color 0.2s;
+  background: transparent;
+  color: #999;
+  border: none;
+  font-size: 1.3rem;
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+  min-width: 32px;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: color 0.2s;
 }
 
-.undo-close-btn:hover { color: white; }
+.undo-close-btn:hover {
+  color: white;
+}
 
 /* ============================================
    PRINT STYLES
    ============================================ */
 
 @media print {
-    /* Allgemeine Print-Optimierungen */
-    * {
-        -webkit-print-color-adjust: exact !important;
-        print-color-adjust: exact !important;
-    }
+  /* Allgemeine Print-Optimierungen */
+  * {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
 
-    body {
-        background: white !important;
-        color: black !important;
-        font-size: 10pt;
-        line-height: 1.4;
-    }
+  body {
+    background: white !important;
+    color: black !important;
+    font-size: 10pt;
+    line-height: 1.4;
+  }
 
-    /* Seiten-Layout */
-    @page {
-        margin: 1.5cm;
-        size: A4 portrait;
-    }
+  /* Seiten-Layout */
+  @page {
+    margin: 1.5cm;
+    size: A4 portrait;
+  }
 
-    /* Verstecke nicht-druckbare Elemente */
-    .theme-toggle,
-    .theme-toggle-btn,
-    .main-nav,
-    nav,
-    footer,
-    .task-actions,
-    .task-checkbox,
-    .drag-handle,
-    button,
-    .btn,
-    .filter-section,
-    .view-controls,
-    .bulk-actions,
-    .archive-controls,
-    .stats-link-card,
-    .modal,
-    .toast,
-    #taskForm,
-    .form-section {
-        display: none !important;
-    }
+  /* Verstecke nicht-druckbare Elemente */
+  .theme-toggle,
+  .theme-toggle-btn,
+  .main-nav,
+  nav,
+  footer,
+  .task-actions,
+  .task-checkbox,
+  .drag-handle,
+  button,
+  .btn,
+  .filter-section,
+  .view-controls,
+  .bulk-actions,
+  .archive-controls,
+  .stats-link-card,
+  .modal,
+  .toast,
+  #taskForm,
+  .form-section {
+    display: none !important;
+  }
 
-    /* Header anpassen */
-    header {
-        background: white !important;
-        border-bottom: 2px solid #1b5e3f !important;
-        padding: 1cm 0 0.5cm 0 !important;
-        margin-bottom: 0.5cm;
-    }
+  /* Header anpassen */
+  header {
+    background: white !important;
+    border-bottom: 2px solid #1b5e3f !important;
+    padding: 1cm 0 0.5cm 0 !important;
+    margin-bottom: 0.5cm;
+  }
 
-    header h1 {
-        color: #1b5e3f !important;
-        font-size: 18pt;
-        margin: 0;
-    }
+  header h1 {
+    color: #1b5e3f !important;
+    font-size: 18pt;
+    margin: 0;
+  }
 
-    header p {
-        color: #333 !important;
-        font-size: 10pt;
-        margin: 0.2cm 0 0 0;
-    }
+  header p {
+    color: #333 !important;
+    font-size: 10pt;
+    margin: 0.2cm 0 0 0;
+  }
 
-    /* Statistik-Karten */
-    .stats-section {
-        display: grid !important;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 0.5cm;
-        margin-bottom: 0.5cm;
-        page-break-inside: avoid;
-    }
+  /* Statistik-Karten */
+  .stats-section {
+    display: grid !important;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5cm;
+    margin-bottom: 0.5cm;
+    page-break-inside: avoid;
+  }
 
-    .stat-card {
-        background: white !important;
-        border: 1px solid #ddd !important;
-        padding: 0.4cm;
-        page-break-inside: avoid;
-    }
+  .stat-card {
+    background: white !important;
+    border: 1px solid #ddd !important;
+    padding: 0.4cm;
+    page-break-inside: avoid;
+  }
 
-    .stat-card h3 {
-        color: #333 !important;
-        font-size: 9pt;
-        margin: 0 0 0.2cm 0;
-    }
+  .stat-card h3 {
+    color: #333 !important;
+    font-size: 9pt;
+    margin: 0 0 0.2cm 0;
+  }
 
-    .stat-number {
-        color: #1b5e3f !important;
-        font-size: 16pt;
-        font-weight: bold;
-        margin: 0;
-    }
+  .stat-number {
+    color: #1b5e3f !important;
+    font-size: 16pt;
+    font-weight: bold;
+    margin: 0;
+  }
 
-    /* Sektions-Header */
-    .section-header {
-        background: white !important;
-        border-bottom: 2px solid #1b5e3f !important;
-        padding: 0.3cm 0;
-        margin: 0.5cm 0 0.3cm 0;
-        page-break-after: avoid;
-    }
+  /* Sektions-Header */
+  .section-header {
+    background: white !important;
+    border-bottom: 2px solid #1b5e3f !important;
+    padding: 0.3cm 0;
+    margin: 0.5cm 0 0.3cm 0;
+    page-break-after: avoid;
+  }
 
-    .section-header h2 {
-        color: #1b5e3f !important;
-        font-size: 14pt;
-        margin: 0;
-    }
+  .section-header h2 {
+    color: #1b5e3f !important;
+    font-size: 14pt;
+    margin: 0;
+  }
 
-    /* Task-Karten */
-    .task-card {
-        background: white !important;
-        border: 1px solid #ddd !important;
-        border-left: 4px solid #1b5e3f !important;
-        padding: 0.4cm;
-        margin-bottom: 0.3cm;
-        page-break-inside: avoid;
-        box-shadow: none !important;
-    }
+  /* Task-Karten */
+  .task-card {
+    background: white !important;
+    border: 1px solid #ddd !important;
+    border-left: 4px solid #1b5e3f !important;
+    padding: 0.4cm;
+    margin-bottom: 0.3cm;
+    page-break-inside: avoid;
+    box-shadow: none !important;
+  }
 
-    .task-card.completed {
-        border-left-color: #27ae60 !important;
-        background: #f0f9f4 !important;
-    }
+  .task-card.completed {
+    border-left-color: #27ae60 !important;
+    background: #f0f9f4 !important;
+  }
 
-    .task-card.archived {
-        border-left-color: #95a5a6 !important;
-        background: #f5f5f5 !important;
-    }
+  .task-card.archived {
+    border-left-color: #95a5a6 !important;
+    background: #f5f5f5 !important;
+  }
 
-    .task-header {
-        margin-bottom: 0.2cm;
-    }
+  .task-header {
+    margin-bottom: 0.2cm;
+  }
 
-    .task-title {
-        color: #1b5e3f !important;
-        font-size: 11pt;
-        font-weight: 600;
-    }
+  .task-title {
+    color: #1b5e3f !important;
+    font-size: 11pt;
+    font-weight: 600;
+  }
 
-    .task-card.completed .task-title {
-        text-decoration: line-through;
-        color: #27ae60 !important;
-    }
+  .task-card.completed .task-title {
+    text-decoration: line-through;
+    color: #27ae60 !important;
+  }
 
-    .task-meta {
-        display: flex;
-        gap: 0.5cm;
-        margin-bottom: 0.2cm;
-        font-size: 9pt;
-    }
+  .task-meta {
+    display: flex;
+    gap: 0.5cm;
+    margin-bottom: 0.2cm;
+    font-size: 9pt;
+  }
 
-    .task-meta span {
-        color: #555 !important;
-    }
+  .task-meta span {
+    color: #555 !important;
+  }
 
-    .task-meta svg {
-        width: 12px;
-        height: 12px;
-        stroke: #555;
-    }
+  .task-meta svg {
+    width: 12px;
+    height: 12px;
+    stroke: #555;
+  }
 
-    .task-description {
-        color: #333 !important;
-        font-size: 9pt;
-        line-height: 1.4;
-        margin-top: 0.2cm;
-    }
+  .task-description {
+    color: #333 !important;
+    font-size: 9pt;
+    line-height: 1.4;
+    margin-top: 0.2cm;
+  }
 
-    /* Status-Badge */
-    .archived-badge {
-        color: #666 !important;
-        font-size: 8pt;
-        padding: 0.1cm 0.2cm;
-        border: 1px solid #999;
-        border-radius: 3px;
-    }
+  /* Status-Badge */
+  .archived-badge {
+    color: #666 !important;
+    font-size: 8pt;
+    padding: 0.1cm 0.2cm;
+    border: 1px solid #999;
+    border-radius: 3px;
+  }
 
-    .archived-badge svg {
-        width: 10px;
-        height: 10px;
-    }
+  .archived-badge svg {
+    width: 10px;
+    height: 10px;
+  }
 
-    /* Charts für Statistik-Seite */
-    .charts-section {
-        display: grid !important;
-        grid-template-columns: 1fr;
-        gap: 0.5cm;
-        page-break-inside: avoid;
-    }
+  /* Charts für Statistik-Seite */
+  .charts-section {
+    display: grid !important;
+    grid-template-columns: 1fr;
+    gap: 0.5cm;
+    page-break-inside: avoid;
+  }
 
-    .chart-card {
-        background: white !important;
-        border: 1px solid #ddd !important;
-        padding: 0.4cm;
-        page-break-inside: avoid;
-    }
+  .chart-card {
+    background: white !important;
+    border: 1px solid #ddd !important;
+    padding: 0.4cm;
+    page-break-inside: avoid;
+  }
 
-    .chart-card h3 {
-        color: #1b5e3f !important;
-        font-size: 11pt;
-        margin: 0 0 0.3cm 0;
-    }
+  .chart-card h3 {
+    color: #1b5e3f !important;
+    font-size: 11pt;
+    margin: 0 0 0.3cm 0;
+  }
 
-    .chart-bar {
-        margin-bottom: 0.2cm;
-    }
+  .chart-bar {
+    margin-bottom: 0.2cm;
+  }
 
-    .chart-bar-label {
-        color: #333 !important;
-        font-size: 8pt;
-    }
+  .chart-bar-label {
+    color: #333 !important;
+    font-size: 8pt;
+  }
 
-    .chart-bar-fill {
-        background: #1b5e3f !important;
-        print-color-adjust: exact;
-    }
+  .chart-bar-fill {
+    background: #1b5e3f !important;
+    print-color-adjust: exact;
+  }
 
-    .chart-bar-value {
-        color: white !important;
-        font-size: 8pt;
-    }
+  .chart-bar-value {
+    color: white !important;
+    font-size: 8pt;
+  }
 
-    .chart-bar-count {
-        color: #555 !important;
-        font-size: 8pt;
-    }
+  .chart-bar-count {
+    color: #555 !important;
+    font-size: 8pt;
+  }
 
-    /* Fortschrittsbalken */
-    .progress-bar {
-        background: #e0e0e0 !important;
-        border: 1px solid #ccc;
-    }
+  /* Fortschrittsbalken */
+  .progress-bar {
+    background: #e0e0e0 !important;
+    border: 1px solid #ccc;
+  }
 
-    .progress-fill {
-        background: #1b5e3f !important;
-        print-color-adjust: exact;
-    }
+  .progress-fill {
+    background: #1b5e3f !important;
+    print-color-adjust: exact;
+  }
 
-    /* Leere-State ausblenden beim Drucken */
-    .empty-state {
-        display: none !important;
-    }
+  /* Leere-State ausblenden beim Drucken */
+  .empty-state {
+    display: none !important;
+  }
 
-    /* Seitenumbrüche optimieren */
-    .dashboard-section,
-    .statistics-section {
-        page-break-inside: avoid;
-    }
+  /* Seitenumbrüche optimieren */
+  .dashboard-section,
+  .statistics-section {
+    page-break-inside: avoid;
+  }
 
-    h2, h3 {
-        page-break-after: avoid;
-    }
+  h2,
+  h3 {
+    page-break-after: avoid;
+  }
 
-    /* Footer für Druckinfo */
-    .container::after {
-        content: "Ausgedruckt am " attr(data-print-date) " | Gartenplaner © 2025";
-        display: block;
-        text-align: center;
-        color: #999 !important;
-        font-size: 8pt;
-        margin-top: 1cm;
-        padding-top: 0.5cm;
-        border-top: 1px solid #ddd;
-    }
+  /* Footer für Druckinfo */
+  .container::after {
+    content: "Ausgedruckt am " attr(data-print-date) " | Gartenplaner © 2025";
+    display: block;
+    text-align: center;
+    color: #999 !important;
+    font-size: 8pt;
+    margin-top: 1cm;
+    padding-top: 0.5cm;
+    border-top: 1px solid #ddd;
+  }
 
-    /* Verbesserte Lesbarkeit */
-    .task-list {
-        display: block !important;
-    }
+  /* Verbesserte Lesbarkeit */
+  .task-list {
+    display: block !important;
+  }
 
-    /* Sicherstellen, dass Farben gedruckt werden */
-    .stat-number,
-    .task-title,
-    .chart-bar-fill {
-        -webkit-print-color-adjust: exact !important;
-        print-color-adjust: exact !important;
-    }
+  /* Sicherstellen, dass Farben gedruckt werden */
+  .stat-number,
+  .task-title,
+  .chart-bar-fill {
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
 }
 
 /* ==========================================
@@ -3996,132 +4230,137 @@ footer {
 
 /* Active Users Indicator */
 .active-users-indicator {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    background: linear-gradient(135deg, var(--bg-secondary) 0%, rgba(255, 255, 255, 0.9) 100%);
-    padding: 0.75rem 1.25rem;
-    border-radius: 25px;
-    border: 2px solid var(--border);
-    font-size: 0.9rem;
-    font-weight: 600;
-    color: var(--text-light);
-    z-index: 999;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
-    opacity: 0.7;
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: linear-gradient(
+    135deg,
+    var(--bg-secondary) 0%,
+    rgba(255, 255, 255, 0.9) 100%
+  );
+  padding: 0.75rem 1.25rem;
+  border-radius: 25px;
+  border: 2px solid var(--border);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-light);
+  z-index: 999;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+  opacity: 0.7;
 }
 
 .active-users-indicator.active {
-    opacity: 1;
-    border-color: var(--primary);
-    color: var(--primary);
+  opacity: 1;
+  border-color: var(--primary);
+  color: var(--primary);
 }
 
 [data-theme="dark"] .active-users-indicator {
-    background: linear-gradient(135deg, #1c1c1c 0%, #262626 100%);
-    border-color: #404040;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  background: linear-gradient(135deg, #1c1c1c 0%, #262626 100%);
+  border-color: #404040;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 [data-theme="dark"] .active-users-indicator.active {
-    border-color: var(--primary);
+  border-color: var(--primary);
 }
 
 /* Collaboration Toast Notifications */
 .collaboration-toast {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    background: white;
-    padding: 1rem 1.5rem;
-    border-radius: 12px;
-    border-left: 4px solid var(--primary);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-    font-size: 0.95rem;
-    font-weight: 500;
-    color: var(--text);
-    z-index: 1001;
-    transform: translateX(400px);
-    opacity: 0;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    max-width: 350px;
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: white;
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+  border-left: 4px solid var(--primary);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--text);
+  z-index: 1001;
+  transform: translateX(400px);
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  max-width: 350px;
 }
 
 .collaboration-toast.show {
-    transform: translateX(0);
-    opacity: 1;
+  transform: translateX(0);
+  opacity: 1;
 }
 
 .collaboration-toast.toast-success {
-    border-left-color: #22c55e;
-    background: linear-gradient(135deg, #ffffff 0%, #f0fdf4 100%);
+  border-left-color: #22c55e;
+  background: linear-gradient(135deg, #ffffff 0%, #f0fdf4 100%);
 }
 
 .collaboration-toast.toast-info {
-    border-left-color: #3b82f6;
-    background: linear-gradient(135deg, #ffffff 0%, #eff6ff 100%);
+  border-left-color: #3b82f6;
+  background: linear-gradient(135deg, #ffffff 0%, #eff6ff 100%);
 }
 
 .collaboration-toast.toast-warning {
-    border-left-color: #f59e0b;
-    background: linear-gradient(135deg, #ffffff 0%, #fffbeb 100%);
+  border-left-color: #f59e0b;
+  background: linear-gradient(135deg, #ffffff 0%, #fffbeb 100%);
 }
 
 .collaboration-toast.toast-error {
-    border-left-color: #ef4444;
-    background: linear-gradient(135deg, #ffffff 0%, #fef2f2 100%);
+  border-left-color: #ef4444;
+  background: linear-gradient(135deg, #ffffff 0%, #fef2f2 100%);
 }
 
 [data-theme="dark"] .collaboration-toast {
-    background: #1c1c1c;
-    border-left-color: var(--primary);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
-    color: #e5e5e5;
+  background: #1c1c1c;
+  border-left-color: var(--primary);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  color: #e5e5e5;
 }
 
 [data-theme="dark"] .collaboration-toast.toast-success {
-    background: linear-gradient(135deg, #1c1c1c 0%, #1a2e1a 100%);
+  background: linear-gradient(135deg, #1c1c1c 0%, #1a2e1a 100%);
 }
 
 [data-theme="dark"] .collaboration-toast.toast-info {
-    background: linear-gradient(135deg, #1c1c1c 0%, #1a2433 100%);
+  background: linear-gradient(135deg, #1c1c1c 0%, #1a2433 100%);
 }
 
 [data-theme="dark"] .collaboration-toast.toast-warning {
-    background: linear-gradient(135deg, #1c1c1c 0%, #2e2416 100%);
+  background: linear-gradient(135deg, #1c1c1c 0%, #2e2416 100%);
 }
 
 [data-theme="dark"] .collaboration-toast.toast-error {
-    background: linear-gradient(135deg, #1c1c1c 0%, #2e1a1a 100%);
+  background: linear-gradient(135deg, #1c1c1c 0%, #2e1a1a 100%);
 }
 
 /* Connection Status Indicator */
 .connection-status {
-    position: fixed;
-    top: 1rem;
-    right: 10rem;
-    width: 12px;
-    height: 12px;
-    background: #ef4444;
-    border-radius: 50%;
-    box-shadow: 0 0 12px rgba(239, 68, 68, 0.6);
-    z-index: 999;
-    animation: pulse 2s infinite;
+  position: fixed;
+  top: 1rem;
+  right: 10rem;
+  width: 12px;
+  height: 12px;
+  background: #ef4444;
+  border-radius: 50%;
+  box-shadow: 0 0 12px rgba(239, 68, 68, 0.6);
+  z-index: 999;
+  animation: pulse 2s infinite;
 }
 
 .connection-status.connected {
-    background: #22c55e;
-    box-shadow: 0 0 12px rgba(34, 197, 94, 0.6);
+  background: #22c55e;
+  box-shadow: 0 0 12px rgba(34, 197, 94, 0.6);
 }
 
 @keyframes pulse {
-    0%, 100% {
-        opacity: 1;
-    }
-    50% {
-        opacity: 0.5;
-    }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 /* ========================================
@@ -4130,619 +4369,624 @@ footer {
 
 /* Error Toast Notifications */
 .error-toast {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    max-width: 400px;
-    background: linear-gradient(135deg, #ffffff 0%, #fff5f5 100%);
-    border: 2px solid #ef4444;
-    border-radius: 12px;
-    box-shadow: 0 8px 24px rgba(239, 68, 68, 0.3);
-    padding: 1.5rem;
-    z-index: 10000;
-    animation: errorSlideIn 0.3s ease-out;
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  max-width: 400px;
+  background: linear-gradient(135deg, #ffffff 0%, #fff5f5 100%);
+  border: 2px solid #ef4444;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(239, 68, 68, 0.3);
+  padding: 1.5rem;
+  z-index: 10000;
+  animation: errorSlideIn 0.3s ease-out;
 }
 
 .error-toast-content {
-    display: flex;
-    align-items: flex-start;
-    gap: 1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
 }
 
 .error-toast-icon {
-    font-size: 2rem;
-    flex-shrink: 0;
-    animation: errorPulse 2s infinite;
+  font-size: 2rem;
+  flex-shrink: 0;
+  animation: errorPulse 2s infinite;
 }
 
 .error-toast-text {
-    flex: 1;
+  flex: 1;
 }
 
 .error-toast-text strong {
-    display: block;
-    color: #dc2626;
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+  display: block;
+  color: #dc2626;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
 }
 
 .error-toast-text p {
-    color: #991b1b;
-    font-size: 0.9rem;
-    margin: 0;
-    line-height: 1.5;
+  color: #991b1b;
+  font-size: 0.9rem;
+  margin: 0;
+  line-height: 1.5;
 }
 
 .error-toast-close {
-    background: none;
-    border: none;
-    color: #dc2626;
-    font-size: 1.5rem;
-    cursor: pointer;
-    padding: 0;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
-    transition: background-color 0.2s;
+  background: none;
+  border: none;
+  color: #dc2626;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.2s;
 }
 
 .error-toast-close:hover {
-    background: rgba(220, 38, 38, 0.1);
+  background: rgba(220, 38, 38, 0.1);
 }
 
 .error-toast-fade {
-    animation: errorSlideOut 0.3s ease-in forwards;
+  animation: errorSlideOut 0.3s ease-in forwards;
 }
 
 @keyframes errorSlideIn {
-    from {
-        transform: translateX(120%);
-        opacity: 0;
-    }
-    to {
-        transform: translateX(0);
-        opacity: 1;
-    }
+  from {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
 }
 
 @keyframes errorSlideOut {
-    from {
-        transform: translateX(0);
-        opacity: 1;
-    }
-    to {
-        transform: translateX(120%);
-        opacity: 0;
-    }
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(120%);
+    opacity: 0;
+  }
 }
 
 @keyframes errorPulse {
-    0%, 100% {
-        transform: scale(1);
-    }
-    50% {
-        transform: scale(1.1);
-    }
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
 }
 
 /* Dark Mode */
 [data-theme="dark"] .error-toast {
-    background: linear-gradient(135deg, #1c1c1c 0%, #2e1a1a 100%);
-    border-color: #b91c1c;
+  background: linear-gradient(135deg, #1c1c1c 0%, #2e1a1a 100%);
+  border-color: #b91c1c;
 }
 
 [data-theme="dark"] .error-toast-text strong {
-    color: #f87171;
+  color: #f87171;
 }
 
 [data-theme="dark"] .error-toast-text p {
-    color: #fca5a5;
+  color: #fca5a5;
 }
 
 [data-theme="dark"] .error-toast-close {
-    color: #f87171;
+  color: #f87171;
 }
 
 [data-theme="dark"] .error-toast-close:hover {
-    background: rgba(248, 113, 113, 0.1);
+  background: rgba(248, 113, 113, 0.1);
 }
 
 /* Storage Warning Toasts - spezielle Styles */
 .error-toast.storage-warning {
-    background: linear-gradient(135deg, #fff3cd 0%, #ffeaa7 100%);
-    border-color: #ffc107;
+  background: linear-gradient(135deg, #fff3cd 0%, #ffeaa7 100%);
+  border-color: #ffc107;
 }
 
 .error-toast.storage-warning .error-toast-text strong {
-    color: #ff8f00;
+  color: #ff8f00;
 }
 
 .error-toast.storage-warning .error-toast-text p {
-    color: #e65100;
+  color: #e65100;
 }
 
 .error-toast.storage-warning .error-toast-close {
-    color: #ff8f00;
+  color: #ff8f00;
 }
 
 .error-toast.storage-critical {
-    background: linear-gradient(135deg, #fee 0%, #fcc 100%);
-    border-color: #dc2626;
-    box-shadow: 0 4px 12px rgba(220, 38, 38, 0.3);
+  background: linear-gradient(135deg, #fee 0%, #fcc 100%);
+  border-color: #dc2626;
+  box-shadow: 0 4px 12px rgba(220, 38, 38, 0.3);
 }
 
 [data-theme="dark"] .error-toast.storage-warning {
-    background: linear-gradient(135deg, #2e2500 0%, #3e3000 100%);
-    border-color: #ffc107;
+  background: linear-gradient(135deg, #2e2500 0%, #3e3000 100%);
+  border-color: #ffc107;
 }
 
 [data-theme="dark"] .error-toast.storage-warning .error-toast-text strong {
-    color: #ffca28;
+  color: #ffca28;
 }
 
 [data-theme="dark"] .error-toast.storage-warning .error-toast-text p {
-    color: #ffd54f;
+  color: #ffd54f;
 }
 
 [data-theme="dark"] .error-toast.storage-critical {
-    background: linear-gradient(135deg, #2e1a1a 0%, #3e1a1a 100%);
+  background: linear-gradient(135deg, #2e1a1a 0%, #3e1a1a 100%);
 }
 
 /* Storage Info Widget */
 .storage-info-widget {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    background: white;
-    border: 2px solid #e0e0e0;
-    border-radius: 12px;
-    padding: 1rem;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    min-width: 250px;
-    z-index: 9999;
-    font-size: 0.85rem;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: white;
+  border: 2px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  min-width: 250px;
+  z-index: 9999;
+  font-size: 0.85rem;
 }
 
 .storage-info-widget.collapsed {
-    padding: 0.5rem;
-    min-width: auto;
-    cursor: pointer;
+  padding: 0.5rem;
+  min-width: auto;
+  cursor: pointer;
 }
 
 .storage-info-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.75rem;
-    font-weight: bold;
-    color: #2c5f2d;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  font-weight: bold;
+  color: #2c5f2d;
 }
 
 .storage-info-toggle {
-    background: none;
-    border: none;
-    font-size: 1.2rem;
-    cursor: pointer;
-    padding: 0;
-    color: #666;
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0;
+  color: #666;
 }
 
 .storage-info-progress {
-    height: 20px;
-    background: #f0f0f0;
-    border-radius: 10px;
-    overflow: hidden;
-    margin-bottom: 0.5rem;
-    position: relative;
+  height: 20px;
+  background: #f0f0f0;
+  border-radius: 10px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+  position: relative;
 }
 
 .storage-info-progress-bar {
-    height: 100%;
-    background: linear-gradient(90deg, #4caf50 0%, #8bc34a 100%);
-    transition: width 0.3s, background 0.3s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: white;
-    font-size: 0.75rem;
-    font-weight: bold;
+  height: 100%;
+  background: linear-gradient(90deg, #4caf50 0%, #8bc34a 100%);
+  transition:
+    width 0.3s,
+    background 0.3s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: bold;
 }
 
 .storage-info-progress-bar.warning {
-    background: linear-gradient(90deg, #ff9800 0%, #ffc107 100%);
+  background: linear-gradient(90deg, #ff9800 0%, #ffc107 100%);
 }
 
 .storage-info-progress-bar.critical {
-    background: linear-gradient(90deg, #f44336 0%, #e91e63 100%);
-    animation: storagePulse 1.5s infinite;
+  background: linear-gradient(90deg, #f44336 0%, #e91e63 100%);
+  animation: storagePulse 1.5s infinite;
 }
 
 .storage-info-details {
-    color: #666;
-    line-height: 1.6;
+  color: #666;
+  line-height: 1.6;
 }
 
 .storage-info-details div {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 0.25rem;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
 }
 
 .storage-info-actions {
-    margin-top: 0.75rem;
-    display: flex;
-    gap: 0.5rem;
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
 }
 
 .storage-info-btn {
-    flex: 1;
-    padding: 0.5rem;
-    border: 1px solid #e0e0e0;
-    background: white;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.75rem;
-    transition: all 0.2s;
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #e0e0e0;
+  background: white;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: all 0.2s;
 }
 
 .storage-info-btn:hover {
-    background: #f5f5f5;
-    border-color: #2c5f2d;
+  background: #f5f5f5;
+  border-color: #2c5f2d;
 }
 
 .storage-info-btn.danger {
-    color: #dc2626;
-    border-color: #dc2626;
+  color: #dc2626;
+  border-color: #dc2626;
 }
 
 .storage-info-btn.danger:hover {
-    background: #fee;
+  background: #fee;
 }
 
 @keyframes storagePulse {
-    0%, 100% {
-        opacity: 1;
-    }
-    50% {
-        opacity: 0.7;
-    }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
 }
 
 [data-theme="dark"] .storage-info-widget {
-    background: #1e1e1e;
-    border-color: #444;
+  background: #1e1e1e;
+  border-color: #444;
 }
 
 [data-theme="dark"] .storage-info-header {
-    color: #8bc34a;
+  color: #8bc34a;
 }
 
 [data-theme="dark"] .storage-info-progress {
-    background: #2a2a2a;
+  background: #2a2a2a;
 }
 
 [data-theme="dark"] .storage-info-details {
-    color: #ccc;
+  color: #ccc;
 }
 
 [data-theme="dark"] .storage-info-btn {
-    background: #2a2a2a;
-    border-color: #444;
-    color: #ccc;
+  background: #2a2a2a;
+  border-color: #444;
+  color: #ccc;
 }
 
 [data-theme="dark"] .storage-info-btn:hover {
-    background: #333;
-    border-color: #8bc34a;
+  background: #333;
+  border-color: #8bc34a;
 }
 
 /* Rate Limit Toasts - spezielle Styles */
 .error-toast.rate-limit {
-    background: linear-gradient(135deg, #fff8dc 0%, #ffeaa7 100%);
-    border-color: #ff9800;
+  background: linear-gradient(135deg, #fff8dc 0%, #ffeaa7 100%);
+  border-color: #ff9800;
 }
 
 .error-toast.rate-limit .error-toast-text strong {
-    color: #f57c00;
+  color: #f57c00;
 }
 
 .error-toast.rate-limit .error-toast-text p {
-    color: #e65100;
+  color: #e65100;
 }
 
 .error-toast.rate-limit .error-toast-close {
-    color: #f57c00;
+  color: #f57c00;
 }
 
 .error-toast.rate-limit .error-toast-icon {
-    animation: rateLimitPulse 1.5s infinite;
+  animation: rateLimitPulse 1.5s infinite;
 }
 
 @keyframes rateLimitPulse {
-    0%, 100% {
-        transform: scale(1);
-        opacity: 1;
-    }
-    50% {
-        transform: scale(1.15);
-        opacity: 0.8;
-    }
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.15);
+    opacity: 0.8;
+  }
 }
 
 [data-theme="dark"] .error-toast.rate-limit {
-    background: linear-gradient(135deg, #3e2500 0%, #4e3000 100%);
-    border-color: #ff9800;
+  background: linear-gradient(135deg, #3e2500 0%, #4e3000 100%);
+  border-color: #ff9800;
 }
 
 [data-theme="dark"] .error-toast.rate-limit .error-toast-text strong {
-    color: #ffb74d;
+  color: #ffb74d;
 }
 
 [data-theme="dark"] .error-toast.rate-limit .error-toast-text p {
-    color: #ffcc80;
+  color: #ffcc80;
 }
 
 /* Rate Limit Badge/Indicator */
 .rate-limit-badge {
-    position: fixed;
-    bottom: 80px;
-    right: 20px;
-    background: linear-gradient(135deg, #ff9800 0%, #f57c00 100%);
-    color: white;
-    padding: 0.5rem 1rem;
-    border-radius: 20px;
-    font-size: 0.85rem;
-    font-weight: bold;
-    box-shadow: 0 4px 12px rgba(255, 152, 0, 0.4);
-    z-index: 9998;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    animation: badgeSlideIn 0.3s ease-out;
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  background: linear-gradient(135deg, #ff9800 0%, #f57c00 100%);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: bold;
+  box-shadow: 0 4px 12px rgba(255, 152, 0, 0.4);
+  z-index: 9998;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  animation: badgeSlideIn 0.3s ease-out;
 }
 
 .rate-limit-badge-icon {
-    font-size: 1.2rem;
-    animation: rateLimitPulse 1.5s infinite;
+  font-size: 1.2rem;
+  animation: rateLimitPulse 1.5s infinite;
 }
 
 .rate-limit-badge-text {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .rate-limit-badge-title {
-    font-size: 0.75rem;
-    opacity: 0.9;
+  font-size: 0.75rem;
+  opacity: 0.9;
 }
 
 .rate-limit-badge-time {
-    font-size: 1rem;
+  font-size: 1rem;
 }
 
 @keyframes badgeSlideIn {
-    from {
-        transform: translateY(100px);
-        opacity: 0;
-    }
-    to {
-        transform: translateY(0);
-        opacity: 1;
-    }
+  from {
+    transform: translateY(100px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 [data-theme="dark"] .rate-limit-badge {
-    background: linear-gradient(135deg, #f57c00 0%, #e65100 100%);
+  background: linear-gradient(135deg, #f57c00 0%, #e65100 100%);
 }
 
 /* Rate Limit Progress Bar (inline in buttons) */
 .rate-limit-progress {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    height: 3px;
-    background: rgba(255, 152, 0, 0.3);
-    transition: width 0.3s ease;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  background: rgba(255, 152, 0, 0.3);
+  transition: width 0.3s ease;
 }
 
 .rate-limit-progress-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #ff9800 0%, #f57c00 100%);
-    transition: width 0.1s linear;
+  height: 100%;
+  background: linear-gradient(90deg, #ff9800 0%, #f57c00 100%);
+  transition: width 0.1s linear;
 }
 
 /* Button mit Rate-Limit Indicator */
 .btn-rate-limited {
-    position: relative;
-    overflow: hidden;
-    opacity: 0.6;
-    cursor: not-allowed !important;
+  position: relative;
+  overflow: hidden;
+  opacity: 0.6;
+  cursor: not-allowed !important;
 }
 
 .btn-rate-limited::after {
-    content: '⏱️';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    font-size: 1.5rem;
-    opacity: 0.5;
+  content: "⏱️";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.5rem;
+  opacity: 0.5;
 }
 
 /* Mobile Anpassungen */
 @media (max-width: 768px) {
-    .rate-limit-badge {
-        bottom: 60px;
-        right: 10px;
-        padding: 0.4rem 0.8rem;
-        font-size: 0.75rem;
-    }
+  .rate-limit-badge {
+    bottom: 60px;
+    right: 10px;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.75rem;
+  }
 
-    .rate-limit-badge-icon {
-        font-size: 1rem;
-    }
+  .rate-limit-badge-icon {
+    font-size: 1rem;
+  }
 
-    .rate-limit-badge-time {
-        font-size: 0.85rem;
-    }
+  .rate-limit-badge-time {
+    font-size: 0.85rem;
+  }
 }
 
 /* Error Boundary Fallback UI */
 .error-boundary-fallback {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    min-height: 400px;
-    padding: 3rem;
-    text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  padding: 3rem;
+  text-align: center;
 }
 
 .error-boundary-icon {
-    font-size: 4rem;
-    margin-bottom: 1rem;
-    animation: errorPulse 2s infinite;
+  font-size: 4rem;
+  margin-bottom: 1rem;
+  animation: errorPulse 2s infinite;
 }
 
 .error-boundary-title {
-    font-size: 1.5rem;
-    color: #dc2626;
-    margin-bottom: 1rem;
+  font-size: 1.5rem;
+  color: #dc2626;
+  margin-bottom: 1rem;
 }
 
 .error-boundary-message {
-    color: #6b7280;
-    margin-bottom: 2rem;
-    max-width: 500px;
+  color: #6b7280;
+  margin-bottom: 2rem;
+  max-width: 500px;
 }
 
 .error-boundary-actions {
-    display: flex;
-    gap: 1rem;
+  display: flex;
+  gap: 1rem;
 }
 
 .error-boundary-btn {
-    padding: 0.75rem 1.5rem;
-    border: none;
-    border-radius: 8px;
-    font-size: 1rem;
-    cursor: pointer;
-    transition: all 0.2s;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
 }
 
 .error-boundary-btn-primary {
-    background: #2c5f2d;
-    color: white;
+  background: #2c5f2d;
+  color: white;
 }
 
 .error-boundary-btn-primary:hover {
-    background: #1e4620;
-    transform: translateY(-2px);
+  background: #1e4620;
+  transform: translateY(-2px);
 }
 
 .error-boundary-btn-secondary {
-    background: #e5e7eb;
-    color: #374151;
+  background: #e5e7eb;
+  color: #374151;
 }
 
 .error-boundary-btn-secondary:hover {
-    background: #d1d5db;
+  background: #d1d5db;
 }
 
 [data-theme="dark"] .error-boundary-fallback {
-    background: #1a1a1a;
+  background: #1a1a1a;
 }
 
 [data-theme="dark"] .error-boundary-title {
-    color: #f87171;
+  color: #f87171;
 }
 
 [data-theme="dark"] .error-boundary-message {
-    color: #9ca3af;
+  color: #9ca3af;
 }
 
 [data-theme="dark"] .error-boundary-btn-secondary {
-    background: #374151;
-    color: #e5e7eb;
+  background: #374151;
+  color: #e5e7eb;
 }
 
 [data-theme="dark"] .error-boundary-btn-secondary:hover {
-    background: #4b5563;
+  background: #4b5563;
 }
 
 /* Loading States mit Error Handling */
 .loading-error {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-    padding: 2rem;
-    background: #fef2f2;
-    border: 1px solid #fecaca;
-    border-radius: 8px;
-    margin: 1rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  margin: 1rem 0;
 }
 
 .loading-error-icon {
-    font-size: 2rem;
+  font-size: 2rem;
 }
 
 .loading-error-text {
-    color: #991b1b;
-    text-align: center;
+  color: #991b1b;
+  text-align: center;
 }
 
 [data-theme="dark"] .loading-error {
-    background: #2e1a1a;
-    border-color: #b91c1c;
+  background: #2e1a1a;
+  border-color: #b91c1c;
 }
 
 [data-theme="dark"] .loading-error-text {
-    color: #fca5a5;
+  color: #fca5a5;
 }
 
 /* Responsive Anpassungen */
 @media (max-width: 768px) {
-    .active-users-indicator {
-        top: 0.5rem;
-        right: 0.5rem;
-        padding: 0.5rem 1rem;
-        font-size: 0.8rem;
-    }
-    
-    .collaboration-toast {
-        bottom: 1rem;
-        right: 1rem;
-        left: 1rem;
-        max-width: none;
-    }
-    
-    .connection-status {
-        top: 0.5rem;
-        right: 7rem;
-    }
+  .active-users-indicator {
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 0.5rem 1rem;
+    font-size: 0.8rem;
+  }
 
-    .error-toast {
-        bottom: 1rem;
-        right: 1rem;
-        left: 1rem;
-        max-width: none;
-    }
+  .collaboration-toast {
+    bottom: 1rem;
+    right: 1rem;
+    left: 1rem;
+    max-width: none;
+  }
 
-    .error-boundary-fallback {
-        padding: 2rem 1rem;
-        min-height: 300px;
-    }
+  .connection-status {
+    top: 0.5rem;
+    right: 7rem;
+  }
 
-    .error-boundary-actions {
-        flex-direction: column;
-        width: 100%;
-    }
+  .error-toast {
+    bottom: 1rem;
+    right: 1rem;
+    left: 1rem;
+    max-width: none;
+  }
 
-    .error-boundary-btn {
-        width: 100%;
-    }
+  .error-boundary-fallback {
+    padding: 2rem 1rem;
+    min-height: 300px;
+  }
+
+  .error-boundary-actions {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .error-boundary-btn {
+    width: 100%;
+  }
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -235,7 +235,7 @@ class GartenPlaner {
 
 		const days = weather.daily.time.slice(0, 7);
 
-		weatherForecast.innerHTML = days
+		const cardsHtml = days
 			.map((date, index) => {
 				const weatherCode = weather.daily.weather_code[index];
 				const tempMax = Math.round(weather.daily.temperature_2m_max[index]);
@@ -244,6 +244,9 @@ class GartenPlaner {
 				const dayName = this.getDayName(date, index);
 				const weatherInfo = this.getWeatherInfo(weatherCode);
 				const todayClass = index === 0 ? "today" : "";
+
+				const precipitation = weather.daily.precipitation_sum[index] || 0;
+				const gardenTip = this.getGardenTip(weatherCode, tempMax, precipitation);
 
 				return `
                 <div class="weather-day-card ${todayClass}">
@@ -256,11 +259,15 @@ class GartenPlaner {
                         <div class="weather-temp">${tempMax}°</div>
                         <div class="weather-temp-range">${tempMin}° - ${tempMax}°</div>
                         <div class="weather-description">${weatherInfo.description}</div>
+                        ${gardenTip}
                     </div>
                 </div>
             `;
 			})
 			.join("");
+
+		const reminders = this.getWeatherReminders(weather);
+		weatherForecast.innerHTML = cardsHtml + reminders;
 	}
 
 	getDayName(dateString, index) {
@@ -322,6 +329,60 @@ class GartenPlaner {
 		}
 
 		return tip ? `<div class="garden-tip">${tip}</div>` : "";
+	}
+
+	getWeatherReminders(weather) {
+		const reminders = [];
+		const todayCode = weather.daily.weather_code[0];
+		const todayTemp = Math.round(weather.daily.temperature_2m_max[0]);
+		const todayPrecip = weather.daily.precipitation_sum[0] || 0;
+		const tomorrowCode = weather.daily.weather_code[1];
+		const tomorrowPrecip = weather.daily.precipitation_sum[1] || 0;
+
+		// Rainy today — skip watering
+		if ((todayCode >= 51 && todayCode <= 65) || (todayCode >= 80 && todayCode <= 82)) {
+			reminders.push({ icon: "💧", text: "Heute regnet es — Bewässerung kann ausgesetzt werden." });
+		} else if (todayTemp > 25 && todayPrecip < 1) {
+			reminders.push({ icon: "🚿", text: "Heiß und trocken heute — Pflanzen gut gießen, am besten morgens oder abends." });
+		}
+
+		// Frost warning
+		const minTemps = weather.daily.temperature_2m_min.slice(0, 3);
+		if (minTemps.some(t => t <= 2)) {
+			reminders.push({ icon: "❄️", text: "Frost möglich in den nächsten Tagen — empfindliche Pflanzen schützen!" });
+		}
+
+		// Storm warning
+		if (todayCode >= 95 || tomorrowCode >= 95) {
+			reminders.push({ icon: "⛈️", text: "Gewitter erwartet — Gartenmöbel und lose Gegenstände sichern." });
+		}
+
+		// Good planting conditions
+		if (todayTemp > 15 && todayTemp < 25 && todayPrecip < 5 && todayCode <= 3) {
+			reminders.push({ icon: "🌱", text: "Ideale Bedingungen heute zum Pflanzen und Arbeiten im Garten." });
+		}
+
+		// Rain tomorrow — plan outdoor work today
+		if ((tomorrowCode >= 51 && tomorrowCode <= 65) || (tomorrowCode >= 80 && tomorrowCode <= 82)) {
+			if (todayCode <= 3) {
+				reminders.push({ icon: "📋", text: "Morgen wird es nass — Außenarbeiten besser heute erledigen." });
+			}
+		}
+
+		// Wind warning
+		const windMax = weather.daily.wind_speed_10m_max?.[0] || 0;
+		if (windMax > 50) {
+			reminders.push({ icon: "💨", text: `Starker Wind heute (${Math.round(windMax)} km/h) — Gewächshäuser prüfen.` });
+		}
+
+		if (reminders.length === 0) return "";
+
+		return `<div class="weather-reminders">
+			<h3>🌿 Garten-Empfehlungen</h3>
+			<ul class="reminder-list">
+				${reminders.map(r => `<li><span class="reminder-icon">${r.icon}</span> ${r.text}</li>`).join("")}
+			</ul>
+		</div>`;
 	}
 
 	showWeatherError(message) {

--- a/src/js/security.js
+++ b/src/js/security.js
@@ -101,9 +101,9 @@ const Security = {
             errors.push('Beschreibung darf maximal 2000 Zeichen lang sein');
         }
 
-        // Mitarbeiter
-        if (!this.validateInput.text(taskData.employee, 1, 100)) {
-            errors.push('Mitarbeiter muss angegeben werden');
+        // Mitarbeiter (optional)
+        if (taskData.employee && !this.validateInput.text(taskData.employee, 0, 100)) {
+            errors.push('Mitarbeiter darf maximal 100 Zeichen lang sein');
         }
 
         // Standort

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -39,8 +39,19 @@ describe('validateTask', () => {
         expect(result.valid).toBe(false);
     });
 
-    test('rejects missing employee', () => {
+    test('accepts empty employee (optional field)', () => {
         const result = validateTask({ ...validTask, employee: '' });
+        expect(result.valid).toBe(true);
+    });
+
+    test('accepts missing employee', () => {
+        const { employee, ...noEmployee } = validTask;
+        const result = validateTask(noEmployee);
+        expect(result.valid).toBe(true);
+    });
+
+    test('rejects employee over 100 chars', () => {
+        const result = validateTask({ ...validTask, employee: 'x'.repeat(101) });
         expect(result.valid).toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- Show garden tips on each weather day card (watering, frost, planting recommendations)
- Add "Garten-Empfehlungen" summary with context-aware reminders (rain, heat, frost, storm, wind)
- Make employee field optional when creating tasks (server + frontend + validation)

Closes #49

## Test plan
- [x] All 52 tests pass
- [x] Weather tips appear on dashboard forecast cards
- [x] Reminders section shows relevant garden advice
- [x] Tasks can be created without employee
- [x] Backwards-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)