### PR TITLE
fix: use public npm registry for CI, internal via build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,13 @@ WORKDIR /app
 RUN apk update && apk upgrade --no-cache || true
 
 # Dependencies installieren
+# NPM_REGISTRY defaults to public npm; override for internal builds:
+#   docker build --build-arg NPM_REGISTRY=http://repo.inform-software.com/artifactory/api/npm/npmjs/ .
+ARG NPM_REGISTRY=https://registry.npmjs.org/
+ARG NPM_STRICT_SSL=true
 COPY package.json package-lock.json* ./
-RUN npm config set strict-ssl false \
-    && npm config set registry http://repo.inform-software.com/artifactory/api/npm/npmjs/ \
+RUN npm config set strict-ssl ${NPM_STRICT_SSL} \
+    && npm config set registry ${NPM_REGISTRY} \
     && npm ci --omit=dev
 RUN npm audit --audit-level=high
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   gartenplaner:
-    build: .
+    build:
+      context: .
+      args:
+        NPM_REGISTRY: http://repo.inform-software.com/artifactory/api/npm/npmjs/
+        NPM_STRICT_SSL: "false"
     container_name: gartenplaner
     ports:
       - "8080:3000"


### PR DESCRIPTION
## Summary
- Dockerfile defaults to `https://registry.npmjs.org/` (public npm)
- Internal INFORM registry configurable via `--build-arg NPM_REGISTRY=...`
- `docker-compose.yml` passes internal registry for local builds
- Fixes all failing GitHub Actions Docker publish builds

## Test plan
- [ ] GitHub Actions build succeeds (no more npm timeout on internal registry)
- [ ] Local `docker compose build` still uses internal registry
- [ ] `docker build .` (without args) uses public npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)