### PR TITLE
fix: replace internal registry URLs in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
@@ -37,7 +37,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
@@ -47,7 +47,7 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/core/-/core-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
@@ -78,7 +78,7 @@
     },
     "node_modules/@babel/core/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -96,14 +96,14 @@
     },
     "node_modules/@babel/core/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/generator/-/generator-7.29.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
@@ -120,7 +120,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
@@ -137,7 +137,7 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
@@ -147,7 +147,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.28.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "license": "MIT",
@@ -161,7 +161,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
@@ -179,7 +179,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
@@ -189,7 +189,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
@@ -199,7 +199,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
@@ -209,7 +209,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
@@ -219,7 +219,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.28.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/helpers/-/helpers-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "dev": true,
       "license": "MIT",
@@ -233,7 +233,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/parser/-/parser-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "dev": true,
       "license": "MIT",
@@ -249,7 +249,7 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
       "license": "MIT",
@@ -262,7 +262,7 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "dev": true,
       "license": "MIT",
@@ -275,7 +275,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "dev": true,
       "license": "MIT",
@@ -288,7 +288,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "dev": true,
       "license": "MIT",
@@ -304,7 +304,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.28.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
       "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
       "dev": true,
       "license": "MIT",
@@ -320,7 +320,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "dev": true,
       "license": "MIT",
@@ -333,7 +333,7 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
       "license": "MIT",
@@ -346,7 +346,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.28.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
       "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "dev": true,
       "license": "MIT",
@@ -362,7 +362,7 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "dev": true,
       "license": "MIT",
@@ -375,7 +375,7 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
       "license": "MIT",
@@ -388,7 +388,7 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "dev": true,
       "license": "MIT",
@@ -401,7 +401,7 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "license": "MIT",
@@ -414,7 +414,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
       "license": "MIT",
@@ -427,7 +427,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
       "license": "MIT",
@@ -440,7 +440,7 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "dev": true,
       "license": "MIT",
@@ -456,7 +456,7 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
       "dev": true,
       "license": "MIT",
@@ -472,7 +472,7 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.28.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
       "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
       "dev": true,
       "license": "MIT",
@@ -488,7 +488,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.28.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/template/-/template-7.28.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "license": "MIT",
@@ -503,7 +503,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/traverse/-/traverse-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
@@ -522,7 +522,7 @@
     },
     "node_modules/@babel/traverse/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -540,14 +540,14 @@
     },
     "node_modules/@babel/traverse/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@babel/types/-/types-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
@@ -561,14 +561,14 @@
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@emnapi/core/-/core-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
       "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
       "dev": true,
       "license": "MIT",
@@ -580,7 +580,7 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@emnapi/runtime/-/runtime-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
       "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
       "dev": true,
       "license": "MIT",
@@ -591,7 +591,7 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
       "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "dev": true,
       "license": "MIT",
@@ -602,7 +602,7 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "license": "ISC",
@@ -620,7 +620,7 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
       "license": "ISC",
@@ -637,7 +637,7 @@
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true,
       "license": "MIT",
@@ -647,7 +647,7 @@
     },
     "node_modules/@jest/console": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/console/-/console-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
       "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
       "dev": true,
       "license": "MIT",
@@ -665,7 +665,7 @@
     },
     "node_modules/@jest/core": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/core/-/core-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
       "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
       "dev": true,
       "license": "MIT",
@@ -712,7 +712,7 @@
     },
     "node_modules/@jest/diff-sequences": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
       "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
       "dev": true,
       "license": "MIT",
@@ -722,7 +722,7 @@
     },
     "node_modules/@jest/environment": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/environment/-/environment-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
       "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
       "dev": true,
       "license": "MIT",
@@ -738,7 +738,7 @@
     },
     "node_modules/@jest/expect": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/expect/-/expect-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
       "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
       "dev": true,
       "license": "MIT",
@@ -752,7 +752,7 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
       "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
       "dev": true,
       "license": "MIT",
@@ -765,7 +765,7 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
       "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
       "dev": true,
       "license": "MIT",
@@ -783,7 +783,7 @@
     },
     "node_modules/@jest/get-type": {
       "version": "30.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/get-type/-/get-type-30.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
       "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
       "dev": true,
       "license": "MIT",
@@ -793,7 +793,7 @@
     },
     "node_modules/@jest/globals": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/globals/-/globals-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
       "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
       "dev": true,
       "license": "MIT",
@@ -809,7 +809,7 @@
     },
     "node_modules/@jest/pattern": {
       "version": "30.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/pattern/-/pattern-30.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
       "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
       "dev": true,
       "license": "MIT",
@@ -823,7 +823,7 @@
     },
     "node_modules/@jest/reporters": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/reporters/-/reporters-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
       "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
       "dev": true,
       "license": "MIT",
@@ -866,7 +866,7 @@
     },
     "node_modules/@jest/schemas": {
       "version": "30.0.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/schemas/-/schemas-30.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "license": "MIT",
@@ -879,7 +879,7 @@
     },
     "node_modules/@jest/snapshot-utils": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
       "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
       "dev": true,
       "license": "MIT",
@@ -895,7 +895,7 @@
     },
     "node_modules/@jest/source-map": {
       "version": "30.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/source-map/-/source-map-30.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
       "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
       "dev": true,
       "license": "MIT",
@@ -910,7 +910,7 @@
     },
     "node_modules/@jest/test-result": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/test-result/-/test-result-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
       "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
       "dev": true,
       "license": "MIT",
@@ -926,7 +926,7 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
       "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
       "dev": true,
       "license": "MIT",
@@ -942,7 +942,7 @@
     },
     "node_modules/@jest/transform": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/transform/-/transform-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
       "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
       "dev": true,
       "license": "MIT",
@@ -968,7 +968,7 @@
     },
     "node_modules/@jest/types": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jest/types/-/types-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
       "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "dev": true,
       "license": "MIT",
@@ -987,7 +987,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
@@ -998,7 +998,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
@@ -1009,7 +1009,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
@@ -1019,14 +1019,14 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
@@ -1037,7 +1037,7 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
       "dev": true,
       "license": "MIT",
@@ -1050,7 +1050,7 @@
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@noble/hashes/-/hashes-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true,
       "license": "MIT",
@@ -1063,7 +1063,7 @@
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
       "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
       "dev": true,
       "license": "MIT",
@@ -1073,13 +1073,13 @@
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@pinojs/redact/-/redact-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "license": "MIT",
@@ -1090,7 +1090,7 @@
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@pkgr/core/-/core-0.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
       "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
       "dev": true,
       "license": "MIT",
@@ -1103,14 +1103,14 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1120,7 +1120,7 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "15.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
       "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1130,7 +1130,7 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
@@ -1141,7 +1141,7 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
@@ -1155,7 +1155,7 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
@@ -1165,7 +1165,7 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "license": "MIT",
@@ -1176,7 +1176,7 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
@@ -1186,14 +1186,14 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
       "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
       "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "dev": true,
       "license": "MIT",
@@ -1203,7 +1203,7 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "dev": true,
       "license": "MIT",
@@ -1213,7 +1213,7 @@
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/node/-/node-25.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
@@ -1223,14 +1223,14 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/yargs/-/yargs-17.0.35.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
       "license": "MIT",
@@ -1240,21 +1240,21 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
       "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
       "cpu": [
         "arm"
@@ -1268,7 +1268,7 @@
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
       "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
       "cpu": [
         "arm64"
@@ -1282,7 +1282,7 @@
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
       "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
       "cpu": [
         "arm64"
@@ -1296,7 +1296,7 @@
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
       "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
       "cpu": [
         "x64"
@@ -1310,7 +1310,7 @@
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
       "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
       "cpu": [
         "x64"
@@ -1324,7 +1324,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
       "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
       "cpu": [
         "arm"
@@ -1338,7 +1338,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
       "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
       "cpu": [
         "arm"
@@ -1352,7 +1352,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
       "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
       "cpu": [
         "arm64"
@@ -1366,7 +1366,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
       "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
       "cpu": [
         "arm64"
@@ -1380,7 +1380,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
       "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
       "cpu": [
         "ppc64"
@@ -1394,7 +1394,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
       "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
       "cpu": [
         "riscv64"
@@ -1408,7 +1408,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
       "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
       "cpu": [
         "riscv64"
@@ -1422,7 +1422,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
       "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
       "cpu": [
         "s390x"
@@ -1436,7 +1436,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
       "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
       "cpu": [
         "x64"
@@ -1450,7 +1450,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
       "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
       "cpu": [
         "x64"
@@ -1464,7 +1464,7 @@
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
       "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
       "cpu": [
         "wasm32"
@@ -1481,7 +1481,7 @@
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
       "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
       "cpu": [
         "arm64"
@@ -1495,7 +1495,7 @@
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
       "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
       "cpu": [
         "ia32"
@@ -1509,7 +1509,7 @@
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
       "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
       "cpu": [
         "x64"
@@ -1523,7 +1523,7 @@
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/accepts/-/accepts-1.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "license": "MIT",
       "dependencies": {
@@ -1536,7 +1536,7 @@
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "license": "MIT",
@@ -1552,7 +1552,7 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
@@ -1565,7 +1565,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
@@ -1581,7 +1581,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/anymatch/-/anymatch-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
@@ -1608,7 +1608,7 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "license": "MIT",
@@ -1618,27 +1618,27 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
     "node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "license": "MIT",
       "engines": {
@@ -1647,7 +1647,7 @@
     },
     "node_modules/babel-jest": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/babel-jest/-/babel-jest-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
       "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
       "dev": true,
       "license": "MIT",
@@ -1669,7 +1669,7 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "7.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
       "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -1689,7 +1689,7 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
       "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
       "dev": true,
       "license": "MIT",
@@ -1702,7 +1702,7 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "license": "MIT",
@@ -1729,7 +1729,7 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
       "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
       "dev": true,
       "license": "MIT",
@@ -1746,14 +1746,14 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.8",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
       "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1766,7 +1766,7 @@
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/body-parser/-/body-parser-1.20.4.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
       "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "license": "MIT",
       "dependencies": {
@@ -1790,7 +1790,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
@@ -1800,7 +1800,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/browserslist/-/browserslist-4.28.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
@@ -1834,7 +1834,7 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/bser/-/bser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1844,14 +1844,14 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/buffer-from/-/buffer-from-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/bytes/-/bytes-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
       "engines": {
@@ -1860,7 +1860,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
@@ -1873,7 +1873,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/call-bound/-/call-bound-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
@@ -1889,7 +1889,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
@@ -1899,7 +1899,7 @@
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
@@ -1909,7 +1909,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001779",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
       "integrity": "sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==",
       "dev": true,
       "funding": [
@@ -1930,7 +1930,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
@@ -1947,7 +1947,7 @@
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/char-regex/-/char-regex-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
       "license": "MIT",
@@ -1957,7 +1957,7 @@
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ci-info/-/ci-info-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
       "funding": [
@@ -1973,14 +1973,14 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
@@ -1995,7 +1995,7 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
@@ -2005,14 +2005,14 @@
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
@@ -2027,7 +2027,7 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
@@ -2040,7 +2040,7 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
@@ -2058,7 +2058,7 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
       "license": "MIT",
@@ -2069,14 +2069,14 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
@@ -2089,20 +2089,20 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/colorette/-/colorette-2.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "license": "MIT",
@@ -2115,7 +2115,7 @@
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/component-emitter/-/component-emitter-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
       "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
       "dev": true,
       "license": "MIT",
@@ -2125,7 +2125,7 @@
     },
     "node_modules/compressible": {
       "version": "2.0.18",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/compressible/-/compressible-2.0.18.tgz",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "license": "MIT",
       "dependencies": {
@@ -2137,7 +2137,7 @@
     },
     "node_modules/compression": {
       "version": "1.8.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/compression/-/compression-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
       "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "license": "MIT",
       "dependencies": {
@@ -2155,7 +2155,7 @@
     },
     "node_modules/compression/node_modules/negotiator": {
       "version": "0.6.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/negotiator/-/negotiator-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
       "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
       "license": "MIT",
       "engines": {
@@ -2164,14 +2164,14 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/content-disposition/-/content-disposition-0.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
       "dependencies": {
@@ -2183,7 +2183,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/content-type/-/content-type-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
@@ -2192,14 +2192,14 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/cookie/-/cookie-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
@@ -2208,20 +2208,20 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
     "node_modules/cookiejar": {
       "version": "2.1.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/cookiejar/-/cookiejar-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
@@ -2236,7 +2236,7 @@
     },
     "node_modules/dateformat": {
       "version": "4.6.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/dateformat/-/dateformat-4.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
       "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
       "license": "MIT",
       "engines": {
@@ -2245,7 +2245,7 @@
     },
     "node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
@@ -2254,7 +2254,7 @@
     },
     "node_modules/dedent": {
       "version": "1.7.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/dedent/-/dedent-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "license": "MIT",
@@ -2269,7 +2269,7 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/deepmerge/-/deepmerge-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "license": "MIT",
@@ -2279,7 +2279,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "license": "MIT",
@@ -2289,7 +2289,7 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/depd/-/depd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
       "engines": {
@@ -2298,7 +2298,7 @@
     },
     "node_modules/destroy": {
       "version": "1.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/destroy/-/destroy-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "license": "MIT",
       "engines": {
@@ -2308,7 +2308,7 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/detect-newline/-/detect-newline-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true,
       "license": "MIT",
@@ -2318,7 +2318,7 @@
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/dezalgo/-/dezalgo-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
       "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
       "dev": true,
       "license": "ISC",
@@ -2329,7 +2329,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
@@ -2343,27 +2343,27 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/emittery/-/emittery-0.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true,
       "license": "MIT",
@@ -2376,14 +2376,14 @@
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/encodeurl/-/encodeurl-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
@@ -2392,7 +2392,7 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
       "dependencies": {
@@ -2401,7 +2401,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/error-ex/-/error-ex-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
@@ -2411,7 +2411,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
@@ -2420,7 +2420,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
@@ -2429,7 +2429,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
@@ -2441,7 +2441,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
@@ -2457,7 +2457,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/escalade/-/escalade-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
@@ -2467,13 +2467,13 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "dev": true,
       "license": "MIT",
@@ -2483,7 +2483,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -2497,7 +2497,7 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
       "engines": {
@@ -2506,7 +2506,7 @@
     },
     "node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/execa/-/execa-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "license": "MIT",
@@ -2530,14 +2530,14 @@
     },
     "node_modules/execa/node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/signal-exit/-/signal-exit-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/exit-x": {
       "version": "0.2.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/exit-x/-/exit-x-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
       "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
       "dev": true,
       "license": "MIT",
@@ -2547,7 +2547,7 @@
     },
     "node_modules/expect": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/expect/-/expect-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
       "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
       "dev": true,
       "license": "MIT",
@@ -2565,7 +2565,7 @@
     },
     "node_modules/express": {
       "version": "4.22.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/express/-/express-4.22.1.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
       "dependencies": {
@@ -2611,7 +2611,7 @@
     },
     "node_modules/express-rate-limit": {
       "version": "8.3.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
       "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
       "dependencies": {
@@ -2629,26 +2629,26 @@
     },
     "node_modules/fast-copy": {
       "version": "4.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fast-copy/-/fast-copy-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
       "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2658,7 +2658,7 @@
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/finalhandler/-/finalhandler-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
       "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "license": "MIT",
       "dependencies": {
@@ -2676,7 +2676,7 @@
     },
     "node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/find-up/-/find-up-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
@@ -2690,7 +2690,7 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/foreground-child/-/foreground-child-3.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
@@ -2707,7 +2707,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/form-data/-/form-data-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
@@ -2724,7 +2724,7 @@
     },
     "node_modules/formidable": {
       "version": "3.5.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/formidable/-/formidable-3.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
       "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dev": true,
       "license": "MIT",
@@ -2742,7 +2742,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/forwarded/-/forwarded-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
       "engines": {
@@ -2751,7 +2751,7 @@
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
       "engines": {
@@ -2760,14 +2760,14 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -2782,7 +2782,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
@@ -2791,7 +2791,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
@@ -2801,7 +2801,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
@@ -2811,7 +2811,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
@@ -2835,7 +2835,7 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/get-package-type/-/get-package-type-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true,
       "license": "MIT",
@@ -2845,7 +2845,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
@@ -2858,7 +2858,7 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/get-stream/-/get-stream-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
@@ -2871,7 +2871,7 @@
     },
     "node_modules/glob": {
       "version": "10.5.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/glob/-/glob-10.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
@@ -2893,7 +2893,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
@@ -2905,14 +2905,14 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
@@ -2922,7 +2922,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
@@ -2934,7 +2934,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
@@ -2950,7 +2950,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/hasown/-/hasown-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "license": "MIT",
       "dependencies": {
@@ -2962,20 +2962,20 @@
     },
     "node_modules/help-me": {
       "version": "5.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/help-me/-/help-me-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/html-escaper/-/html-escaper-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/http-errors/-/http-errors-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
@@ -2995,7 +2995,7 @@
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/human-signals/-/human-signals-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -3005,7 +3005,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
       "dependencies": {
@@ -3017,7 +3017,7 @@
     },
     "node_modules/import-local": {
       "version": "3.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/import-local/-/import-local-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "dev": true,
       "license": "MIT",
@@ -3037,7 +3037,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
@@ -3047,7 +3047,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
@@ -3059,13 +3059,13 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ip-address/-/ip-address-10.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
@@ -3074,7 +3074,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
       "engines": {
@@ -3083,14 +3083,14 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
@@ -3100,7 +3100,7 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true,
       "license": "MIT",
@@ -3110,7 +3110,7 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/is-stream/-/is-stream-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
@@ -3123,14 +3123,14 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3140,7 +3140,7 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3157,7 +3157,7 @@
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -3170,7 +3170,7 @@
     },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3185,7 +3185,7 @@
     },
     "node_modules/istanbul-lib-source-maps": {
       "version": "5.0.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
       "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3200,7 +3200,7 @@
     },
     "node_modules/istanbul-lib-source-maps/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -3218,14 +3218,14 @@
     },
     "node_modules/istanbul-lib-source-maps/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3239,7 +3239,7 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jackspeak/-/jackspeak-3.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3255,7 +3255,7 @@
     },
     "node_modules/jest": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest/-/jest-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
@@ -3282,7 +3282,7 @@
     },
     "node_modules/jest-changed-files": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
       "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
       "dev": true,
       "license": "MIT",
@@ -3297,7 +3297,7 @@
     },
     "node_modules/jest-circus": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-circus/-/jest-circus-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
       "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
       "dev": true,
       "license": "MIT",
@@ -3329,7 +3329,7 @@
     },
     "node_modules/jest-cli": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-cli/-/jest-cli-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
       "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
       "dev": true,
       "license": "MIT",
@@ -3362,7 +3362,7 @@
     },
     "node_modules/jest-config": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-config/-/jest-config-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
       "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
       "dev": true,
       "license": "MIT",
@@ -3413,7 +3413,7 @@
     },
     "node_modules/jest-diff": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-diff/-/jest-diff-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
       "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
       "dev": true,
       "license": "MIT",
@@ -3429,7 +3429,7 @@
     },
     "node_modules/jest-docblock": {
       "version": "30.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-docblock/-/jest-docblock-30.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
       "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
       "dev": true,
       "license": "MIT",
@@ -3442,7 +3442,7 @@
     },
     "node_modules/jest-each": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-each/-/jest-each-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
       "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
       "dev": true,
       "license": "MIT",
@@ -3459,7 +3459,7 @@
     },
     "node_modules/jest-environment-node": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
       "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
       "dev": true,
       "license": "MIT",
@@ -3478,7 +3478,7 @@
     },
     "node_modules/jest-haste-map": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
       "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
       "dev": true,
       "license": "MIT",
@@ -3503,7 +3503,7 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
       "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
       "dev": true,
       "license": "MIT",
@@ -3517,7 +3517,7 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
       "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
       "dev": true,
       "license": "MIT",
@@ -3533,7 +3533,7 @@
     },
     "node_modules/jest-message-util": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
       "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
       "dev": true,
       "license": "MIT",
@@ -3554,7 +3554,7 @@
     },
     "node_modules/jest-mock": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-mock/-/jest-mock-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
       "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
       "dev": true,
       "license": "MIT",
@@ -3569,7 +3569,7 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "dev": true,
       "license": "MIT",
@@ -3587,7 +3587,7 @@
     },
     "node_modules/jest-regex-util": {
       "version": "30.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
       "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "dev": true,
       "license": "MIT",
@@ -3597,7 +3597,7 @@
     },
     "node_modules/jest-resolve": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-resolve/-/jest-resolve-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
       "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
       "dev": true,
       "license": "MIT",
@@ -3617,7 +3617,7 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
       "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
       "dev": true,
       "license": "MIT",
@@ -3631,7 +3631,7 @@
     },
     "node_modules/jest-runner": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-runner/-/jest-runner-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
       "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
       "dev": true,
       "license": "MIT",
@@ -3665,7 +3665,7 @@
     },
     "node_modules/jest-runtime": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-runtime/-/jest-runtime-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
       "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
       "dev": true,
       "license": "MIT",
@@ -3699,7 +3699,7 @@
     },
     "node_modules/jest-snapshot": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
       "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
       "dev": true,
       "license": "MIT",
@@ -3732,7 +3732,7 @@
     },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -3745,7 +3745,7 @@
     },
     "node_modules/jest-util": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-util/-/jest-util-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
       "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
       "dev": true,
       "license": "MIT",
@@ -3763,7 +3763,7 @@
     },
     "node_modules/jest-validate": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-validate/-/jest-validate-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
       "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
       "dev": true,
       "license": "MIT",
@@ -3781,7 +3781,7 @@
     },
     "node_modules/jest-validate/node_modules/camelcase": {
       "version": "6.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/camelcase/-/camelcase-6.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "license": "MIT",
@@ -3794,7 +3794,7 @@
     },
     "node_modules/jest-watcher": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-watcher/-/jest-watcher-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
       "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
       "dev": true,
       "license": "MIT",
@@ -3814,7 +3814,7 @@
     },
     "node_modules/jest-worker": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jest-worker/-/jest-worker-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
       "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
       "dev": true,
       "license": "MIT",
@@ -3831,7 +3831,7 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/supports-color/-/supports-color-8.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
@@ -3847,7 +3847,7 @@
     },
     "node_modules/joycon": {
       "version": "3.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/joycon/-/joycon-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
       "license": "MIT",
       "engines": {
@@ -3856,14 +3856,14 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/js-yaml/-/js-yaml-3.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
@@ -3877,7 +3877,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jsesc/-/jsesc-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
@@ -3890,14 +3890,14 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/json5/-/json5-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
@@ -3910,7 +3910,7 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/leven/-/leven-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true,
       "license": "MIT",
@@ -3920,14 +3920,14 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/locate-path/-/locate-path-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "license": "MIT",
@@ -3940,7 +3940,7 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
@@ -3950,7 +3950,7 @@
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/make-dir/-/make-dir-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
@@ -3966,7 +3966,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
@@ -3979,7 +3979,7 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/makeerror/-/makeerror-1.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
       "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3989,7 +3989,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
@@ -3998,7 +3998,7 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
       "engines": {
@@ -4007,7 +4007,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "license": "MIT",
       "funding": {
@@ -4016,14 +4016,14 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "license": "MIT",
       "engines": {
@@ -4032,7 +4032,7 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "license": "MIT",
       "bin": {
@@ -4044,7 +4044,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
@@ -4053,7 +4053,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "dependencies": {
@@ -4065,7 +4065,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
@@ -4075,7 +4075,7 @@
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
@@ -4091,7 +4091,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/minimist/-/minimist-1.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
       "funding": {
@@ -4100,7 +4100,7 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/minipass/-/minipass-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -4110,13 +4110,13 @@
     },
     "node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
       "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
       "dev": true,
       "license": "MIT",
@@ -4132,14 +4132,14 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/negotiator/-/negotiator-0.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "license": "MIT",
       "engines": {
@@ -4148,21 +4148,21 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/node-int64/-/node-int64-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/node-releases/-/node-releases-2.0.36.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
@@ -4172,7 +4172,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "license": "MIT",
@@ -4185,7 +4185,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/object-inspect/-/object-inspect-1.13.4.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
@@ -4197,7 +4197,7 @@
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
       "license": "MIT",
       "engines": {
@@ -4206,7 +4206,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/on-finished/-/on-finished-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
       "dependencies": {
@@ -4218,7 +4218,7 @@
     },
     "node_modules/on-headers": {
       "version": "1.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/on-headers/-/on-headers-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
       "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
@@ -4227,7 +4227,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
@@ -4236,7 +4236,7 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/onetime/-/onetime-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
@@ -4252,7 +4252,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/p-limit/-/p-limit-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
@@ -4268,7 +4268,7 @@
     },
     "node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/p-locate/-/p-locate-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "license": "MIT",
@@ -4281,7 +4281,7 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/p-limit/-/p-limit-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "license": "MIT",
@@ -4297,7 +4297,7 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
@@ -4307,14 +4307,14 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "license": "MIT",
@@ -4333,7 +4333,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
       "engines": {
@@ -4342,7 +4342,7 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/path-exists/-/path-exists-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
@@ -4352,7 +4352,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "license": "MIT",
@@ -4362,7 +4362,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
@@ -4372,7 +4372,7 @@
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/path-scurry/-/path-scurry-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -4389,7 +4389,7 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lru-cache/-/lru-cache-10.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
@@ -4402,7 +4402,7 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
@@ -4422,7 +4422,7 @@
     },
     "node_modules/pino": {
       "version": "9.14.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino/-/pino-9.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
       "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
       "license": "MIT",
       "dependencies": {
@@ -4444,7 +4444,7 @@
     },
     "node_modules/pino-abstract-transport": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
       "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
       "license": "MIT",
       "dependencies": {
@@ -4453,7 +4453,7 @@
     },
     "node_modules/pino-pretty": {
       "version": "13.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
       "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
       "license": "MIT",
       "dependencies": {
@@ -4477,7 +4477,7 @@
     },
     "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
       "version": "3.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
       "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
       "license": "MIT",
       "dependencies": {
@@ -4486,7 +4486,7 @@
     },
     "node_modules/pino-pretty/node_modules/strip-json-comments": {
       "version": "5.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
       "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
       "license": "MIT",
       "engines": {
@@ -4498,13 +4498,13 @@
     },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.7",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pirates/-/pirates-4.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "license": "MIT",
@@ -4514,7 +4514,7 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "license": "MIT",
@@ -4527,7 +4527,7 @@
     },
     "node_modules/pretty-format": {
       "version": "30.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pretty-format/-/pretty-format-30.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
       "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
@@ -4542,7 +4542,7 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
@@ -4555,7 +4555,7 @@
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/process-warning/-/process-warning-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
       "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
       "funding": [
         {
@@ -4571,7 +4571,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
       "dependencies": {
@@ -4584,7 +4584,7 @@
     },
     "node_modules/pump": {
       "version": "3.0.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pump/-/pump-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
       "dependencies": {
@@ -4594,7 +4594,7 @@
     },
     "node_modules/pure-rand": {
       "version": "7.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pure-rand/-/pure-rand-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
       "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
       "dev": true,
       "funding": [
@@ -4611,7 +4611,7 @@
     },
     "node_modules/qs": {
       "version": "6.14.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/qs/-/qs-6.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
       "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4626,13 +4626,13 @@
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "license": "MIT",
       "engines": {
@@ -4641,7 +4641,7 @@
     },
     "node_modules/raw-body": {
       "version": "2.5.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/raw-body/-/raw-body-2.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
       "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
@@ -4656,14 +4656,14 @@
     },
     "node_modules/react-is": {
       "version": "18.3.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/react-is/-/react-is-18.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/real-require": {
       "version": "0.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/real-require/-/real-require-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
       "license": "MIT",
       "engines": {
@@ -4672,7 +4672,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
@@ -4682,7 +4682,7 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "license": "MIT",
@@ -4695,7 +4695,7 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/resolve-from/-/resolve-from-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true,
       "license": "MIT",
@@ -4705,7 +4705,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
@@ -4725,7 +4725,7 @@
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "license": "MIT",
       "engines": {
@@ -4734,13 +4734,13 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
       "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
       "funding": [
         {
@@ -4756,7 +4756,7 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
@@ -4766,7 +4766,7 @@
     },
     "node_modules/send": {
       "version": "0.19.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/send/-/send-0.19.2.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
       "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "license": "MIT",
       "dependencies": {
@@ -4790,13 +4790,13 @@
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/serve-static": {
       "version": "1.16.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/serve-static/-/serve-static-1.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
       "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "license": "MIT",
       "dependencies": {
@@ -4811,13 +4811,13 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
@@ -4830,7 +4830,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
@@ -4840,7 +4840,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/side-channel/-/side-channel-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "license": "MIT",
       "dependencies": {
@@ -4859,7 +4859,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "license": "MIT",
       "dependencies": {
@@ -4875,7 +4875,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
@@ -4893,7 +4893,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
@@ -4912,7 +4912,7 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/signal-exit/-/signal-exit-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
@@ -4925,7 +4925,7 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
@@ -4935,7 +4935,7 @@
     },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
       "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "license": "MIT",
       "dependencies": {
@@ -4944,7 +4944,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -4954,7 +4954,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.13",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/source-map-support/-/source-map-support-0.5.13.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "license": "MIT",
@@ -4965,7 +4965,7 @@
     },
     "node_modules/split2": {
       "version": "4.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/split2/-/split2-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
       "engines": {
@@ -4974,14 +4974,14 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/stack-utils/-/stack-utils-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
       "license": "MIT",
@@ -4994,7 +4994,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/statuses/-/statuses-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
@@ -5003,7 +5003,7 @@
     },
     "node_modules/string-length": {
       "version": "4.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/string-length/-/string-length-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
       "dev": true,
       "license": "MIT",
@@ -5017,7 +5017,7 @@
     },
     "node_modules/string-length/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
@@ -5027,7 +5027,7 @@
     },
     "node_modules/string-length/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
@@ -5040,7 +5040,7 @@
     },
     "node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/string-width/-/string-width-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "license": "MIT",
@@ -5059,7 +5059,7 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
@@ -5074,7 +5074,7 @@
     },
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
@@ -5084,14 +5084,14 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
@@ -5104,7 +5104,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
@@ -5121,7 +5121,7 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
@@ -5134,7 +5134,7 @@
     },
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
@@ -5144,7 +5144,7 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-bom/-/strip-bom-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
       "license": "MIT",
@@ -5154,7 +5154,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
       "license": "MIT",
@@ -5164,7 +5164,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
@@ -5177,7 +5177,7 @@
     },
     "node_modules/superagent": {
       "version": "10.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/superagent/-/superagent-10.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
       "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "dev": true,
       "license": "MIT",
@@ -5198,7 +5198,7 @@
     },
     "node_modules/superagent/node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/debug/-/debug-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
@@ -5216,7 +5216,7 @@
     },
     "node_modules/superagent/node_modules/mime": {
       "version": "2.6.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/mime/-/mime-2.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
       "license": "MIT",
@@ -5229,14 +5229,14 @@
     },
     "node_modules/superagent/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/supertest": {
       "version": "7.2.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/supertest/-/supertest-7.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
       "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
       "dev": true,
       "license": "MIT",
@@ -5251,7 +5251,7 @@
     },
     "node_modules/supertest/node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "dev": true,
       "license": "MIT",
@@ -5261,7 +5261,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
@@ -5274,7 +5274,7 @@
     },
     "node_modules/synckit": {
       "version": "0.11.12",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/synckit/-/synckit-0.11.12.tgz",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
       "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
       "dev": true,
       "license": "MIT",
@@ -5290,7 +5290,7 @@
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/test-exclude/-/test-exclude-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "dev": true,
       "license": "ISC",
@@ -5305,7 +5305,7 @@
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
       "version": "1.1.12",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
@@ -5316,7 +5316,7 @@
     },
     "node_modules/test-exclude/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/glob/-/glob-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
@@ -5338,7 +5338,7 @@
     },
     "node_modules/test-exclude/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/minimatch/-/minimatch-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
@@ -5351,7 +5351,7 @@
     },
     "node_modules/thread-stream": {
       "version": "3.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/thread-stream/-/thread-stream-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
       "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
       "license": "MIT",
       "dependencies": {
@@ -5360,14 +5360,14 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/tmpl/-/tmpl-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/toidentifier/-/toidentifier-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
       "engines": {
@@ -5376,7 +5376,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
@@ -5384,7 +5384,7 @@
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/type-detect/-/type-detect-4.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
       "license": "MIT",
@@ -5394,7 +5394,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/type-fest/-/type-fest-0.21.3.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
@@ -5407,7 +5407,7 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
       "dependencies": {
@@ -5420,14 +5420,14 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/undici-types/-/undici-types-7.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
       "engines": {
@@ -5436,7 +5436,7 @@
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
       "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
       "dev": true,
       "hasInstallScript": true,
@@ -5471,7 +5471,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
@@ -5502,7 +5502,7 @@
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
       "engines": {
@@ -5511,7 +5511,7 @@
     },
     "node_modules/uuid": {
       "version": "11.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/uuid/-/uuid-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
       "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -5524,7 +5524,7 @@
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
       "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
       "dev": true,
       "license": "ISC",
@@ -5539,7 +5539,7 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
       "engines": {
@@ -5548,7 +5548,7 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/walker/-/walker-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
       "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -5558,7 +5558,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
@@ -5574,7 +5574,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "license": "MIT",
@@ -5593,7 +5593,7 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
@@ -5611,7 +5611,7 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
@@ -5621,14 +5621,14 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
@@ -5643,7 +5643,7 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
@@ -5656,7 +5656,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
@@ -5669,13 +5669,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
       "license": "ISC",
@@ -5689,7 +5689,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
@@ -5699,14 +5699,14 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/yargs/-/yargs-17.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
@@ -5725,7 +5725,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
@@ -5735,7 +5735,7 @@
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
@@ -5745,14 +5745,14 @@
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
@@ -5767,7 +5767,7 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
@@ -5780,7 +5780,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary
- Replace 438 `repo.inform-software.com` resolved URLs with `registry.npmjs.org` in `package-lock.json`
- Fixes `npm ci` crash in GitHub Actions ("Exit handler never called!")
- Local `npm ci` still works (Artifactory proxies from npmjs.org anyway)

## Test plan
- [ ] GitHub Actions Docker publish build succeeds
- [ ] Local `npm ci` works
- [ ] 85/85 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)