### PR TITLE
feat: replace unsafe-inline with CSP nonce for style-src (#140)

### DIFF
--- a/public/logs.html
+++ b/public/logs.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../src/css/styles.css" />
-    <style>
+    <style nonce="__CSP_NONCE__">
       .log-viewer-container {
         max-width: 1400px;
         margin: 20px auto;

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const compression = require('compression');
+const fs = require('fs');
 const path = require('path');
 
 const { requestLogger } = require('./logger');
@@ -29,6 +30,24 @@ app.use(express.json({ limit: '100kb' }));
 
 // Security headers
 app.use(securityHeaders);
+
+// Inject CSP nonce into HTML responses
+app.use((req, res, next) => {
+    const originalSendFile = res.sendFile.bind(res);
+    res.sendFile = function(filePath, options, callback) {
+        if (filePath.endsWith('.html')) {
+            fs.readFile(filePath, 'utf8', (err, html) => {
+                if (err) return next(err);
+                html = html.replace(/__CSP_NONCE__/g, res.locals.cspNonce);
+                res.set('Content-Type', 'text/html');
+                res.send(html);
+            });
+        } else {
+            originalSendFile(filePath, options, callback);
+        }
+    };
+    next();
+});
 
 // Request logging
 app.use(requestLogger);

--- a/src/server/middleware/security.js
+++ b/src/server/middleware/security.js
@@ -1,5 +1,10 @@
-// Security headers (#2 CORS removed - same-origin, #8 CSP added)
+const crypto = require('crypto');
+
 function securityHeaders(req, res, next) {
+    // Generate unique nonce per request
+    const nonce = crypto.randomBytes(16).toString('base64');
+    res.locals.cspNonce = nonce;
+
     res.setHeader('X-Frame-Options', 'SAMEORIGIN');
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
@@ -9,7 +14,7 @@ function securityHeaders(req, res, next) {
     res.setHeader('Content-Security-Policy', [
         "default-src 'self'",
         "script-src 'self' https://cdnjs.cloudflare.com",
-        "style-src 'self' 'unsafe-inline'",
+        `style-src 'self' 'nonce-${nonce}'`,
         "img-src 'self' data:",
         "font-src 'self'",
         "connect-src 'self' https://api.open-meteo.com https://geocoding-api.open-meteo.com",

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -705,6 +705,29 @@ describe('Security', () => {
         expect(updated.body.title).toBe('Tom & Jerry');
     });
 
+    test('CSP header contains nonce instead of unsafe-inline', async () => {
+        const res = await request(app).get('/');
+        const csp = res.headers['content-security-policy'];
+        expect(csp).not.toContain('unsafe-inline');
+        expect(csp).toMatch(/style-src 'self' 'nonce-[A-Za-z0-9+/=]+'/);
+    });
+
+    test('each request gets a unique CSP nonce', async () => {
+        const res1 = await request(app).get('/');
+        const res2 = await request(app).get('/');
+        const nonce1 = res1.headers['content-security-policy'].match(/nonce-([A-Za-z0-9+/=]+)/)[1];
+        const nonce2 = res2.headers['content-security-policy'].match(/nonce-([A-Za-z0-9+/=]+)/)[1];
+        expect(nonce1).not.toBe(nonce2);
+    });
+
+    test('HTML pages contain nonce in style tags', async () => {
+        const res = await request(app).get('/logs');
+        const csp = res.headers['content-security-policy'];
+        const nonce = csp.match(/nonce-([A-Za-z0-9+/=]+)/)[1];
+        expect(res.text).toContain(`nonce="${nonce}"`);
+        expect(res.text).not.toContain('__CSP_NONCE__');
+    });
+
     test('stores subtask text as raw without HTML escaping', async () => {
         const res = await request(app)
             .post('/api/tasks')


### PR DESCRIPTION
## Summary
- Generate per-request cryptographic nonce via `crypto.randomBytes(16)`
- CSP `style-src` now uses `'nonce-<value>'` instead of `'unsafe-inline'`
- Nonce injection middleware replaces `__CSP_NONCE__` placeholders in HTML responses
- Updated `logs.html` `<style>` tag with nonce placeholder

Closes #140

## Test plan
- [ ] 85/85 tests pass
- [ ] CSP header contains `nonce-` instead of `unsafe-inline`
- [ ] Each request gets a unique nonce
- [ ] `/logs` page renders correctly with nonce-injected styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)