### PR TITLE
Add subtask array validation and sanitization

### DIFF
--- a/server.js
+++ b/server.js
@@ -169,6 +169,33 @@ function validateTask(taskData, partial = false) {
             errors.push('Ungültige Wiederholung (erlaubt: none, daily, weekly, monthly)');
         }
     }
+    if (taskData.subtasks !== undefined) {
+        if (!Array.isArray(taskData.subtasks)) {
+            errors.push('Unteraufgaben müssen ein Array sein');
+        } else {
+            if (taskData.subtasks.length > 50) {
+                errors.push('Maximal 50 Unteraufgaben erlaubt');
+            }
+            taskData.subtasks.forEach((st, i) => {
+                if (typeof st === 'string') {
+                    if (st.length > 500) {
+                        errors.push(`Unteraufgabe ${i + 1}: Text darf maximal 500 Zeichen lang sein`);
+                    }
+                } else if (typeof st === 'object' && st !== null) {
+                    if (typeof st.text !== 'string') {
+                        errors.push(`Unteraufgabe ${i + 1}: text muss ein String sein`);
+                    } else if (st.text.length > 500) {
+                        errors.push(`Unteraufgabe ${i + 1}: Text darf maximal 500 Zeichen lang sein`);
+                    }
+                    if (st.completed !== undefined && typeof st.completed !== 'boolean') {
+                        errors.push(`Unteraufgabe ${i + 1}: completed muss ein Boolean sein`);
+                    }
+                } else {
+                    errors.push(`Unteraufgabe ${i + 1}: muss ein String oder Objekt mit text-Eigenschaft sein`);
+                }
+            });
+        }
+    }
 
     return { valid: errors.length === 0, errors };
 }
@@ -442,7 +469,13 @@ app.put('/api/tasks/:id', async (req, res) => {
         }
         if (sanitized.priority !== undefined) task.priority = sanitized.priority;
         if (sanitized.recurrence !== undefined) task.recurrence = sanitized.recurrence;
-        if (sanitized.subtasks !== undefined) task.subtasks = sanitized.subtasks;
+        if (sanitized.subtasks !== undefined) {
+            task.subtasks = Array.isArray(sanitized.subtasks) ? sanitized.subtasks.map(st => ({
+                id: Date.now() + Math.random(),
+                text: typeof st === 'string' ? st : (st.text || ''),
+                completed: typeof st === 'object' ? !!st.completed : false
+            })) : [];
+        }
 
         if (changes.length > 0) {
             if (!task.history) task.history = [];

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -94,6 +94,69 @@ describe('validateTask', () => {
         const result = validateTask({ ...validTask, description: 'x'.repeat(2001) });
         expect(result.valid).toBe(false);
     });
+
+    test('rejects more than 50 subtasks', () => {
+        const subtasks = Array.from({ length: 51 }, (_, i) => ({ text: `Subtask ${i}`, completed: false }));
+        const result = validateTask({ ...validTask, subtasks });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('50')]));
+    });
+
+    test('accepts exactly 50 subtasks', () => {
+        const subtasks = Array.from({ length: 50 }, (_, i) => ({ text: `Subtask ${i}`, completed: false }));
+        const result = validateTask({ ...validTask, subtasks });
+        expect(result.valid).toBe(true);
+    });
+
+    test('rejects subtask text over 500 chars', () => {
+        const subtasks = [{ text: 'x'.repeat(501), completed: false }];
+        const result = validateTask({ ...validTask, subtasks });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('500')]));
+    });
+
+    test('rejects subtask string over 500 chars', () => {
+        const subtasks = ['x'.repeat(501)];
+        const result = validateTask({ ...validTask, subtasks });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('500')]));
+    });
+
+    test('rejects subtasks that are not an array', () => {
+        const result = validateTask({ ...validTask, subtasks: 'not-an-array' });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('Array')]));
+    });
+
+    test('rejects subtask with non-string text', () => {
+        const subtasks = [{ text: 123, completed: false }];
+        const result = validateTask({ ...validTask, subtasks });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('String')]));
+    });
+
+    test('rejects subtask with non-boolean completed', () => {
+        const subtasks = [{ text: 'Valid text', completed: 'yes' }];
+        const result = validateTask({ ...validTask, subtasks });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('Boolean')]));
+    });
+
+    test('rejects subtask with invalid type (number)', () => {
+        const subtasks = [42];
+        const result = validateTask({ ...validTask, subtasks });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('String oder Objekt')]));
+    });
+
+    test('accepts valid subtasks (mixed strings and objects)', () => {
+        const subtasks = [
+            { text: 'Object subtask', completed: true },
+            'String subtask'
+        ];
+        const result = validateTask({ ...validTask, subtasks });
+        expect(result.valid).toBe(true);
+    });
 });
 
 // --- Unit Tests: escapeHtml ---
@@ -247,6 +310,38 @@ describe('API Endpoints', () => {
                 .put('/api/tasks/nonexistent')
                 .send({ title: 'Test' });
             expect(res.status).toBe(404);
+        });
+
+        test('normalizes subtasks like POST does', async () => {
+            const created = await request(app).post('/api/tasks').send(validTask);
+            const res = await request(app)
+                .put(`/api/tasks/${created.body.id}`)
+                .send({
+                    subtasks: [
+                        { text: 'Object subtask', completed: true },
+                        'String subtask'
+                    ]
+                });
+
+            expect(res.status).toBe(200);
+            expect(res.body.subtasks).toHaveLength(2);
+            expect(res.body.subtasks[0]).toHaveProperty('id');
+            expect(res.body.subtasks[0].text).toBe('Object subtask');
+            expect(res.body.subtasks[0].completed).toBe(true);
+            expect(res.body.subtasks[1]).toHaveProperty('id');
+            expect(res.body.subtasks[1].text).toBe('String subtask');
+            expect(res.body.subtasks[1].completed).toBe(false);
+        });
+
+        test('rejects subtasks exceeding max count via PUT', async () => {
+            const created = await request(app).post('/api/tasks').send(validTask);
+            const subtasks = Array.from({ length: 51 }, (_, i) => ({ text: `Sub ${i}`, completed: false }));
+            const res = await request(app)
+                .put(`/api/tasks/${created.body.id}`)
+                .send({ subtasks });
+
+            expect(res.status).toBe(400);
+            expect(res.body.errors).toEqual(expect.arrayContaining([expect.stringContaining('50')]));
         });
 
         test('tracks status change in history', async () => {


### PR DESCRIPTION
## Summary
- Add subtask validation to `validateTask()`: max 50 subtasks, max 500 chars per text, type checks
- Fix PUT handler to normalize subtasks into `{id, text, completed}` objects (same as POST), instead of passing raw data through
- Add 11 new tests covering all validation rules and PUT normalization

Closes #112

## Test plan
- [x] 11 new tests (9 unit, 2 integration)
- [x] All 67 tests pass
- [ ] Manual: Create task with >50 subtasks, verify 400 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)