### PR TITLE
Move HTML sanitization from input to output

### DIFF
--- a/server.js
+++ b/server.js
@@ -141,11 +141,11 @@ function escapeHtml(str) {
 
 function sanitizeTaskData(data) {
     const sanitized = {};
-    if (data.title !== undefined) sanitized.title = escapeHtml(data.title.trim());
-    if (data.employee !== undefined) sanitized.employee = escapeHtml(data.employee.trim());
-    if (data.location !== undefined) sanitized.location = escapeHtml(data.location.trim());
-    if (data.description !== undefined) sanitized.description = escapeHtml(data.description.trim());
-    if (data.notes !== undefined) sanitized.notes = escapeHtml(data.notes.trim());
+    if (data.title !== undefined) sanitized.title = data.title.trim();
+    if (data.employee !== undefined) sanitized.employee = data.employee.trim();
+    if (data.location !== undefined) sanitized.location = data.location.trim();
+    if (data.description !== undefined) sanitized.description = data.description.trim();
+    if (data.notes !== undefined) sanitized.notes = data.notes.trim();
     if (data.status !== undefined) sanitized.status = data.status;
     if (data.priority !== undefined) sanitized.priority = data.priority;
     if (data.recurrence !== undefined) sanitized.recurrence = data.recurrence;
@@ -316,7 +316,7 @@ app.post('/api/tasks', (req, res) => {
         }],
         subtasks: Array.isArray(sanitized.subtasks) ? sanitized.subtasks.map(st => ({
             id: Date.now() + Math.random(),
-            text: typeof st === 'string' ? escapeHtml(st) : escapeHtml(st.text || ''),
+            text: typeof st === 'string' ? st : (st.text || ''),
             completed: typeof st === 'object' ? !!st.completed : false
         })) : [],
         sortOrder: Date.now()

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -126,13 +126,13 @@ describe('escapeHtml', () => {
 // --- Unit Tests: sanitizeTaskData ---
 
 describe('sanitizeTaskData', () => {
-    test('trims and escapes text fields', () => {
+    test('trims text fields but stores raw (unescaped) data', () => {
         const result = sanitizeTaskData({
             title: '  <b>Test</b>  ',
             employee: ' Max ',
             location: ' Garten '
         });
-        expect(result.title).toBe('&lt;b&gt;Test&lt;/b&gt;');
+        expect(result.title).toBe('<b>Test</b>');
         expect(result.employee).toBe('Max');
         expect(result.location).toBe('Garten');
     });
@@ -147,6 +147,21 @@ describe('sanitizeTaskData', () => {
         const result = sanitizeTaskData({ title: 'Test' });
         expect(result).toHaveProperty('title');
         expect(result).not.toHaveProperty('employee');
+    });
+
+    test('preserves special characters without HTML escaping', () => {
+        const result = sanitizeTaskData({
+            title: 'Tom & Jerry',
+            employee: 'O\'Brien',
+            location: 'Garten <Süd>',
+            description: 'Use "quotes" & ampersands',
+            notes: '<script>alert("xss")</script>'
+        });
+        expect(result.title).toBe('Tom & Jerry');
+        expect(result.employee).toBe("O'Brien");
+        expect(result.location).toBe('Garten <Süd>');
+        expect(result.description).toBe('Use "quotes" & ampersands');
+        expect(result.notes).toBe('<script>alert("xss")</script>');
     });
 });
 
@@ -471,7 +486,7 @@ describe('Security', () => {
         expect(keyBuffer.length).not.toBe(emptyBuffer.length);
     });
 
-    test('sanitizes XSS in task input', async () => {
+    test('stores raw text without HTML escaping (escaping happens on frontend render)', async () => {
         const res = await request(app)
             .post('/api/tasks')
             .send({
@@ -481,7 +496,49 @@ describe('Security', () => {
             });
 
         expect(res.status).toBe(201);
-        expect(res.body.title).not.toContain('<script>');
-        expect(res.body.title).toContain('&lt;script&gt;');
+        // API returns raw text — frontend is responsible for escaping on render
+        expect(res.body.title).toBe('<script>alert("xss")</script>');
+    });
+
+    test('returns special characters as-is in API responses', async () => {
+        const res = await request(app)
+            .post('/api/tasks')
+            .send({
+                title: 'Tom & Jerry',
+                employee: "O'Brien",
+                location: 'Garten <Süd>',
+                description: 'Use "quotes" & ampersands'
+            });
+
+        expect(res.status).toBe(201);
+        expect(res.body.title).toBe('Tom & Jerry');
+        expect(res.body.employee).toBe("O'Brien");
+        expect(res.body.location).toBe('Garten <Süd>');
+        expect(res.body.description).toBe('Use "quotes" & ampersands');
+
+        // Verify the data round-trips correctly (no double-escaping on edit)
+        const updated = await request(app)
+            .put(`/api/tasks/${res.body.id}`)
+            .send({ title: 'Tom & Jerry' });
+
+        expect(updated.status).toBe(200);
+        expect(updated.body.title).toBe('Tom & Jerry');
+    });
+
+    test('stores subtask text as raw without HTML escaping', async () => {
+        const res = await request(app)
+            .post('/api/tasks')
+            .send({
+                title: 'Task with subtasks',
+                location: 'Garten',
+                subtasks: [
+                    { text: 'Tom & Jerry <subtask>', completed: false },
+                    'Plain string with "quotes"'
+                ]
+            });
+
+        expect(res.status).toBe(201);
+        expect(res.body.subtasks[0].text).toBe('Tom & Jerry <subtask>');
+        expect(res.body.subtasks[1].text).toBe('Plain string with "quotes"');
     });
 });


### PR DESCRIPTION
## Summary
- Remove `escapeHtml()` from `sanitizeTaskData()` — data is now stored raw instead of HTML-encoded
- Remove `escapeHtml()` from subtask text processing in POST handler
- Frontend already safe: `task-renderer.js` escapes via `Security.escapeHtml()` on render, edit modal uses `.value`
- Update and add tests for raw storage, no double-escaping, and round-trip integrity

Closes #110

## Test plan
- [x] All 55 tests pass (4 new/updated)
- [x] Verified frontend uses `Security.escapeHtml()` on render (task-renderer.js)
- [x] Verified edit modal uses `.value` property (task-events.js)
- [ ] Manual: Create task with `&`, `<`, `>`, `"`, `'` in title — verify correct display and no double-escaping on edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)