### PR TITLE
chore: bump to 1.1.0 and fix beta versioning

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,11 +34,11 @@ jobs:
         run: |
           IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/gardenplanner"
           VERSION="${{ steps.pkg.outputs.version }}"
-          SHA_SHORT="$(echo ${{ github.sha }} | cut -c1-7)"
+          BUILD="${{ github.run_number }}"
           if [ "${{ github.ref_name }}" = "main" ]; then
             echo "tags=${IMAGE}:latest,${IMAGE}:${VERSION}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.ref_name }}" = "develop" ]; then
-            echo "tags=${IMAGE}:beta,${IMAGE}:${VERSION}-beta,${IMAGE}:${VERSION}-beta.${SHA_SHORT}" >> "$GITHUB_OUTPUT"
+            echo "tags=${IMAGE}:beta,${IMAGE}:${VERSION}-beta,${IMAGE}:${VERSION}-beta.${BUILD}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Docker image

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump `package.json` version from 1.0.0 to 1.1.0 (Phase 2 Security Hardening)
- Beta Docker tags now use `github.run_number` instead of git SHA for readable build IDs

**Tag examples after merge:**
- `:beta` — rolling latest
- `:1.1.0-beta` — tied to package.json version
- `:1.1.0-beta.42` — unique, auto-incrementing build number

Version should be bumped in `package.json` with each significant change.

## Test plan
- [ ] Docker Hub shows three tags with correct version after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)