### PR TITLE
feat: add version tags for beta Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,10 +33,12 @@ jobs:
         id: tags
         run: |
           IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/gardenplanner"
+          VERSION="${{ steps.pkg.outputs.version }}"
+          SHA_SHORT="$(echo ${{ github.sha }} | cut -c1-7)"
           if [ "${{ github.ref_name }}" = "main" ]; then
-            echo "tags=${IMAGE}:latest,${IMAGE}:${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tags=${IMAGE}:latest,${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.ref_name }}" = "develop" ]; then
-            echo "tags=${IMAGE}:beta" >> "$GITHUB_OUTPUT"
+            echo "tags=${IMAGE}:beta,${IMAGE}:${VERSION}-beta,${IMAGE}:${VERSION}-beta.${SHA_SHORT}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
Beta builds get three tags instead of just `:beta`:
- `:beta` — rolling latest, for easy pulling
- `:<version>-beta` — e.g., `1.0.0-beta`, tied to package.json version
- `:<version>-beta.<sha>` — e.g., `1.0.0-beta.abc1234`, unique per commit

## Test plan
- [ ] Docker publish workflow succeeds on develop push
- [ ] Three tags visible on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)