### PR TITLE
fix: sanitize error messages and unify error format (#138)

### DIFF
--- a/src/server/middleware/error-handler.js
+++ b/src/server/middleware/error-handler.js
@@ -1,13 +1,41 @@
 const { logger } = require('../logger');
 
-// --- Global error handler ---
+const GENERIC_MESSAGES = {
+    400: 'Bad request',
+    401: 'Unauthorized',
+    403: 'Forbidden',
+    404: 'Not found',
+    409: 'Conflict',
+    413: 'Request too large',
+    429: 'Too many requests'
+};
+
 function errorHandler(err, req, res, next) {
-    // Let Express-generated HTTP errors (e.g., 413 Payload Too Large) pass through with their status
-    if (err.status && err.status < 500) {
-        return res.status(err.status).json({ error: err.message });
+    const status = err.status || 500;
+    const isProduction = process.env.NODE_ENV === 'production';
+
+    // Always log server errors with full context
+    if (status >= 500) {
+        logger.error({
+            err: err.message,
+            stack: err.stack,
+            url: req.originalUrl,
+            method: req.method,
+            ip: req.ip
+        }, 'unhandled error');
     }
-    logger.error({ err: err.message, url: req.originalUrl, method: req.method }, 'unhandled error');
-    res.status(500).json({ error: 'Internal server error' });
+
+    // In production, use generic messages for all errors
+    // In development/test, pass through the original message for 4xx
+    const message = (isProduction || status >= 500)
+        ? (GENERIC_MESSAGES[status] || 'Internal server error')
+        : (err.message || GENERIC_MESSAGES[status] || 'Internal server error');
+
+    res.status(status).json({
+        error: true,
+        status,
+        message
+    });
 }
 
 module.exports = { errorHandler };

--- a/src/server/routes/archive.js
+++ b/src/server/routes/archive.js
@@ -12,7 +12,7 @@ const {
 router.post('/tasks/:id/archive', validateIdParam, async (req, res) => {
     const result = await archiveTask(req.params.id);
     if (result.error) {
-        return res.status(result.status).json({ error: result.message });
+        return res.status(result.status).json({ error: true, status: result.status, message: result.message });
     }
     res.json(result.task);
 });
@@ -21,7 +21,7 @@ router.post('/tasks/:id/archive', validateIdParam, async (req, res) => {
 router.post('/tasks/:id/unarchive', validateIdParam, async (req, res) => {
     const result = await unarchiveTask(req.params.id);
     if (result.error) {
-        return res.status(result.status).json({ error: result.message });
+        return res.status(result.status).json({ error: true, status: result.status, message: result.message });
     }
     res.json(result.task);
 });
@@ -35,7 +35,7 @@ router.get('/archived-tasks', (req, res) => {
 router.delete('/archived-tasks/:id', validateIdParam, async (req, res) => {
     const result = await deleteArchivedTask(req.params.id);
     if (result.error) {
-        return res.status(result.status).json({ error: result.message });
+        return res.status(result.status).json({ error: true, status: result.status, message: result.message });
     }
     res.status(204).send();
 });

--- a/src/server/routes/tasks.js
+++ b/src/server/routes/tasks.js
@@ -23,7 +23,7 @@ router.post('/search', (req, res) => {
 // GET /api/tasks/:id - Get single task
 router.get('/:id', validateIdParam, (req, res) => {
     const task = getTask(req.params.id);
-    if (!task) return res.status(404).json({ error: 'Task not found' });
+    if (!task) return res.status(404).json({ error: true, status: 404, message: 'Task not found' });
     res.json(task);
 });
 
@@ -31,7 +31,7 @@ router.get('/:id', validateIdParam, (req, res) => {
 router.post('/', async (req, res) => {
     const result = await createTask(req.body);
     if (result.error) {
-        return res.status(result.status).json({ errors: result.errors });
+        return res.status(result.status).json({ error: true, status: result.status, message: 'Validation failed', errors: result.errors });
     }
     res.status(201).json(result.task);
 });
@@ -40,8 +40,8 @@ router.post('/', async (req, res) => {
 router.put('/:id', validateIdParam, async (req, res) => {
     const result = await updateTask(req.params.id, req.body);
     if (result.error) {
-        if (result.status === 400) return res.status(400).json({ errors: result.errors });
-        return res.status(result.status).json({ error: result.message });
+        if (result.status === 400) return res.status(400).json({ error: true, status: 400, message: 'Validation failed', errors: result.errors });
+        return res.status(result.status).json({ error: true, status: result.status, message: result.message });
     }
     res.json(result.task);
 });
@@ -50,7 +50,7 @@ router.put('/:id', validateIdParam, async (req, res) => {
 router.delete('/:id', validateIdParam, async (req, res) => {
     const result = await deleteTask(req.params.id);
     if (result.error) {
-        return res.status(result.status).json({ error: result.message });
+        return res.status(result.status).json({ error: true, status: result.status, message: result.message });
     }
     res.status(204).send();
 });

--- a/src/server/validation/task-validator.js
+++ b/src/server/validation/task-validator.js
@@ -4,7 +4,7 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9
 
 function validateIdParam(req, res, next) {
     if (!UUID_REGEX.test(req.params.id)) {
-        return res.status(400).json({ error: 'Invalid ID format. Expected a valid UUID.' });
+        return res.status(400).json({ error: true, status: 400, message: 'Invalid ID format' });
     }
     next();
 }

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -257,6 +257,8 @@ describe('API Endpoints', () => {
                 .send({ title: '' });
 
             expect(res.status).toBe(400);
+            expect(res.body.error).toBe(true);
+            expect(res.body.status).toBe(400);
             expect(res.body).toHaveProperty('errors');
         });
     });
@@ -292,7 +294,8 @@ describe('API Endpoints', () => {
         test('returns 400 for invalid ID format', async () => {
             const res = await request(app).get('/api/tasks/nonexistent');
             expect(res.status).toBe(400);
-            expect(res.body.error).toMatch(/Invalid ID format/);
+            expect(res.body.error).toBe(true);
+            expect(res.body.message).toMatch(/Invalid ID format/);
         });
 
         test('returns 404 for valid UUID that does not exist', async () => {
@@ -317,7 +320,8 @@ describe('API Endpoints', () => {
                 .put('/api/tasks/nonexistent')
                 .send({ title: 'Test' });
             expect(res.status).toBe(400);
-            expect(res.body.error).toMatch(/Invalid ID format/);
+            expect(res.body.error).toBe(true);
+            expect(res.body.message).toMatch(/Invalid ID format/);
         });
 
         test('returns 404 for valid UUID that does not exist', async () => {
@@ -385,7 +389,8 @@ describe('API Endpoints', () => {
         test('returns 400 for invalid ID format', async () => {
             const res = await request(app).delete('/api/tasks/nonexistent');
             expect(res.status).toBe(400);
-            expect(res.body.error).toMatch(/Invalid ID format/);
+            expect(res.body.error).toBe(true);
+            expect(res.body.message).toMatch(/Invalid ID format/);
         });
 
         test('returns 404 for valid UUID that does not exist', async () => {
@@ -572,7 +577,8 @@ describe('UUID validation for :id parameters', () => {
             if (body) req.send(body);
             const res = await req;
             expect(res.status).toBe(400);
-            expect(res.body.error).toMatch(/Invalid ID format/);
+            expect(res.body.error).toBe(true);
+            expect(res.body.message).toMatch(/Invalid ID format/);
         });
     });
 
@@ -585,12 +591,27 @@ describe('UUID validation for :id parameters', () => {
 // --- Error Handler Tests ---
 
 describe('Global error handler', () => {
-    test('returns 500 with generic message and no stack trace', async () => {
+    test('returns consistent error format for 500 errors', async () => {
         const res = await request(app).get('/api/test-error');
         expect(res.status).toBe(500);
-        expect(res.body).toEqual({ error: 'Internal server error' });
+        expect(res.body).toEqual({
+            error: true,
+            status: 500,
+            message: 'Internal server error'
+        });
         expect(res.body.stack).toBeUndefined();
-        expect(res.body.message).toBeUndefined();
+    });
+
+    test('returns consistent error format for 413 payload too large', async () => {
+        const largeBody = { title: 'x'.repeat(200 * 1024), location: 'Garten' };
+        const res = await request(app)
+            .post('/api/tasks')
+            .send(largeBody);
+
+        expect(res.status).toBe(413);
+        expect(res.body.error).toBe(true);
+        expect(res.body.status).toBe(413);
+        expect(res.body).toHaveProperty('message');
     });
 });
 
@@ -711,5 +732,6 @@ describe('JSON body size limit', () => {
             .send(largeBody);
 
         expect(res.status).toBe(413);
+        expect(res.body.error).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- Unified error response format: `{ error: true, status, message, errors? }`
- Production mode returns generic messages, no internal details leaked
- 5xx errors now log full stack traces server-side
- Updated all routes (tasks, archive) and `validateIdParam` to consistent format

Closes #138

## Test plan
- [ ] 80/80 tests pass
- [ ] `POST /api/tasks` with invalid body returns `{ error: true, status: 400, message: "Validation failed", errors: [...] }`
- [ ] `GET /api/test-error` returns `{ error: true, status: 500, message: "Internal server error" }` (no stack)
- [ ] 413 payload returns generic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)