### PR TITLE
fix: enforce npm audit in Docker builds (#141)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apk update && apk upgrade --no-cache || true
 COPY package.json package-lock.json* ./
 RUN npm config set strict-ssl false \
     && npm config set registry http://repo.inform-software.com/artifactory/api/npm/npmjs/ \
-    && npm install --omit=dev \
-    && (npm audit --audit-level=moderate || true)
+    && npm ci --omit=dev
+RUN npm audit --audit-level=high
 
 # Anwendungsdateien kopieren (#7: no tests/docs in production)
 COPY server.js ./


### PR DESCRIPTION
## Summary
- Replace `npm install` with `npm ci` for deterministic, lockfile-based installs
- Separate `npm audit` into its own `RUN` step with `--audit-level=high`
- Remove `|| true` so high-severity vulnerabilities fail the build

Closes #141

## Test plan
- [ ] `docker compose build` succeeds with current dependencies
- [ ] Build fails if a high-severity vulnerability is introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)