### PR TITLE
fix: clean up tempSubtasks state to prevent memory leak (#150)

### DIFF
--- a/src/js/task-events.js
+++ b/src/js/task-events.js
@@ -11,6 +11,12 @@ GartenPlaner.prototype.setupEventListeners = function () {
 			e.preventDefault();
 			this.addTask();
 		});
+		// Clear tempSubtasks when the form is reset (e.g. via browser reset)
+		taskForm.addEventListener("reset", () => {
+			this.tempSubtasks = [];
+			// Defer rendering so the native reset completes first
+			setTimeout(() => this.renderCreateSubtasksList(), 0);
+		});
 	}
 
 	// Filter (nur wenn vorhanden)

--- a/src/js/task-state.js
+++ b/src/js/task-state.js
@@ -92,13 +92,7 @@ GartenPlaner.prototype.addTask = async function () {
 		this.updateEmployeeFilter();
 		this.updateLocationFilter();
 
-		const taskForm = document.getElementById("taskForm");
-		if (taskForm) {
-			taskForm.reset();
-		}
-
-		this.tempSubtasks = [];
-		this.renderCreateSubtasksList();
+		this.resetCreateForm();
 
 		setTimeout(() => {
 			const newTaskElement = document.querySelector(
@@ -150,6 +144,18 @@ GartenPlaner.prototype.addTask = async function () {
 		);
 	} finally {
 		this.setButtonLoading(submitBtn, false);
+	}
+};
+
+// Centralized cleanup for the create-task form and tempSubtasks state.
+// Prevents memory leaks by ensuring tempSubtasks is always cleared
+// when the form is reset, submitted, or when all data is cleared.
+GartenPlaner.prototype.resetCreateForm = function () {
+	this.tempSubtasks = [];
+	this.renderCreateSubtasksList();
+	const taskForm = document.getElementById("taskForm");
+	if (taskForm) {
+		taskForm.reset();
 	}
 };
 
@@ -707,6 +713,7 @@ GartenPlaner.prototype.clearAllData = async function () {
 				this.updateStatistics();
 				this.updateEmployeeFilter();
 				this.updateLocationFilter();
+				this.resetCreateForm();
 				this.showNotification("\ud83d\uddd1\ufe0f Alle Daten gel\u00f6scht");
 			}
 		}


### PR DESCRIPTION
## Summary
- `tempSubtasks` was only cleared on successful `addTask()`, leaking on errors and `clearAllData()`
- New `resetCreateForm()` method centralizes cleanup
- Form `reset` event listener as additional safety net
- Subtasks preserved on API error so user can retry

Closes #150

## Test plan
- [ ] Create task with subtasks — subtasks cleared after save
- [ ] API error on create — subtasks preserved for retry
- [ ] Clear all data — form and subtasks reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)