### PR TITLE
fix: whitelist Google Fonts in CSP headers

### DIFF
--- a/src/server/middleware/security.js
+++ b/src/server/middleware/security.js
@@ -14,9 +14,9 @@ function securityHeaders(req, res, next) {
     res.setHeader('Content-Security-Policy', [
         "default-src 'self'",
         "script-src 'self' https://cdnjs.cloudflare.com",
-        `style-src 'self' 'nonce-${nonce}'`,
+        `style-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com`,
         "img-src 'self' data:",
-        "font-src 'self'",
+        "font-src 'self' https://fonts.gstatic.com",
         "connect-src 'self' https://api.open-meteo.com https://geocoding-api.open-meteo.com",
         "frame-ancestors 'none'",
         "base-uri 'self'",


### PR DESCRIPTION
## Summary
- Add `https://fonts.googleapis.com` to `style-src` (CSS loading)
- Add `https://fonts.gstatic.com` to `font-src` (font file loading)
- Fixes blank/broken pages caused by CSP blocking Google Fonts after #140

## Test plan
- [ ] Pages render correctly with Google Fonts
- [ ] 85/85 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)