### PR TITLE
docs: add JSDoc type hints to server functions (#148)

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,11 +1,33 @@
-// --- Central configuration constants ---
-// Replaces magic numbers scattered across server modules (#145)
+/**
+ * @module config
+ * Central configuration constants for the GardenPlanner server.
+ * Replaces magic numbers scattered across server modules (#145).
+ */
 
+/**
+ * @typedef {Object} PaginationConfig
+ * @property {number} MAX_LIMIT - Maximum items per page (200)
+ * @property {number} DEFAULT_LIMIT - Default items per page (50)
+ */
+
+/** @type {PaginationConfig} */
 const PAGINATION = {
     MAX_LIMIT: 200,
     DEFAULT_LIMIT: 50,
 };
 
+/**
+ * @typedef {Object} FieldLimitsConfig
+ * @property {number} TITLE_MAX - Max characters for task title
+ * @property {number} EMPLOYEE_MAX - Max characters for employee name
+ * @property {number} LOCATION_MAX - Max characters for location
+ * @property {number} DESCRIPTION_MAX - Max characters for description
+ * @property {number} NOTES_MAX - Max characters for notes
+ * @property {number} MAX_SUBTASKS - Max number of subtasks per task
+ * @property {number} SUBTASK_TEXT_MAX - Max characters for subtask text
+ */
+
+/** @type {FieldLimitsConfig} */
 const FIELD_LIMITS = {
     TITLE_MAX: 200,
     EMPLOYEE_MAX: 100,
@@ -16,6 +38,15 @@ const FIELD_LIMITS = {
     SUBTASK_TEXT_MAX: 500,
 };
 
+/**
+ * @typedef {Object} StorageConfig
+ * @property {number} LOCK_TIMEOUT_MS - Max wait time for file lock acquisition
+ * @property {number} LOCK_POLL_INTERVAL_MS - Interval between lock retry attempts
+ * @property {number} WRITE_MAX_RETRIES - Max retries for atomic file rename
+ * @property {number} WRITE_RETRY_DELAY_MS - Delay between write retries
+ */
+
+/** @type {StorageConfig} */
 const STORAGE = {
     LOCK_TIMEOUT_MS: 5000,
     LOCK_POLL_INTERVAL_MS: 10,

--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -98,7 +98,12 @@ const auditTransport = process.env.NODE_ENV === 'test'
 
 const auditLogger = pino({ level: 'info' }, auditTransport);
 
-// Structured audit log entry
+/**
+ * Write a structured audit log entry to the audit log file.
+ * @param {string} event - Audit event name (e.g. 'task_created', 'auth_failure')
+ * @param {Object} [details={}] - Additional context for the event
+ * @returns {void}
+ */
 function audit(event, details = {}) {
     auditLogger.info({
         event,
@@ -107,7 +112,13 @@ function audit(event, details = {}) {
     });
 }
 
-// Express request logging middleware
+/**
+ * Express middleware that logs each request with method, URL, status, duration, and IP.
+ * @param {import('express').Request} req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @param {import('express').NextFunction} next - Express next function
+ * @returns {void}
+ */
 function requestLogger(req, res, next) {
     const start = Date.now();
 

--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -3,7 +3,14 @@ const { audit } = require('../logger');
 
 const API_KEY = process.env.API_KEY || '';
 
-// API key authentication for /api/* routes
+/**
+ * Express middleware for API key authentication on /api/* routes.
+ * Uses timing-safe comparison. Skips auth for /auth/status and when no API_KEY is configured.
+ * @param {import('express').Request} req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @param {import('express').NextFunction} next - Express next function
+ * @returns {void}
+ */
 function apiKeyAuth(req, res, next) {
     // Auth status endpoint is always accessible
     if (req.path === '/auth/status') {

--- a/src/server/middleware/error-handler.js
+++ b/src/server/middleware/error-handler.js
@@ -10,6 +10,15 @@ const GENERIC_MESSAGES = {
     429: 'Too many requests'
 };
 
+/**
+ * Express error-handling middleware. Logs 5xx errors and returns JSON error responses.
+ * In production, uses generic messages for all errors; in dev/test, passes through 4xx messages.
+ * @param {Error & {status?: number}} err - Error object, optionally with an HTTP status
+ * @param {import('express').Request} req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @param {import('express').NextFunction} next - Express next function
+ * @returns {void}
+ */
 function errorHandler(err, req, res, next) {
     const status = err.status || 500;
     const isProduction = process.env.NODE_ENV === 'production';

--- a/src/server/middleware/rate-limit.js
+++ b/src/server/middleware/rate-limit.js
@@ -1,3 +1,8 @@
+/**
+ * @module middleware/rate-limit
+ * Express rate-limiting middleware with separate limiters for general, write, and auth requests.
+ */
+
 const rateLimit = require('express-rate-limit');
 const { MemoryStore, ipKeyGenerator } = require('express-rate-limit');
 
@@ -23,6 +28,7 @@ const generalStore = new MemoryStore();
 const writeStore = new MemoryStore();
 const authStore = new MemoryStore();
 
+/** @type {import('express').RequestHandler} General rate limiter - 100 req / 15 min */
 const generalLimiter = rateLimit({
     ...COMMON_OPTIONS,
     ...RATE_LIMITS.general,
@@ -30,6 +36,7 @@ const generalLimiter = rateLimit({
     store: generalStore
 });
 
+/** @type {import('express').RequestHandler} Write rate limiter - 30 req / 15 min */
 const writeLimiter = rateLimit({
     ...COMMON_OPTIONS,
     ...RATE_LIMITS.write,
@@ -37,6 +44,7 @@ const writeLimiter = rateLimit({
     store: writeStore
 });
 
+/** @type {import('express').RequestHandler} Auth rate limiter - 10 req / 15 min (IP-only) */
 const authLimiter = rateLimit({
     ...COMMON_OPTIONS,
     ...RATE_LIMITS.auth,
@@ -44,7 +52,10 @@ const authLimiter = rateLimit({
     // Auth limiter always uses IP (no key yet)
 });
 
-// Reset all rate limiter stores (useful for tests)
+/**
+ * Reset all rate limiter in-memory stores. Useful for test isolation.
+ * @returns {void}
+ */
 function resetRateLimitStores() {
     generalStore.resetAll();
     writeStore.resetAll();

--- a/src/server/middleware/security.js
+++ b/src/server/middleware/security.js
@@ -1,5 +1,13 @@
 const crypto = require('crypto');
 
+/**
+ * Express middleware that sets security headers (CSP, HSTS, X-Frame-Options, etc.).
+ * Generates a unique CSP nonce per request stored in res.locals.cspNonce.
+ * @param {import('express').Request} req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @param {import('express').NextFunction} next - Express next function
+ * @returns {void}
+ */
 function securityHeaders(req, res, next) {
     // Generate unique nonce per request
     const nonce = crypto.randomBytes(16).toString('base64');

--- a/src/server/routes/archive.js
+++ b/src/server/routes/archive.js
@@ -1,3 +1,9 @@
+/**
+ * @module routes/archive
+ * Express router for task archiving endpoints.
+ * Supports archiving, unarchiving, listing, and permanently deleting archived tasks.
+ */
+
 const express = require('express');
 const router = express.Router();
 const { validateIdParam } = require('../validation/task-validator');

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -1,3 +1,9 @@
+/**
+ * @module routes/auth
+ * Express router for authentication status endpoints.
+ * Exposes GET /auth/status to check whether API key auth is required.
+ */
+
 const express = require('express');
 const router = express.Router();
 const { API_KEY } = require('../middleware/auth');

--- a/src/server/routes/plants.js
+++ b/src/server/routes/plants.js
@@ -1,3 +1,9 @@
+/**
+ * @module routes/plants
+ * Express router for plant data endpoints under /api/plants.
+ * Supports listing plants with optional category/search filters and fetching individual plants.
+ */
+
 const express = require('express');
 const router = express.Router();
 const { listPlants, getPlant, listCategories } = require('../services/plant-service');

--- a/src/server/routes/tasks.js
+++ b/src/server/routes/tasks.js
@@ -1,3 +1,9 @@
+/**
+ * @module routes/tasks
+ * Express router for task CRUD endpoints under /api/tasks.
+ * Supports listing, searching, creating, updating, and deleting tasks.
+ */
+
 const express = require('express');
 const router = express.Router();
 const { validateIdParam } = require('../validation/task-validator');

--- a/src/server/services/task-service.js
+++ b/src/server/services/task-service.js
@@ -1,3 +1,45 @@
+/**
+ * @module services/task-service
+ * Business logic for task CRUD, search, pagination, and archiving.
+ */
+
+/**
+ * @typedef {Object} Task
+ * @property {string} id - UUID v4 identifier
+ * @property {string} title - Task title
+ * @property {string} employee - Assigned employee name
+ * @property {string} location - Task location
+ * @property {string} description - Detailed description
+ * @property {string} notes - Additional notes
+ * @property {'pending'|'in-progress'|'completed'} status - Current status
+ * @property {'low'|'medium'|'high'} priority - Priority level
+ * @property {'none'|'daily'|'weekly'|'monthly'} recurrence - Recurrence pattern
+ * @property {string} createdAt - ISO 8601 creation timestamp
+ * @property {string} [completedAt] - ISO 8601 completion timestamp
+ * @property {string} [archivedAt] - ISO 8601 archive timestamp
+ * @property {Array<{timestamp: string, action: string, details: Object}>} history - Change history
+ * @property {Array<{id: number, text: string, completed: boolean}>} subtasks - Subtask list
+ * @property {number} sortOrder - Numeric sort order (epoch ms)
+ */
+
+/**
+ * @typedef {Object} PaginatedResult
+ * @property {Task[]} data - Page of tasks
+ * @property {number} total - Total number of matching tasks
+ * @property {number} page - Current page number
+ * @property {number} limit - Items per page
+ * @property {number} pages - Total number of pages
+ */
+
+/**
+ * @typedef {Object} TaskOperationResult
+ * @property {boolean} error - Whether the operation failed
+ * @property {number} [status] - HTTP status code (on error)
+ * @property {string} [message] - Error message (on error)
+ * @property {string[]} [errors] - Validation error messages (on validation failure)
+ * @property {Task} [task] - The resulting task (on success)
+ */
+
 const { v4: uuidv4 } = require('uuid');
 const { audit } = require('../logger');
 const { PAGINATION } = require('../config');
@@ -17,6 +59,15 @@ const {
 
 // --- Pagination helper ---
 
+/**
+ * Paginate an array of tasks based on query parameters.
+ * Returns null if no pagination params are provided (backwards-compatible).
+ * @param {Task[]} tasks - Full array of tasks to paginate
+ * @param {Object} query - Query parameters
+ * @param {string|number} [query.page] - Page number (1-based)
+ * @param {string|number} [query.limit] - Items per page
+ * @returns {PaginatedResult|null} Paginated result or null if no pagination requested
+ */
 function paginate(tasks, query) {
     const page = parseInt(query.page, 10);
     const limit = parseInt(query.limit, 10);
@@ -36,6 +87,14 @@ function paginate(tasks, query) {
 
 // --- Task CRUD operations ---
 
+/**
+ * List tasks with optional status filter and pagination.
+ * @param {Object} query - Query parameters
+ * @param {string} [query.status] - Filter by status ('pending'|'in-progress'|'completed')
+ * @param {string|number} [query.page] - Page number
+ * @param {string|number} [query.limit] - Items per page
+ * @returns {Task[]|PaginatedResult} Array of tasks or paginated result
+ */
 function listTasks(query) {
     let tasks = readTasks();
 
@@ -52,6 +111,16 @@ function listTasks(query) {
     return paginated || tasks;
 }
 
+/**
+ * Search tasks by status, employee, and/or location with optional pagination.
+ * @param {Object} body - Search criteria from request body
+ * @param {string} [body.status] - Filter by status
+ * @param {string} [body.employee] - Filter by employee name (exact match)
+ * @param {string} [body.location] - Filter by location (exact match)
+ * @param {string|number} [body.page] - Page number
+ * @param {string|number} [body.limit] - Items per page
+ * @returns {Task[]|PaginatedResult} Array of tasks or paginated result
+ */
 function searchTasks(body) {
     let tasks = readTasks();
     const { status, employee, location, page, limit } = body;
@@ -73,11 +142,21 @@ function searchTasks(body) {
     return paginated || tasks;
 }
 
+/**
+ * Get a single task by ID.
+ * @param {string} id - Task UUID
+ * @returns {Task|null} The task or null if not found
+ */
 function getTask(id) {
     const tasks = readTasks();
     return tasks.find(t => String(t.id) === String(id)) || null;
 }
 
+/**
+ * Create a new task. Validates and sanitizes input, generates UUID, and persists.
+ * @param {Object} body - Task data from request body
+ * @returns {Promise<TaskOperationResult>} Result with the created task or validation errors
+ */
 async function createTask(body) {
     const validation = validateTask(body);
     if (!validation.valid) {
@@ -122,6 +201,12 @@ async function createTask(body) {
     return { error: false, task };
 }
 
+/**
+ * Update an existing task by ID. Validates input, tracks changes in history.
+ * @param {string} id - Task UUID
+ * @param {Object} body - Partial task data to update
+ * @returns {Promise<TaskOperationResult>} Result with the updated task or error
+ */
 async function updateTask(id, body) {
     const validation = validateTask(body, true);
     if (!validation.valid) {
@@ -200,6 +285,11 @@ async function updateTask(id, body) {
     return { error: false, task: result.task };
 }
 
+/**
+ * Delete a task by ID.
+ * @param {string} id - Task UUID
+ * @returns {Promise<TaskOperationResult>} Result indicating success or not-found error
+ */
 async function deleteTask(id) {
     const result = await withLockedTasks((tasks) => {
         const index = tasks.findIndex(t => String(t.id) === String(id));
@@ -214,6 +304,11 @@ async function deleteTask(id) {
     return { error: false };
 }
 
+/**
+ * Archive a task by moving it from the active tasks store to the archive.
+ * @param {string} id - Task UUID
+ * @returns {Promise<TaskOperationResult>} Result with the archived task or not-found error
+ */
 async function archiveTask(id) {
     await acquireLock(TASKS_FILE);
     await acquireLock(ARCHIVED_FILE);
@@ -246,6 +341,11 @@ async function archiveTask(id) {
     }
 }
 
+/**
+ * Restore an archived task back to the active tasks store.
+ * @param {string} id - Archived task UUID
+ * @returns {Promise<TaskOperationResult>} Result with the restored task or not-found error
+ */
 async function unarchiveTask(id) {
     await acquireLock(ARCHIVED_FILE);
     await acquireLock(TASKS_FILE);
@@ -278,10 +378,19 @@ async function unarchiveTask(id) {
     }
 }
 
+/**
+ * List all archived tasks.
+ * @returns {Task[]} Array of archived tasks
+ */
 function listArchivedTasks() {
     return readArchivedTasks();
 }
 
+/**
+ * Permanently delete an archived task.
+ * @param {string} id - Archived task UUID
+ * @returns {Promise<TaskOperationResult>} Result indicating success or not-found error
+ */
 async function deleteArchivedTask(id) {
     const result = await withLockedArchive((archived) => {
         const index = archived.findIndex(t => String(t.id) === String(id));

--- a/src/server/storage/json-store.js
+++ b/src/server/storage/json-store.js
@@ -1,3 +1,8 @@
+/**
+ * @module storage/json-store
+ * JSON file-based storage with in-memory caching, file locking, and atomic writes.
+ */
+
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
@@ -22,6 +27,13 @@ if (!fs.existsSync(ARCHIVED_FILE)) {
 
 const locks = new Map();
 
+/**
+ * Acquire an in-memory lock for a given file path. Polls until the lock is available or times out.
+ * @param {string} file - Absolute file path to lock on
+ * @param {number} [timeout=STORAGE.LOCK_TIMEOUT_MS] - Max wait time in milliseconds
+ * @returns {Promise<void>} Resolves when lock is acquired
+ * @throws {Error} If lock acquisition times out
+ */
 function acquireLock(file, timeout = STORAGE.LOCK_TIMEOUT_MS) {
     return new Promise((resolve, reject) => {
         const start = Date.now();
@@ -38,6 +50,11 @@ function acquireLock(file, timeout = STORAGE.LOCK_TIMEOUT_MS) {
     });
 }
 
+/**
+ * Release an in-memory lock for a given file path.
+ * @param {string} file - Absolute file path to unlock
+ * @returns {void}
+ */
 function releaseLock(file) {
     locks.delete(file);
 }
@@ -45,6 +62,11 @@ function releaseLock(file) {
 // --- In-memory cache ---
 const cache = new Map();
 
+/**
+ * Read and parse a JSON file, returning cached data if available.
+ * @param {string} file - Absolute file path
+ * @returns {Array|Object} Parsed JSON data, or empty array on read/parse error
+ */
 function readJSON(file) {
     const cached = cache.get(file);
     if (cached !== undefined) return cached;
@@ -58,6 +80,13 @@ function readJSON(file) {
     }
 }
 
+/**
+ * Atomically write data to a JSON file (write to .tmp then rename). Updates cache.
+ * @param {string} file - Absolute file path
+ * @param {Array|Object} data - Data to serialize as JSON
+ * @returns {Promise<void>}
+ * @throws {Error} If write or rename fails after retries
+ */
 async function writeJSON(file, data) {
     cache.set(file, data);
     const tmp = file + '.tmp';
@@ -73,15 +102,37 @@ async function writeJSON(file, data) {
     }
 }
 
+/**
+ * Clear all in-memory caches. Useful for test isolation.
+ * @returns {void}
+ */
 function resetCaches() {
     cache.clear();
 }
 
+/** @returns {Array} Active tasks array */
 function readTasks() { return readJSON(TASKS_FILE); }
+
+/**
+ * @param {Array} tasks - Tasks array to persist
+ * @returns {Promise<void>}
+ */
 async function writeTasks(tasks) { await writeJSON(TASKS_FILE, tasks); }
+
+/** @returns {Array} Archived tasks array */
 function readArchivedTasks() { return readJSON(ARCHIVED_FILE); }
+
+/**
+ * @param {Array} tasks - Archived tasks array to persist
+ * @returns {Promise<void>}
+ */
 async function writeArchivedTasks(tasks) { await writeJSON(ARCHIVED_FILE, tasks); }
 
+/**
+ * Execute a function with exclusive lock on the tasks file. Automatically reads, writes, and unlocks.
+ * @param {function(Array): {tasks: Array|undefined, [key: string]: *}} fn - Callback receiving current tasks; return {tasks} to persist changes
+ * @returns {Promise<Object>} The result object returned by fn
+ */
 async function withLockedTasks(fn) {
     await acquireLock(TASKS_FILE);
     try {
@@ -94,6 +145,11 @@ async function withLockedTasks(fn) {
     }
 }
 
+/**
+ * Execute a function with exclusive lock on the archived tasks file. Automatically reads, writes, and unlocks.
+ * @param {function(Array): {tasks: Array|undefined, [key: string]: *}} fn - Callback receiving current archived tasks; return {tasks} to persist changes
+ * @returns {Promise<Object>} The result object returned by fn
+ */
 async function withLockedArchive(fn) {
     await acquireLock(ARCHIVED_FILE);
     try {

--- a/src/server/validation/task-validator.js
+++ b/src/server/validation/task-validator.js
@@ -1,9 +1,26 @@
-// --- Validation ---
+/**
+ * @module validation/task-validator
+ * Input validation and sanitization for task data.
+ */
+
+/**
+ * @typedef {Object} ValidationResult
+ * @property {boolean} valid - Whether validation passed
+ * @property {string[]} errors - Array of validation error messages (empty if valid)
+ */
 
 const { FIELD_LIMITS } = require('../config');
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
+/**
+ * Express middleware that validates req.params.id is a valid UUID v4.
+ * Responds with 400 if the format is invalid.
+ * @param {import('express').Request} req - Express request object
+ * @param {import('express').Response} res - Express response object
+ * @param {import('express').NextFunction} next - Express next function
+ * @returns {void}
+ */
 function validateIdParam(req, res, next) {
     if (!UUID_REGEX.test(req.params.id)) {
         return res.status(400).json({ error: true, status: 400, message: 'Invalid ID format' });
@@ -11,6 +28,12 @@ function validateIdParam(req, res, next) {
     next();
 }
 
+/**
+ * Validate task data against field limits and allowed values.
+ * @param {Object} taskData - Task data to validate
+ * @param {boolean} [partial=false] - If true, only validates fields that are present (for updates)
+ * @returns {ValidationResult} Validation result with errors array
+ */
 function validateTask(taskData, partial = false) {
     const errors = [];
 
@@ -88,12 +111,13 @@ function validateTask(taskData, partial = false) {
     return { valid: errors.length === 0, errors };
 }
 
-// Canonical server-side escapeHtml implementation.
-// Note: The client-side version in src/js/security.js also escapes forward slashes
-// (/ -> &#x2F;) for additional DOM context safety. This server version does not,
-// because server-side escaping is only used for logging/audit contexts.
-// Do NOT attempt to share a single module between server (CommonJS) and browser
-// (global scripts) without a build system.
+/**
+ * Escape HTML special characters for safe output in logging/audit contexts.
+ * Note: The client-side version in src/js/security.js also escapes forward slashes
+ * for additional DOM context safety. This server version does not.
+ * @param {string|null|undefined} str - String to escape
+ * @returns {string} HTML-escaped string, or empty string if input is null/undefined
+ */
 function escapeHtml(str) {
     if (str === null || str === undefined) return '';
     return String(str)
@@ -104,6 +128,11 @@ function escapeHtml(str) {
         .replace(/'/g, '&#039;');
 }
 
+/**
+ * Sanitize task data by trimming string fields. Does not validate.
+ * @param {Object} data - Raw task data from request body
+ * @returns {Object} Sanitized copy with trimmed string fields
+ */
 function sanitizeTaskData(data) {
     const sanitized = {};
     if (data.title !== undefined) sanitized.title = data.title.trim();


### PR DESCRIPTION
## Summary
JSDoc annotations added to all 13 server-side files:
- `@typedef` for Task, ValidationResult, PaginatedResult, config types
- `@param`/`@returns` on all exported functions
- `@module` docs on route and middleware files

Closes #148

## Test plan
- [ ] 85/85 tests pass (no code changes, only comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)