### PR TITLE
Add Docker Hub publish CI/CD pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,49 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract version from package.json
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/gardenplanner"
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            echo "tags=${IMAGE}:latest,${IMAGE}:${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.ref_name }}" = "develop" ]; then
+            echo "tags=${IMAGE}:beta" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to build and publish Docker images to Docker Hub
- Push `beta` tag on develop branch merges
- Push `latest` + version tag on main branch merges
- Uses Docker Buildx with GitHub Actions cache for faster builds

## Tag Strategy

| Branch | Docker Tag | Example |
|--------|-----------|---------|
| `develop` | `beta` | `user/gardenplanner:beta` |
| `main` | `latest` + version | `user/gardenplanner:latest`, `user/gardenplanner:1.0.0` |

## Required Setup
- [ ] Add `DOCKERHUB_USERNAME` secret in repo settings
- [ ] Add `DOCKERHUB_TOKEN` secret in repo settings

## Test plan
- [ ] Merge to develop → verify `beta` tag on Docker Hub
- [ ] Merge to main → verify `latest` + version tag on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)