### PR TITLE
refactor: extract logs page inline CSS to stylesheet (#106)

### DIFF
--- a/public/logs.html
+++ b/public/logs.html
@@ -8,438 +8,149 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../src/css/styles.css" />
-    <style nonce="__CSP_NONCE__">
-      .log-viewer-container {
-        max-width: 1400px;
-        margin: 20px auto;
-        padding: 20px;
-      }
-
-      .log-controls {
-        background: var(--bg-secondary);
-        padding: 20px;
-        border-radius: var(--radius-lg);
-        border: 1px solid var(--border);
-        margin-bottom: 20px;
-      }
-
-      .log-filters {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        gap: 15px;
-        margin-bottom: 15px;
-      }
-
-      .filter-group {
-        display: flex;
-        flex-direction: column;
-      }
-
-      .filter-group label {
-        font-size: 0.9em;
-        color: var(--text);
-        opacity: 0.8;
-        margin-bottom: 5px;
-      }
-
-      .filter-group select,
-      .filter-group input {
-        padding: 14px 18px;
-        border: 1.5px solid var(--border);
-        border-radius: var(--radius-md);
-        font-size: 0.95em;
-        font-family: var(--font-body);
-        background: var(--bg-secondary);
-        color: var(--text);
-      }
-
-      .log-actions {
-        display: flex;
-        gap: 10px;
-        flex-wrap: wrap;
-      }
-
-      .log-stats {
-        background: var(--primary);
-        color: white;
-        padding: 20px;
-        border-radius: var(--radius-lg);
-        margin-bottom: 20px;
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-        gap: 15px;
-      }
-
-      .stat-item {
-        text-align: center;
-      }
-
-      .stat-value {
-        font-size: 2em;
-        font-weight: bold;
-        margin-bottom: 5px;
-      }
-
-      .stat-label {
-        font-size: 0.9em;
-        opacity: 0.9;
-      }
-
-      .log-table-container {
-        background: var(--bg-secondary);
-        border-radius: var(--radius-lg);
-        border: 1px solid var(--border);
-        overflow: hidden;
-      }
-
-      .log-table {
-        width: 100%;
-        border-collapse: collapse;
-      }
-
-      .log-table thead {
-        background: var(--bg-tertiary);
-        border-bottom: 2px solid var(--border);
-      }
-
-      .log-table th {
-        padding: 15px 10px;
-        text-align: left;
-        font-weight: 600;
-        color: var(--text);
-        font-size: 0.9em;
-      }
-
-      .log-table td {
-        padding: 12px 10px;
-        border-bottom: 1px solid var(--border);
-        font-size: 0.9em;
-        color: var(--text);
-      }
-
-      .log-table tbody tr:hover {
-        background: var(--bg-tertiary);
-      }
-
-      .log-level {
-        padding: 4px 14px;
-        border-radius: 9999px;
-        font-size: 12px;
-        font-weight: 500;
-        text-transform: uppercase;
-      }
-
-      .log-level.debug {
-        background: #e9ecef;
-        color: #6c757d;
-      }
-
-      .log-level.info {
-        background: #d1ecf1;
-        color: #0c5460;
-      }
-
-      .log-level.warn {
-        background: #fff3cd;
-        color: #856404;
-      }
-
-      .log-level.error {
-        background: #f8d7da;
-        color: #721c24;
-      }
-
-      .log-level.critical {
-        background: #dc3545;
-        color: white;
-      }
-
-      .log-category {
-        padding: 4px 14px;
-        background: #ECFDF5;
-        color: #365E3D;
-        border-radius: 9999px;
-        font-size: 12px;
-        font-weight: 500;
-      }
-
-      .log-message {
-        max-width: 400px;
-        word-break: break-word;
-      }
-
-      .log-context {
-        font-family: "Courier New", monospace;
-        font-size: 0.85em;
-        color: var(--text-light);
-        cursor: pointer;
-      }
-
-      .log-context:hover {
-        color: var(--primary);
-      }
-
-      .log-timestamp {
-        color: var(--text-light);
-        font-size: 0.85em;
-      }
-
-      .log-detail-modal {
-        display: none;
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(28, 25, 23, 0.4);
-        backdrop-filter: blur(4px);
-        -webkit-backdrop-filter: blur(4px);
-        z-index: 10000;
-        align-items: center;
-        justify-content: center;
-      }
-
-      .log-detail-modal.active {
-        display: flex;
-      }
-
-      .log-detail-content {
-        background: var(--bg-secondary);
-        border-radius: 20px;
-        padding: 32px;
-        max-width: 800px;
-        max-height: 80vh;
-        overflow-y: auto;
-        position: relative;
-        border: 1px solid var(--border);
-      }
-
-      .log-detail-close {
-        position: absolute;
-        top: 15px;
-        right: 15px;
-        font-size: 24px;
-        cursor: pointer;
-        color: var(--text-light);
-        border: none;
-        background: none;
-      }
-
-      .log-detail-close:hover {
-        color: var(--text);
-      }
-
-      .log-detail-section {
-        margin-bottom: 20px;
-      }
-
-      .log-detail-section h3 {
-        margin-bottom: 10px;
-        color: var(--text);
-      }
-
-      .log-detail-json {
-        background: var(--bg);
-        padding: 15px;
-        border-radius: var(--radius-md);
-        font-family: "Courier New", monospace;
-        font-size: 0.9em;
-        overflow-x: auto;
-        color: var(--text);
-        border: 1px solid var(--border);
-      }
-
-      .empty-state {
-        text-align: center;
-        padding: 60px 20px;
-        color: var(--text-light);
-      }
-
-      .empty-state-icon {
-        font-size: 4em;
-        margin-bottom: 20px;
-      }
-
-      .health-indicator {
-        display: inline-block;
-        padding: 4px 14px;
-        border-radius: 9999px;
-        font-weight: 500;
-        font-size: 12px;
-      }
-
-      .health-healthy {
-        background: #ECFDF5;
-        color: #166534;
-      }
-
-      .health-warning {
-        background: #FEF9C3;
-        color: #854D0E;
-      }
-
-      .health-critical {
-        background: #FEE2E2;
-        color: #991B1B;
-      }
-
-      @media (max-width: 768px) {
-        .log-filters {
-          grid-template-columns: 1fr;
-        }
-
-        .log-stats {
-          grid-template-columns: repeat(2, 1fr);
-        }
-
-        .log-table {
-          font-size: 0.85em;
-        }
-
-        .log-message {
-          max-width: 200px;
-        }
-      }
-    </style>
   </head>
   <body>
     <div class="log-viewer-container">
-      <h1>📊 System Logs</h1>
+      <header>
+        <h1>📊 System Logs</h1>
 
-      <div class="nav-container">
-        <nav class="main-nav" role="navigation" aria-label="Hauptnavigation">
-          <a href="/dashboard" class="nav-link">📋 Dashboard</a>
-          <a href="/statistics" class="nav-link">📊 Statistiken</a>
-          <a href="/plants" class="nav-link">🌱 Pflanzen</a>
-          <a href="/logs" class="nav-link active" aria-current="page"
-            >📜 Logs</a
+        <div class="nav-container">
+          <nav class="main-nav" aria-label="Hauptnavigation">
+            <a href="/dashboard" class="nav-link">📋 Dashboard</a>
+            <a href="/statistics" class="nav-link">📊 Statistiken</a>
+            <a href="/plants" class="nav-link">🌱 Pflanzen</a>
+            <a href="/logs" class="nav-link active" aria-current="page"
+              >📜 Logs</a
+            >
+          </nav>
+          <a href="/index" class="btn btn-primary nav-action-btn"
+            >➕ Neue Aufgabe</a
           >
-        </nav>
-        <a href="/index" class="btn btn-primary nav-action-btn"
-          >➕ Neue Aufgabe</a
-        >
-      </div>
+        </div>
+      </header>
 
-      <!-- Statistiken -->
-      <div class="log-stats" id="logStats">
-        <div class="stat-item">
-          <div class="stat-value" id="statTotal">0</div>
-          <div class="stat-label">Total Logs</div>
-        </div>
-        <div class="stat-item">
-          <div class="stat-value" id="statErrors">0</div>
-          <div class="stat-label">Errors (1h)</div>
-        </div>
-        <div class="stat-item">
-          <div class="stat-value" id="statCategories">0</div>
-          <div class="stat-label">Categories</div>
-        </div>
-        <div class="stat-item">
-          <div class="stat-value" id="statSize">0 KB</div>
-          <div class="stat-label">Log Size</div>
-        </div>
-      </div>
+      <main>
+        <!-- Statistiken -->
+        <section class="log-stats" id="logStats" aria-label="Log-Statistiken">
+          <div class="stat-item">
+            <div class="stat-value" id="statTotal">0</div>
+            <div class="stat-label">Total Logs</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value" id="statErrors">0</div>
+            <div class="stat-label">Errors (1h)</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value" id="statCategories">0</div>
+            <div class="stat-label">Categories</div>
+          </div>
+          <div class="stat-item">
+            <div class="stat-value" id="statSize">0 KB</div>
+            <div class="stat-label">Log Size</div>
+          </div>
+        </section>
 
-      <!-- Filter und Aktionen -->
-      <div class="log-controls">
-        <div class="log-filters">
-          <div class="filter-group">
-            <label>Log Level</label>
-            <select id="filterLevel">
-              <option value="">Alle Levels</option>
-              <option value="DEBUG">Debug</option>
-              <option value="INFO">Info</option>
-              <option value="WARN">Warnung</option>
-              <option value="ERROR">Error</option>
-              <option value="CRITICAL">Critical</option>
-            </select>
+        <!-- Filter und Aktionen -->
+        <section class="log-controls" aria-label="Filter und Aktionen">
+          <div class="log-filters">
+            <div class="filter-group">
+              <label for="filterLevel">Log Level</label>
+              <select id="filterLevel">
+                <option value="">Alle Levels</option>
+                <option value="DEBUG">Debug</option>
+                <option value="INFO">Info</option>
+                <option value="WARN">Warnung</option>
+                <option value="ERROR">Error</option>
+                <option value="CRITICAL">Critical</option>
+              </select>
+            </div>
+
+            <div class="filter-group">
+              <label for="filterCategory">Kategorie</label>
+              <select id="filterCategory">
+                <option value="">Alle Kategorien</option>
+                <option value="app">App</option>
+                <option value="security">Security</option>
+                <option value="storage">Storage</option>
+                <option value="encryption">Encryption</option>
+                <option value="rate-limit">Rate Limit</option>
+                <option value="performance">Performance</option>
+              </select>
+            </div>
+
+            <div class="filter-group">
+              <label for="filterSearch">Suche</label>
+              <input
+                type="text"
+                id="filterSearch"
+                placeholder="Suche in Logs..."
+              />
+            </div>
+
+            <div class="filter-group">
+              <label for="filterLimit">Limit</label>
+              <select id="filterLimit">
+                <option value="50">50 Einträge</option>
+                <option value="100" selected>100 Einträge</option>
+                <option value="200">200 Einträge</option>
+                <option value="">Alle Einträge</option>
+              </select>
+            </div>
           </div>
 
-          <div class="filter-group">
-            <label>Kategorie</label>
-            <select id="filterCategory">
-              <option value="">Alle Kategorien</option>
-              <option value="app">App</option>
-              <option value="security">Security</option>
-              <option value="storage">Storage</option>
-              <option value="encryption">Encryption</option>
-              <option value="rate-limit">Rate Limit</option>
-              <option value="performance">Performance</option>
-            </select>
+          <div class="log-actions">
+            <button class="btn btn-primary" onclick="logViewer.refresh()">
+              🔄 Aktualisieren
+            </button>
+            <button class="btn" onclick="logViewer.exportJSON()">
+              💾 Export JSON
+            </button>
+            <button class="btn" onclick="logViewer.exportCSV()">
+              📊 Export CSV
+            </button>
+            <button class="btn" onclick="logViewer.exportText()">
+              📄 Export Text
+            </button>
+            <button class="btn btn-danger" onclick="logViewer.clearLogs()">
+              🗑️ Logs löschen
+            </button>
+            <div style="margin-left: auto">
+              <span id="healthIndicator" class="health-indicator" role="status"></span>
+            </div>
           </div>
+        </section>
 
-          <div class="filter-group">
-            <label>Suche</label>
-            <input
-              type="text"
-              id="filterSearch"
-              placeholder="Suche in Logs..."
-            />
-          </div>
-
-          <div class="filter-group">
-            <label>Limit</label>
-            <select id="filterLimit">
-              <option value="50">50 Einträge</option>
-              <option value="100" selected>100 Einträge</option>
-              <option value="200">200 Einträge</option>
-              <option value="">Alle Einträge</option>
-            </select>
-          </div>
-        </div>
-
-        <div class="log-actions">
-          <button class="btn btn-primary" onclick="logViewer.refresh()">
-            🔄 Aktualisieren
-          </button>
-          <button class="btn" onclick="logViewer.exportJSON()">
-            💾 Export JSON
-          </button>
-          <button class="btn" onclick="logViewer.exportCSV()">
-            📊 Export CSV
-          </button>
-          <button class="btn" onclick="logViewer.exportText()">
-            📄 Export Text
-          </button>
-          <button class="btn btn-danger" onclick="logViewer.clearLogs()">
-            🗑️ Logs löschen
-          </button>
-          <div style="margin-left: auto">
-            <span id="healthIndicator" class="health-indicator"></span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Log-Tabelle -->
-      <div class="log-table-container">
-        <table class="log-table">
-          <thead>
-            <tr>
-              <th>Zeit</th>
-              <th>Level</th>
-              <th>Kategorie</th>
-              <th>Nachricht</th>
-              <th>Context</th>
-            </tr>
-          </thead>
-          <tbody id="logTableBody">
-            <tr>
-              <td colspan="5">
-                <div class="empty-state">
-                  <div class="empty-state-icon">📋</div>
-                  <p>Lade Logs...</p>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+        <!-- Log-Tabelle -->
+        <section class="log-table-container" aria-label="Log-Eintraege">
+          <table class="log-table">
+            <thead>
+              <tr>
+                <th>Zeit</th>
+                <th>Level</th>
+                <th>Kategorie</th>
+                <th>Nachricht</th>
+                <th>Context</th>
+              </tr>
+            </thead>
+            <tbody id="logTableBody">
+              <tr>
+                <td colspan="5">
+                  <div class="empty-state">
+                    <div class="empty-state-icon">📋</div>
+                    <p>Lade Logs...</p>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </main>
     </div>
 
     <!-- Detail Modal -->
-    <div class="log-detail-modal" id="logDetailModal">
+    <div class="log-detail-modal" id="logDetailModal" role="dialog" aria-modal="true" aria-label="Log-Detail">
       <div class="log-detail-content">
-        <button class="log-detail-close" onclick="logViewer.closeDetail()">
+        <button class="log-detail-close" onclick="logViewer.closeDetail()" aria-label="Dialog schliessen">
           ×
         </button>
         <div id="logDetailContent"></div>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -5057,3 +5057,297 @@ footer {
     width: 100%;
   }
 }
+
+/* === Log Viewer === */
+
+.log-viewer-container {
+  max-width: 1400px;
+  margin: 20px auto;
+  padding: 20px;
+}
+
+.log-controls {
+  background: var(--bg-secondary);
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  margin-bottom: 20px;
+}
+
+.log-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 15px;
+  margin-bottom: 15px;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.filter-group label {
+  font-size: 0.9em;
+  color: var(--text);
+  opacity: 0.8;
+  margin-bottom: 5px;
+}
+
+.filter-group select,
+.filter-group input {
+  padding: 14px 18px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: 0.95em;
+  font-family: var(--font-body);
+  background: var(--bg-secondary);
+  color: var(--text);
+}
+
+.log-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.log-stats {
+  background: var(--primary);
+  color: white;
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  margin-bottom: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 15px;
+}
+
+.stat-item {
+  text-align: center;
+}
+
+.stat-value {
+  font-size: 2em;
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+
+.stat-label {
+  font-size: 0.9em;
+  opacity: 0.9;
+}
+
+.log-table-container {
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.log-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.log-table thead {
+  background: var(--bg-tertiary);
+  border-bottom: 2px solid var(--border);
+}
+
+.log-table th {
+  padding: 15px 10px;
+  text-align: left;
+  font-weight: 600;
+  color: var(--text);
+  font-size: 0.9em;
+}
+
+.log-table td {
+  padding: 12px 10px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.9em;
+  color: var(--text);
+}
+
+.log-table tbody tr:hover {
+  background: var(--bg-tertiary);
+}
+
+.log-level {
+  padding: 4px 14px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.log-level.debug {
+  background: #e9ecef;
+  color: #6c757d;
+}
+
+.log-level.info {
+  background: #d1ecf1;
+  color: #0c5460;
+}
+
+.log-level.warn {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.log-level.error {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.log-level.critical {
+  background: #dc3545;
+  color: white;
+}
+
+.log-category {
+  padding: 4px 14px;
+  background: #ECFDF5;
+  color: #365E3D;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.log-message {
+  max-width: 400px;
+  word-break: break-word;
+}
+
+.log-context {
+  font-family: "Courier New", monospace;
+  font-size: 0.85em;
+  color: var(--text-light);
+  cursor: pointer;
+}
+
+.log-context:hover {
+  color: var(--primary);
+}
+
+.log-timestamp {
+  color: var(--text-light);
+  font-size: 0.85em;
+}
+
+.log-detail-modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(28, 25, 23, 0.4);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 10000;
+  align-items: center;
+  justify-content: center;
+}
+
+.log-detail-modal.active {
+  display: flex;
+}
+
+.log-detail-content {
+  background: var(--bg-secondary);
+  border-radius: 20px;
+  padding: 32px;
+  max-width: 800px;
+  max-height: 80vh;
+  overflow-y: auto;
+  position: relative;
+  border: 1px solid var(--border);
+}
+
+.log-detail-close {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  font-size: 24px;
+  cursor: pointer;
+  color: var(--text-light);
+  border: none;
+  background: none;
+}
+
+.log-detail-close:hover {
+  color: var(--text);
+}
+
+.log-detail-section {
+  margin-bottom: 20px;
+}
+
+.log-detail-section h3 {
+  margin-bottom: 10px;
+  color: var(--text);
+}
+
+.log-detail-json {
+  background: var(--bg);
+  padding: 15px;
+  border-radius: var(--radius-md);
+  font-family: "Courier New", monospace;
+  font-size: 0.9em;
+  overflow-x: auto;
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.log-viewer-container .empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--text-light);
+}
+
+.log-viewer-container .empty-state-icon {
+  font-size: 4em;
+  margin-bottom: 20px;
+}
+
+.health-indicator {
+  display: inline-block;
+  padding: 4px 14px;
+  border-radius: 9999px;
+  font-weight: 500;
+  font-size: 12px;
+}
+
+.health-healthy {
+  background: #ECFDF5;
+  color: #166534;
+}
+
+.health-warning {
+  background: #FEF9C3;
+  color: #854D0E;
+}
+
+.health-critical {
+  background: #FEE2E2;
+  color: #991B1B;
+}
+
+@media (max-width: 768px) {
+  .log-filters {
+    grid-template-columns: 1fr;
+  }
+
+  .log-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .log-table {
+    font-size: 0.85em;
+  }
+
+  .log-message {
+    max-width: 200px;
+  }
+}

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -720,12 +720,13 @@ describe('Security', () => {
         expect(nonce1).not.toBe(nonce2);
     });
 
-    test('HTML pages contain nonce in style tags', async () => {
+    test('logs page has no inline style tags after CSS extraction', async () => {
         const res = await request(app).get('/logs');
-        const csp = res.headers['content-security-policy'];
-        const nonce = csp.match(/nonce-([A-Za-z0-9+/=]+)/)[1];
-        expect(res.text).toContain(`nonce="${nonce}"`);
+        expect(res.text).not.toContain('<style');
         expect(res.text).not.toContain('__CSP_NONCE__');
+        // CSP header should still be present with a nonce
+        const csp = res.headers['content-security-policy'];
+        expect(csp).toMatch(/nonce-[A-Za-z0-9+/=]+/);
     });
 
     test('stores subtask text as raw without HTML escaping', async () => {


### PR DESCRIPTION
## Summary
- Extract ~292 lines of inline CSS from `logs.html` to `src/css/styles.css`
- Add semantic HTML: `<main>`, `<header>`, `<section>` with ARIA labels
- Scope `.empty-state` under `.log-viewer-container` to avoid conflicts
- Add `for` attributes on labels, dialog ARIA roles

Closes #106

## Test plan
- [ ] 85/85 tests pass
- [ ] `/logs` page renders correctly with external CSS
- [ ] ARIA landmarks visible in accessibility tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)