### PR TITLE
refactor: centralize magic numbers and document escapeHtml (#144, #145)

### DIFF
--- a/src/js/security.js
+++ b/src/js/security.js
@@ -1,6 +1,9 @@
 // Sicherheits-Modul für XSS-Schutz und Input-Validierung
 const Security = {
     // HTML-Zeichen escapen
+    // Note: This client-side version also escapes forward slashes (/ -> &#x2F;)
+    // for additional DOM context safety. The server-side canonical version in
+    // src/server/validation/task-validator.js does not escape slashes.
     escapeHtml(unsafe) {
         if (unsafe === null || unsafe === undefined) {
             return '';

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,0 +1,26 @@
+// --- Central configuration constants ---
+// Replaces magic numbers scattered across server modules (#145)
+
+const PAGINATION = {
+    MAX_LIMIT: 200,
+    DEFAULT_LIMIT: 50,
+};
+
+const FIELD_LIMITS = {
+    TITLE_MAX: 200,
+    EMPLOYEE_MAX: 100,
+    LOCATION_MAX: 100,
+    DESCRIPTION_MAX: 2000,
+    NOTES_MAX: 5000,
+    MAX_SUBTASKS: 50,
+    SUBTASK_TEXT_MAX: 500,
+};
+
+const STORAGE = {
+    LOCK_TIMEOUT_MS: 5000,
+    LOCK_POLL_INTERVAL_MS: 10,
+    WRITE_MAX_RETRIES: 3,
+    WRITE_RETRY_DELAY_MS: 50,
+};
+
+module.exports = { PAGINATION, FIELD_LIMITS, STORAGE };

--- a/src/server/services/task-service.js
+++ b/src/server/services/task-service.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require('uuid');
 const { audit } = require('../logger');
+const { PAGINATION } = require('../config');
 const { validateTask, sanitizeTaskData } = require('../validation/task-validator');
 const {
     readTasks,
@@ -24,7 +25,7 @@ function paginate(tasks, query) {
     if (!page && !limit) return null;
 
     const safePage = (Number.isInteger(page) && page > 0) ? page : 1;
-    const safeLimit = (Number.isInteger(limit) && limit > 0 && limit <= 200) ? limit : 50;
+    const safeLimit = (Number.isInteger(limit) && limit > 0 && limit <= PAGINATION.MAX_LIMIT) ? limit : PAGINATION.DEFAULT_LIMIT;
     const total = tasks.length;
     const pages = Math.ceil(total / safeLimit);
     const start = (safePage - 1) * safeLimit;

--- a/src/server/storage/json-store.js
+++ b/src/server/storage/json-store.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
+const { STORAGE } = require('../config');
 
 const DATA_DIR = path.join(__dirname, '..', '..', '..', 'data');
 const TASKS_FILE = path.join(DATA_DIR, 'tasks.json');
@@ -21,7 +22,7 @@ if (!fs.existsSync(ARCHIVED_FILE)) {
 
 const locks = new Map();
 
-function acquireLock(file, timeout = 5000) {
+function acquireLock(file, timeout = STORAGE.LOCK_TIMEOUT_MS) {
     return new Promise((resolve, reject) => {
         const start = Date.now();
         (function tryLock() {
@@ -32,7 +33,7 @@ function acquireLock(file, timeout = 5000) {
             if (Date.now() - start > timeout) {
                 return reject(new Error(`Lock timeout for ${path.basename(file)}`));
             }
-            setTimeout(tryLock, 10);
+            setTimeout(tryLock, STORAGE.LOCK_POLL_INTERVAL_MS);
         })();
     });
 }
@@ -61,13 +62,13 @@ async function writeJSON(file, data) {
     cache.set(file, data);
     const tmp = file + '.tmp';
     await fsp.writeFile(tmp, JSON.stringify(data, null, 2), 'utf8');
-    for (let attempt = 0; attempt < 3; attempt++) {
+    for (let attempt = 0; attempt < STORAGE.WRITE_MAX_RETRIES; attempt++) {
         try {
             await fsp.rename(tmp, file);
             return;
         } catch (err) {
-            if (attempt === 2 || err.code !== 'EPERM') throw err;
-            await new Promise(resolve => setTimeout(resolve, 50));
+            if (attempt === STORAGE.WRITE_MAX_RETRIES - 1 || err.code !== 'EPERM') throw err;
+            await new Promise(resolve => setTimeout(resolve, STORAGE.WRITE_RETRY_DELAY_MS));
         }
     }
 }

--- a/src/server/validation/task-validator.js
+++ b/src/server/validation/task-validator.js
@@ -1,5 +1,7 @@
 // --- Validation ---
 
+const { FIELD_LIMITS } = require('../config');
+
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function validateIdParam(req, res, next) {
@@ -13,28 +15,28 @@ function validateTask(taskData, partial = false) {
     const errors = [];
 
     if (!partial || taskData.title !== undefined) {
-        if (typeof taskData.title !== 'string' || taskData.title.trim().length < 1 || taskData.title.trim().length > 200) {
-            errors.push('Titel muss zwischen 1 und 200 Zeichen lang sein');
+        if (typeof taskData.title !== 'string' || taskData.title.trim().length < 1 || taskData.title.trim().length > FIELD_LIMITS.TITLE_MAX) {
+            errors.push(`Titel muss zwischen 1 und ${FIELD_LIMITS.TITLE_MAX} Zeichen lang sein`);
         }
     }
     if (taskData.employee !== undefined && taskData.employee !== '') {
-        if (typeof taskData.employee !== 'string' || taskData.employee.trim().length > 100) {
-            errors.push('Mitarbeiter darf maximal 100 Zeichen lang sein');
+        if (typeof taskData.employee !== 'string' || taskData.employee.trim().length > FIELD_LIMITS.EMPLOYEE_MAX) {
+            errors.push(`Mitarbeiter darf maximal ${FIELD_LIMITS.EMPLOYEE_MAX} Zeichen lang sein`);
         }
     }
     if (!partial || taskData.location !== undefined) {
-        if (typeof taskData.location !== 'string' || taskData.location.trim().length < 1 || taskData.location.trim().length > 100) {
-            errors.push('Standort muss angegeben werden (max 100 Zeichen)');
+        if (typeof taskData.location !== 'string' || taskData.location.trim().length < 1 || taskData.location.trim().length > FIELD_LIMITS.LOCATION_MAX) {
+            errors.push(`Standort muss angegeben werden (max ${FIELD_LIMITS.LOCATION_MAX} Zeichen)`);
         }
     }
     if (taskData.description !== undefined && taskData.description !== '') {
-        if (typeof taskData.description !== 'string' || taskData.description.length > 2000) {
-            errors.push('Beschreibung darf maximal 2000 Zeichen lang sein');
+        if (typeof taskData.description !== 'string' || taskData.description.length > FIELD_LIMITS.DESCRIPTION_MAX) {
+            errors.push(`Beschreibung darf maximal ${FIELD_LIMITS.DESCRIPTION_MAX} Zeichen lang sein`);
         }
     }
     if (taskData.notes !== undefined && taskData.notes !== '') {
-        if (typeof taskData.notes !== 'string' || taskData.notes.length > 5000) {
-            errors.push('Notizen d\u00fcrfen maximal 5000 Zeichen lang sein');
+        if (typeof taskData.notes !== 'string' || taskData.notes.length > FIELD_LIMITS.NOTES_MAX) {
+            errors.push(`Notizen d\u00fcrfen maximal ${FIELD_LIMITS.NOTES_MAX} Zeichen lang sein`);
         }
     }
     if (taskData.status !== undefined) {
@@ -59,19 +61,19 @@ function validateTask(taskData, partial = false) {
         if (!Array.isArray(taskData.subtasks)) {
             errors.push('Unteraufgaben m\u00fcssen ein Array sein');
         } else {
-            if (taskData.subtasks.length > 50) {
-                errors.push('Maximal 50 Unteraufgaben erlaubt');
+            if (taskData.subtasks.length > FIELD_LIMITS.MAX_SUBTASKS) {
+                errors.push(`Maximal ${FIELD_LIMITS.MAX_SUBTASKS} Unteraufgaben erlaubt`);
             }
             taskData.subtasks.forEach((st, i) => {
                 if (typeof st === 'string') {
-                    if (st.length > 500) {
-                        errors.push(`Unteraufgabe ${i + 1}: Text darf maximal 500 Zeichen lang sein`);
+                    if (st.length > FIELD_LIMITS.SUBTASK_TEXT_MAX) {
+                        errors.push(`Unteraufgabe ${i + 1}: Text darf maximal ${FIELD_LIMITS.SUBTASK_TEXT_MAX} Zeichen lang sein`);
                     }
                 } else if (typeof st === 'object' && st !== null) {
                     if (typeof st.text !== 'string') {
                         errors.push(`Unteraufgabe ${i + 1}: text muss ein String sein`);
-                    } else if (st.text.length > 500) {
-                        errors.push(`Unteraufgabe ${i + 1}: Text darf maximal 500 Zeichen lang sein`);
+                    } else if (st.text.length > FIELD_LIMITS.SUBTASK_TEXT_MAX) {
+                        errors.push(`Unteraufgabe ${i + 1}: Text darf maximal ${FIELD_LIMITS.SUBTASK_TEXT_MAX} Zeichen lang sein`);
                     }
                     if (st.completed !== undefined && typeof st.completed !== 'boolean') {
                         errors.push(`Unteraufgabe ${i + 1}: completed muss ein Boolean sein`);
@@ -86,6 +88,12 @@ function validateTask(taskData, partial = false) {
     return { valid: errors.length === 0, errors };
 }
 
+// Canonical server-side escapeHtml implementation.
+// Note: The client-side version in src/js/security.js also escapes forward slashes
+// (/ -> &#x2F;) for additional DOM context safety. This server version does not,
+// because server-side escaping is only used for logging/audit contexts.
+// Do NOT attempt to share a single module between server (CommonJS) and browser
+// (global scripts) without a build system.
 function escapeHtml(str) {
     if (str === null || str === undefined) return '';
     return String(str)


### PR DESCRIPTION
## Summary
- **#144**: Document escapeHtml differences (server escapes 5 chars, client 6 with `/`) with cross-reference comments
- **#145**: New `src/server/config.js` with `PAGINATION`, `FIELD_LIMITS`, `STORAGE` constants
  - Updated `task-validator.js`, `task-service.js`, `json-store.js` to use central config
  - Left `rate-limit.js` as-is (already well-organized)

Closes #144, closes #145

## Test plan
- [ ] 85/85 tests pass
- [ ] No behavioral changes (pure refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)