### PR TITLE
Set explicit JSON body size limit on express.json()

### DIFF
--- a/server.js
+++ b/server.js
@@ -200,7 +200,7 @@ function sanitizeTaskData(data) {
 // --- Middleware ---
 
 app.use(compression());
-app.use(express.json());
+app.use(express.json({ limit: '100kb' }));
 
 // Security headers (#2 CORS removed - same-origin, #8 CSP added)
 app.use((req, res, next) => {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -542,3 +542,16 @@ describe('Security', () => {
         expect(res.body.subtasks[1].text).toBe('Plain string with "quotes"');
     });
 });
+
+// --- JSON body size limit ---
+
+describe('JSON body size limit', () => {
+    test('rejects payloads over 100kb with 413 status', async () => {
+        const largeBody = { title: 'x'.repeat(200 * 1024), location: 'Garten' };
+        const res = await request(app)
+            .post('/api/tasks')
+            .send(largeBody);
+
+        expect(res.status).toBe(413);
+    });
+});


### PR DESCRIPTION
## Summary
- Add explicit `limit: '100kb'` option to `express.json()` instead of relying on implicit Express defaults
- Add test verifying 413 response for oversized payloads

Closes #111

## Test plan
- [x] New test: oversized payload returns 413
- [x] All existing tests pass
- [ ] Manual: Send >100kb JSON body and verify rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)