### PR TITLE
fix: serve /src in production for CSS/JS assets

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -66,9 +66,11 @@ app.use('/api', generalLimiter);
 
 app.use('/public', express.static(path.join(PROJECT_ROOT, 'public'), { maxAge: '1d' }));
 
-// #115: /src only in development (like /tests and /docs)
+// Serve /src (CSS/JS needed in production since HTML references ../src/)
+app.use('/src', express.static(path.join(PROJECT_ROOT, 'src'), { maxAge: '1d' }));
+
+// #115: /tests and /docs only in development
 if (process.env.NODE_ENV !== 'production') {
-    app.use('/src', express.static(path.join(PROJECT_ROOT, 'src'), { maxAge: '1d' }));
     app.use('/tests', express.static(path.join(PROJECT_ROOT, 'tests')));
     app.use('/docs', express.static(path.join(PROJECT_ROOT, 'docs')));
 }


### PR DESCRIPTION
## Summary
HTML pages reference CSS/JS via `../src/` relative paths. The `/src` static route was incorrectly blocked in production (#115), making all pages appear blank.

- `/src` is now served in all environments (CSS/JS needed)
- `/tests` and `/docs` remain blocked in production

## Test plan
- [ ] Pages load with CSS/JS in Docker container (`NODE_ENV=production`)
- [ ] 85/85 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)