### PR TITLE
Add global error handler middleware and graceful shutdown

### DIFF
--- a/server.js
+++ b/server.js
@@ -688,16 +688,48 @@ app.get('/api/plant-categories', (req, res) => {
     res.json(categories);
 });
 
+// --- Test-only error route (for verifying error handler) ---
+if (process.env.NODE_ENV === 'test') {
+    app.get('/api/test-error', (req, res, next) => {
+        next(new Error('Test error for verification'));
+    });
+}
+
+// --- Global error handler ---
+app.use((err, req, res, next) => {
+    // Let Express-generated HTTP errors (e.g., 413 Payload Too Large) pass through with their status
+    if (err.status && err.status < 500) {
+        return res.status(err.status).json({ error: err.message });
+    }
+    logger.error({ err: err.message, url: req.originalUrl, method: req.method }, 'unhandled error');
+    res.status(500).json({ error: 'Internal server error' });
+});
+
 // --- Start server ---
 
 if (require.main === module) {
-    app.listen(PORT, () => {
+    const server = app.listen(PORT, () => {
         logger.info({ port: PORT, auth: !!API_KEY }, 'Gartenplaner API started');
         audit('server_started', { port: PORT, authEnabled: !!API_KEY });
         if (!API_KEY) {
             logger.warn('No API_KEY set. API is open for all requests.');
         }
     });
+
+    function shutdown(signal) {
+        logger.info({ signal }, 'shutting down gracefully');
+        server.close(() => {
+            logger.info('all connections closed');
+            process.exit(0);
+        });
+        setTimeout(() => {
+            logger.error('forced shutdown after timeout');
+            process.exit(1);
+        }, 10000);
+    }
+
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
 module.exports = { app, validateTask, escapeHtml, sanitizeTaskData, paginate, resetCaches };

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -582,6 +582,18 @@ describe('UUID validation for :id parameters', () => {
     });
 });
 
+// --- Error Handler Tests ---
+
+describe('Global error handler', () => {
+    test('returns 500 with generic message and no stack trace', async () => {
+        const res = await request(app).get('/api/test-error');
+        expect(res.status).toBe(500);
+        expect(res.body).toEqual({ error: 'Internal server error' });
+        expect(res.body.stack).toBeUndefined();
+        expect(res.body.message).toBeUndefined();
+    });
+});
+
 // --- Security Tests ---
 
 describe('Security', () => {


### PR DESCRIPTION
## Summary
- Add global Express error handler after all routes — returns generic 500 JSON response, no stack trace leakage
- Add graceful shutdown on SIGTERM/SIGINT — stops accepting connections, waits for in-flight requests, force-exits after 10s timeout
- Add test-only `/api/test-error` endpoint (gated behind `NODE_ENV=test`) to verify error handler

Closes #121

## Test plan
- [x] New test: error handler returns 500 with `{ error: 'Internal server error' }`, no stack trace
- [x] All 57 tests pass
- [ ] Manual: Verify `docker stop` gracefully shuts down the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)