### PR TITLE
feat: implement multi-tab synchronization via BroadcastChannel (#155)

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -470,6 +470,7 @@
     <script src="../src/js/task-renderer.js"></script>
     <script src="../src/js/task-events.js"></script>
     <script src="../src/js/task-export.js"></script>
+    <script src="../src/js/tab-sync.js"></script>
     <script src="../src/js/dashboard-init.js"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -251,6 +251,7 @@
     <script src="../src/js/task-renderer.js"></script>
     <script src="../src/js/task-events.js"></script>
     <script src="../src/js/task-export.js"></script>
+    <script src="../src/js/tab-sync.js"></script>
 
     <!-- Inline validation for progressive disclosure form -->
     <script>

--- a/src/js/tab-sync.js
+++ b/src/js/tab-sync.js
@@ -1,0 +1,132 @@
+// tab-sync.js - Multi-tab synchronization for GartenPlaner
+// Uses BroadcastChannel API with localStorage storage event fallback.
+// Must be loaded AFTER app.js defines the GartenPlaner class.
+
+(function () {
+	"use strict";
+
+	var CHANNEL_NAME = "gardenplanner-sync";
+	var STORAGE_KEY = "gardenplanner-sync-event";
+
+	/**
+	 * TabSync manages cross-tab communication so that task changes
+	 * (create, update, delete, archive, unarchive) in one tab are
+	 * reflected in all other open tabs.
+	 */
+	function TabSync() {
+		this.channel = null;
+		this.usesBroadcastChannel = typeof BroadcastChannel !== "undefined";
+		this._boundOnStorage = this._onStorageEvent.bind(this);
+		this._init();
+	}
+
+	TabSync.prototype._init = function () {
+		if (this.usesBroadcastChannel) {
+			this.channel = new BroadcastChannel(CHANNEL_NAME);
+			this.channel.onmessage = this._onMessage.bind(this);
+		} else {
+			// Fallback: listen for storage events (fires in *other* tabs only)
+			window.addEventListener("storage", this._boundOnStorage);
+		}
+
+		if (window.logger) {
+			window.logger.info("TabSync initialised", "tab-sync", {
+				transport: this.usesBroadcastChannel
+					? "BroadcastChannel"
+					: "storage-event",
+			});
+		}
+	};
+
+	/**
+	 * Broadcast a task-changed event to other tabs.
+	 * @param {'create'|'update'|'delete'|'archive'|'unarchive'} action
+	 * @param {string|number} taskId
+	 */
+	TabSync.prototype.broadcast = function (action, taskId) {
+		var message = {
+			type: "task-changed",
+			action: action,
+			taskId: taskId,
+			timestamp: Date.now(),
+		};
+
+		if (this.usesBroadcastChannel && this.channel) {
+			this.channel.postMessage(message);
+		} else {
+			// Fallback: write to localStorage so other tabs receive a storage event.
+			// We JSON-stringify with a unique timestamp so the value always changes
+			// (storage events only fire when the value actually changes).
+			try {
+				localStorage.setItem(STORAGE_KEY, JSON.stringify(message));
+			} catch (e) {
+				// localStorage might be full or unavailable — silently ignore
+			}
+		}
+
+		if (window.logger) {
+			window.logger.debug("TabSync broadcast", "tab-sync", message);
+		}
+	};
+
+	/** Handler for BroadcastChannel messages */
+	TabSync.prototype._onMessage = function (event) {
+		var data = event.data;
+		if (data && data.type === "task-changed") {
+			this._handleSyncEvent(data);
+		}
+	};
+
+	/** Handler for localStorage storage events (fallback) */
+	TabSync.prototype._onStorageEvent = function (event) {
+		if (event.key !== STORAGE_KEY || !event.newValue) return;
+		try {
+			var data = JSON.parse(event.newValue);
+			if (data && data.type === "task-changed") {
+				this._handleSyncEvent(data);
+			}
+		} catch (e) {
+			// Malformed JSON — ignore
+		}
+	};
+
+	/**
+	 * React to a sync event from another tab by reloading tasks and re-rendering.
+	 */
+	TabSync.prototype._handleSyncEvent = function (data) {
+		if (window.logger) {
+			window.logger.info("TabSync received sync event", "tab-sync", data);
+		}
+
+		var planer = window.gartenPlaner;
+		if (!planer) return;
+
+		// Reload tasks from storage/API and re-render
+		planer.loadTasks().then(function (tasks) {
+			planer.tasks = tasks;
+			return planer.loadArchivedTasks();
+		}).then(function (archivedTasks) {
+			planer.archivedTasks = archivedTasks;
+			planer.renderTasks();
+			planer.updateStatistics();
+			planer.updateEmployeeFilter();
+			planer.updateLocationFilter();
+		}).catch(function (error) {
+			console.error("TabSync: failed to reload tasks", error);
+		});
+	};
+
+	/** Clean up resources (useful for tests or SPA teardown) */
+	TabSync.prototype.destroy = function () {
+		if (this.channel) {
+			this.channel.close();
+			this.channel = null;
+		}
+		window.removeEventListener("storage", this._boundOnStorage);
+	};
+
+	// Instantiate and expose globally
+	var tabSync = new TabSync();
+	window.tabSync = tabSync;
+	window.GP.tabSync = tabSync;
+})();

--- a/src/js/task-state.js
+++ b/src/js/task-state.js
@@ -105,6 +105,10 @@ GartenPlaner.prototype.addTask = async function () {
 
 		this.showNotification("\u2705 Aufgabe erfolgreich hinzugef\u00fcgt!");
 
+		if (window.tabSync) {
+			window.tabSync.broadcast("create", task.id);
+		}
+
 		if (window.logger) {
 			window.logger.endPerformance("addTask");
 			window.logger.info("Task created successfully", "app", {
@@ -202,6 +206,9 @@ GartenPlaner.prototype.deleteTask = async function (id) {
 		this.updateStatistics();
 		this.updateEmployeeFilter();
 		this.updateLocationFilter();
+		if (window.tabSync) {
+			window.tabSync.broadcast("delete", id);
+		}
 		this.showNotification("\ud83d\uddd1\ufe0f Aufgabe gel\u00f6scht");
 	} catch (error) {
 		console.error("Fehler beim L\u00f6schen der Aufgabe:", error);
@@ -301,6 +308,9 @@ GartenPlaner.prototype.saveEditedTask = async function (id) {
 		this.updateStatistics();
 		this.updateEmployeeFilter();
 		this.updateLocationFilter();
+		if (window.tabSync) {
+			window.tabSync.broadcast("update", id);
+		}
 		this.showNotification("\u2705 Aufgabe erfolgreich aktualisiert!");
 	} catch (error) {
 		console.error("Fehler in saveEditedTask:", error);
@@ -370,6 +380,9 @@ GartenPlaner.prototype.archiveTask = async function (id) {
 			this.updateStatistics();
 			this.updateEmployeeFilter();
 			this.updateLocationFilter();
+			if (window.tabSync) {
+				window.tabSync.broadcast("archive", id);
+			}
 			this.showNotification("\ud83d\udce6 Aufgabe archiviert");
 		}
 	} catch (error) {
@@ -416,6 +429,9 @@ GartenPlaner.prototype.unarchiveTask = async function (id) {
 			this.updateStatistics();
 			this.updateEmployeeFilter();
 			this.updateLocationFilter();
+			if (window.tabSync) {
+				window.tabSync.broadcast("unarchive", id);
+			}
 			this.showNotification("\u21bb Aufgabe wiederhergestellt");
 		}
 	} catch (error) {
@@ -456,6 +472,9 @@ GartenPlaner.prototype.deleteArchivedTask = async function (id) {
 			);
 			await this.saveArchivedTasks();
 			this.renderTasks();
+			if (window.tabSync) {
+				window.tabSync.broadcast("delete", id);
+			}
 			this.showNotification(
 				"\ud83d\uddd1\ufe0f Archivierte Aufgabe gel\u00f6scht",
 			);
@@ -508,6 +527,9 @@ GartenPlaner.prototype.toggleTaskStatus = async function (id) {
 		await this.saveTasks();
 		this.renderTasks();
 		this.updateStatistics();
+		if (window.tabSync) {
+			window.tabSync.broadcast("update", id);
+		}
 		this.showNotification(
 			task.status === "completed"
 				? "\u2705 Aufgabe erledigt!"


### PR DESCRIPTION
## Summary
- New `src/js/tab-sync.js` using BroadcastChannel with localStorage fallback
- Broadcasts task changes (create, update, delete, archive, unarchive) to other tabs
- Receiving tabs reload and re-render tasks automatically
- Script loaded on dashboard.html and index.html

Closes #155

## Test plan
- [ ] Open app in two tabs
- [ ] Create/edit/delete task in tab 1 — tab 2 updates automatically
- [ ] Works with BroadcastChannel (Chrome, Firefox, Edge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)