### PR TITLE
feat: add tiered per-IP/per-key rate limiting (#139)

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,12 +1,12 @@
 const express = require('express');
 const compression = require('compression');
-const rateLimit = require('express-rate-limit');
 const path = require('path');
 
 const { requestLogger } = require('./logger');
 const { securityHeaders } = require('./middleware/security');
 const { apiKeyAuth } = require('./middleware/auth');
 const { errorHandler } = require('./middleware/error-handler');
+const { generalLimiter, writeLimiter, authLimiter, resetRateLimitStores } = require('./middleware/rate-limit');
 const { validateTask, escapeHtml, sanitizeTaskData } = require('./validation/task-validator');
 const { paginate } = require('./services/task-service');
 const { resetCaches } = require('./storage/json-store');
@@ -39,14 +39,9 @@ app.use('/api/auth', authRouter);
 // API key authentication for /api/* routes
 app.use('/api', apiKeyAuth);
 
-// Rate limiting
-const limiter = rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100,
-    standardHeaders: true,
-    legacyHeaders: false
-});
-app.use('/api', limiter);
+// Rate limiting — tiered
+app.use('/api/auth', authLimiter);
+app.use('/api', generalLimiter);
 
 // --- Static file serving (replaces nginx) ---
 
@@ -75,6 +70,14 @@ app.get('/', (req, res) => {
     res.sendFile(path.join(PROJECT_ROOT, 'public', 'index.html'));
 });
 
+// Stricter rate limit on write operations
+app.post('/api/tasks', writeLimiter);
+app.put('/api/tasks/:id', writeLimiter);
+app.delete('/api/tasks/:id', writeLimiter);
+app.post('/api/tasks/:id/archive', writeLimiter);
+app.post('/api/tasks/:id/unarchive', writeLimiter);
+app.delete('/api/archived-tasks/:id', writeLimiter);
+
 // --- API Routes ---
 
 app.use('/api/tasks', tasksRouter);
@@ -96,4 +99,4 @@ if (process.env.NODE_ENV === 'test') {
 // --- Global error handler (AFTER all routes) ---
 app.use(errorHandler);
 
-module.exports = { app, validateTask, escapeHtml, sanitizeTaskData, paginate, resetCaches };
+module.exports = { app, validateTask, escapeHtml, sanitizeTaskData, paginate, resetCaches, resetRateLimitStores };

--- a/src/server/middleware/rate-limit.js
+++ b/src/server/middleware/rate-limit.js
@@ -1,0 +1,54 @@
+const rateLimit = require('express-rate-limit');
+const { MemoryStore, ipKeyGenerator } = require('express-rate-limit');
+
+// --- Rate limit configuration ---
+const RATE_LIMITS = {
+    general: { windowMs: 15 * 60 * 1000, max: 100 },   // 100 req / 15 min
+    write:   { windowMs: 15 * 60 * 1000, max: 30 },     // 30 req / 15 min
+    auth:    { windowMs: 15 * 60 * 1000, max: 10 }       // 10 req / 15 min
+};
+
+const COMMON_OPTIONS = {
+    standardHeaders: true,
+    legacyHeaders: false
+};
+
+// Key generator: use API key if present, fall back to IP (IPv6-safe via ipKeyGenerator)
+function keyGenerator(req) {
+    return req.headers['x-api-key'] || ipKeyGenerator(req.ip);
+}
+
+// Explicit stores so we can reset them in tests
+const generalStore = new MemoryStore();
+const writeStore = new MemoryStore();
+const authStore = new MemoryStore();
+
+const generalLimiter = rateLimit({
+    ...COMMON_OPTIONS,
+    ...RATE_LIMITS.general,
+    keyGenerator,
+    store: generalStore
+});
+
+const writeLimiter = rateLimit({
+    ...COMMON_OPTIONS,
+    ...RATE_LIMITS.write,
+    keyGenerator,
+    store: writeStore
+});
+
+const authLimiter = rateLimit({
+    ...COMMON_OPTIONS,
+    ...RATE_LIMITS.auth,
+    store: authStore
+    // Auth limiter always uses IP (no key yet)
+});
+
+// Reset all rate limiter stores (useful for tests)
+function resetRateLimitStores() {
+    generalStore.resetAll();
+    writeStore.resetAll();
+    authStore.resetAll();
+}
+
+module.exports = { generalLimiter, writeLimiter, authLimiter, RATE_LIMITS, resetRateLimitStores };

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -2,17 +2,18 @@ const request = require('supertest');
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
-const { app, validateTask, escapeHtml, sanitizeTaskData, paginate, resetCaches } = require('../src/server/app');
+const { app, validateTask, escapeHtml, sanitizeTaskData, paginate, resetCaches, resetRateLimitStores } = require('../src/server/app');
 
 const DATA_DIR = path.join(__dirname, '..', 'data');
 const TASKS_FILE = path.join(DATA_DIR, 'tasks.json');
 const ARCHIVED_FILE = path.join(DATA_DIR, 'archived-tasks.json');
 
-// Reset data files and caches before each test
+// Reset data files, caches, and rate limiters before each test
 beforeEach(() => {
     fs.writeFileSync(TASKS_FILE, '[]', 'utf8');
     fs.writeFileSync(ARCHIVED_FILE, '[]', 'utf8');
     resetCaches();
+    resetRateLimitStores();
 });
 
 // --- Unit Tests: validateTask ---
@@ -719,6 +720,28 @@ describe('Security', () => {
         expect(res.status).toBe(201);
         expect(res.body.subtasks[0].text).toBe('Tom & Jerry <subtask>');
         expect(res.body.subtasks[1].text).toBe('Plain string with "quotes"');
+    });
+});
+
+// --- Rate Limiting Tests ---
+
+describe('Rate limiting', () => {
+    test('returns rate limit headers on API responses', async () => {
+        const res = await request(app).get('/api/tasks');
+        expect(res.headers).toHaveProperty('ratelimit-limit');
+        expect(res.headers).toHaveProperty('ratelimit-remaining');
+    });
+
+    test('write endpoints have stricter limits than read endpoints', async () => {
+        const readRes = await request(app).get('/api/tasks');
+        const writeRes = await request(app)
+            .post('/api/tasks')
+            .send({ title: 'Test', location: 'Garten' });
+
+        const readLimit = parseInt(readRes.headers['ratelimit-limit'], 10);
+        const writeLimit = parseInt(writeRes.headers['ratelimit-limit'], 10);
+
+        expect(readLimit).toBeGreaterThan(writeLimit);
     });
 });
 


### PR DESCRIPTION
## Summary
- New `src/server/middleware/rate-limit.js` with three tiers: general (100/15min), write (30/15min), auth (10/15min)
- Key generator uses `X-API-Key` when present, falls back to IP
- Explicit MemoryStores with `resetRateLimitStores()` for test isolation
- Write limiter applied to all mutation endpoints (POST/PUT/DELETE)

Closes #139

## Test plan
- [ ] 82/82 tests pass
- [ ] `GET /api/tasks` returns `ratelimit-limit: 100` header
- [ ] `POST /api/tasks` returns `ratelimit-limit: 30` header
- [ ] Rate limits track per API key when header present

🤖 Generated with [Claude Code](https://claude.com/claude-code)