### PR TITLE
feat: add sorting, result count, and favorites to plant library (#108)

### DIFF
--- a/public/plants.html
+++ b/public/plants.html
@@ -31,13 +31,34 @@
                 <div class="search-box">
                     <input type="text" id="plantSearch" placeholder="Pflanze suchen..." aria-label="Pflanzen durchsuchen">
                 </div>
+                <div class="plant-sort-box">
+                    <label for="plantSort" class="sr-only">Sortierung</label>
+                    <select id="plantSort" aria-label="Pflanzen sortieren">
+                        <option value="name-asc">Name (A-Z)</option>
+                        <option value="name-desc">Name (Z-A)</option>
+                        <option value="category">Kategorie</option>
+                    </select>
+                </div>
+                <div class="plant-favorites-toggle">
+                    <button id="favoritesToggle" class="favorites-toggle-btn" aria-label="Nur Favoriten anzeigen" aria-pressed="false">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+                        </svg>
+                        Favoriten
+                    </button>
+                </div>
                 <div class="category-filters" id="categoryFilters">
                     <button class="category-btn active" data-category="">Alle</button>
                 </div>
             </section>
 
+            <div class="plant-result-count" id="plantResultCount" aria-live="polite"></div>
+
             <section class="plant-grid" id="plantGrid">
-                <div class="loading">Lade Pflanzenbibliothek...</div>
+                <div class="ui-state ui-state--loading">
+                    <div class="ui-state__spinner" aria-hidden="true"></div>
+                    <h3 class="ui-state__title">Lade Pflanzenbibliothek...</h3>
+                </div>
             </section>
 
             <!-- Plant Detail Modal -->
@@ -66,6 +87,8 @@
     <script src="../src/js/logger.js"></script>
     <script src="../src/js/error-handler.js"></script>
     <script src="../src/js/api.js"></script>
+    <script src="../src/js/ui-states.js"></script>
+    <script src="../src/js/confirm-dialog.js"></script>
     <script src="../src/js/app.js"></script>
     <script src="../src/js/task-state.js"></script>
     <script src="../src/js/task-filters.js"></script>

--- a/src/css/plants.css
+++ b/src/css/plants.css
@@ -63,6 +63,98 @@
   border-color: var(--primary);
 }
 
+/* === Plant Library Enhancements === */
+
+/* Sort dropdown */
+.plant-sort-box select {
+  padding: 10px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: 0.9rem;
+  font-family: var(--font-body);
+  background: var(--bg-secondary);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.2s;
+  appearance: auto;
+}
+
+.plant-sort-box select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(54, 94, 61, 0.1);
+}
+
+/* Favorites toggle button */
+.favorites-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 8px 16px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-light);
+  font-size: 0.9rem;
+  font-family: var(--font-body);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.favorites-toggle-btn:hover {
+  border-color: var(--primary-light);
+  color: var(--primary);
+}
+
+.favorites-toggle-btn.active {
+  background: #FEF2F2;
+  border-color: #F87171;
+  color: #DC2626;
+}
+
+/* Result count */
+.plant-result-count {
+  padding: 0 3rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-light);
+}
+
+/* Favorite button on plant card */
+.plant-favorite-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: none;
+  border: none;
+  color: var(--text-light);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  z-index: 1;
+  opacity: 0.5;
+}
+
+.plant-card:hover .plant-favorite-btn {
+  opacity: 1;
+}
+
+.plant-favorite-btn.active {
+  color: #DC2626;
+  opacity: 1;
+}
+
+.plant-favorite-btn:hover {
+  color: #DC2626;
+  opacity: 1;
+  transform: scale(1.15);
+}
+
 /* Plant Grid */
 .plant-grid {
   display: grid;
@@ -72,6 +164,7 @@
 }
 
 .plant-card {
+  position: relative;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -356,6 +449,27 @@
     max-width: 100%;
   }
 
+  .plant-sort-box {
+    width: 100%;
+  }
+
+  .plant-sort-box select {
+    width: 100%;
+  }
+
+  .plant-favorites-toggle {
+    width: 100%;
+  }
+
+  .favorites-toggle-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .plant-result-count {
+    padding: 0 1.5rem;
+  }
+
   .plant-grid {
     padding: 1rem 1.5rem;
     grid-template-columns: 1fr;
@@ -486,4 +600,49 @@
 
 [data-theme="dark"] .plant-modal-content::-webkit-scrollbar-thumb:hover {
   background: var(--text-light);
+}
+
+/* Dark Mode - Plant Library Enhancements */
+[data-theme="dark"] .plant-sort-box select {
+  background: var(--bg-tertiary, #262626);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+[data-theme="dark"] .plant-sort-box select:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(168, 213, 186, 0.2);
+}
+
+[data-theme="dark"] .favorites-toggle-btn {
+  background: var(--bg-tertiary, #262626);
+  border-color: var(--border);
+  color: var(--text-light);
+}
+
+[data-theme="dark"] .favorites-toggle-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+[data-theme="dark"] .favorites-toggle-btn.active {
+  background: rgb(220 38 38 / 15%);
+  border-color: #F87171;
+  color: #F87171;
+}
+
+[data-theme="dark"] .plant-result-count {
+  color: var(--text-light);
+}
+
+[data-theme="dark"] .plant-favorite-btn {
+  color: var(--text-light);
+}
+
+[data-theme="dark"] .plant-favorite-btn.active {
+  color: #F87171;
+}
+
+[data-theme="dark"] .plant-favorite-btn:hover {
+  color: #F87171;
 }

--- a/src/js/plants.js
+++ b/src/js/plants.js
@@ -3,6 +3,34 @@
     const API_BASE = '/api';
     let allPlants = [];
     let currentCategory = '';
+    let currentSort = 'name-asc';
+    let showFavoritesOnly = false;
+
+    // Favorites stored in localStorage
+    function getFavorites() {
+        try {
+            const stored = localStorage.getItem('plant_favorites');
+            return stored ? JSON.parse(stored) : [];
+        } catch {
+            return [];
+        }
+    }
+
+    function saveFavorites(favorites) {
+        localStorage.setItem('plant_favorites', JSON.stringify(favorites));
+    }
+
+    function toggleFavorite(plantId) {
+        const favorites = getFavorites();
+        const index = favorites.indexOf(plantId);
+        if (index === -1) {
+            favorites.push(plantId);
+        } else {
+            favorites.splice(index, 1);
+        }
+        saveFavorites(favorites);
+        return index === -1; // returns true if now favorited
+    }
 
     async function init() {
         await loadCategories();
@@ -33,11 +61,61 @@
 
             const res = await fetch(`${API_BASE}/plants${qs ? '?' + qs : ''}`);
             allPlants = await res.json();
-            renderPlants(allPlants);
+            applyClientFiltersAndRender();
         } catch (err) {
             console.error('Fehler beim Laden der Pflanzen:', err);
             const grid = document.getElementById('plantGrid');
-            if (grid) grid.innerHTML = '<div class="empty-state"><h3>Fehler beim Laden</h3></div>';
+            if (grid) {
+                grid.innerHTML = typeof UIStates !== "undefined"
+                    ? UIStates.renderErrorState("Pflanzen konnten nicht geladen werden.", function () { loadPlants(); })
+                    : '<div class="empty-state"><h3>Fehler beim Laden</h3></div>';
+            }
+            updateResultCount(0);
+        }
+    }
+
+    function sortPlants(plants) {
+        const sorted = [...plants];
+        switch (currentSort) {
+            case 'name-asc':
+                sorted.sort((a, b) => a.name.localeCompare(b.name, 'de'));
+                break;
+            case 'name-desc':
+                sorted.sort((a, b) => b.name.localeCompare(a.name, 'de'));
+                break;
+            case 'category':
+                sorted.sort((a, b) => {
+                    const catCmp = a.category.localeCompare(b.category, 'de');
+                    return catCmp !== 0 ? catCmp : a.name.localeCompare(b.name, 'de');
+                });
+                break;
+        }
+        return sorted;
+    }
+
+    function applyClientFiltersAndRender() {
+        let plants = [...allPlants];
+
+        // Filter favorites if toggle is active
+        if (showFavoritesOnly) {
+            const favorites = getFavorites();
+            plants = plants.filter(p => favorites.includes(p.id));
+        }
+
+        // Sort
+        plants = sortPlants(plants);
+
+        updateResultCount(plants.length);
+        renderPlants(plants);
+    }
+
+    function updateResultCount(count) {
+        const el = document.getElementById('plantResultCount');
+        if (!el) return;
+        if (count === 1) {
+            el.textContent = '1 Pflanze gefunden';
+        } else {
+            el.textContent = `${count} Pflanzen gefunden`;
         }
     }
 
@@ -46,9 +124,19 @@
         if (!grid) return;
 
         if (plants.length === 0) {
-            grid.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🌱</div><h3>Keine Pflanzen gefunden</h3><p>Versuchen Sie einen anderen Suchbegriff.</p></div>';
+            var searchInput = document.getElementById('plantSearch');
+            var searchVal = searchInput ? searchInput.value.trim() : '';
+            if (typeof UIStates !== "undefined" && searchVal) {
+                grid.innerHTML = UIStates.renderNoResultsState(searchVal);
+            } else if (typeof UIStates !== "undefined") {
+                grid.innerHTML = UIStates.renderEmptyState('\ud83c\udf31', 'Keine Pflanzen gefunden', 'Versuchen Sie einen anderen Suchbegriff oder passen Sie die Filter an.');
+            } else {
+                grid.innerHTML = '<div class="empty-state"><div class="empty-state-icon">\ud83c\udf31</div><h3>Keine Pflanzen gefunden</h3><p>Versuchen Sie einen anderen Suchbegriff oder passen Sie die Filter an.</p></div>';
+            }
             return;
         }
+
+        const favorites = getFavorites();
 
         grid.innerHTML = plants.map(p => {
             var safeName = Security.escapeHtml(p.name);
@@ -56,9 +144,15 @@
             var diffLabel = { easy: 'Einfach', medium: 'Mittel', hard: 'Schwer' }[p.difficulty] || p.difficulty;
             var sunLabel = { full: 'Volle Sonne', partial: 'Halbschatten', shade: 'Schatten' }[p.sun] || p.sun;
             var waterLabel = { low: 'Wenig', medium: 'Mittel', high: 'Viel' }[p.water] || p.water;
+            var isFav = favorites.includes(p.id);
 
             return `
                 <div class="plant-card" data-plant-id="${p.id}">
+                    <button class="plant-favorite-btn${isFav ? ' active' : ''}" data-plant-id="${p.id}" aria-label="${isFav ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}" aria-pressed="${isFav}" title="${isFav ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="${isFav ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/>
+                        </svg>
+                    </button>
                     <div class="plant-card-icon">${p.icon}</div>
                     <div class="plant-card-body">
                         <h3 class="plant-card-name">${safeName}</h3>
@@ -73,8 +167,33 @@
             `;
         }).join('');
 
+        // Attach click handlers for plant detail (not on favorite button)
         grid.querySelectorAll('.plant-card').forEach(card => {
-            card.addEventListener('click', () => openPlantDetail(card.dataset.plantId));
+            card.addEventListener('click', (e) => {
+                // Don't open detail when clicking favorite button
+                if (e.target.closest('.plant-favorite-btn')) return;
+                openPlantDetail(card.dataset.plantId);
+            });
+        });
+
+        // Attach click handlers for favorite buttons
+        grid.querySelectorAll('.plant-favorite-btn').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                const plantId = btn.dataset.plantId;
+                const nowFav = toggleFavorite(plantId);
+                btn.classList.toggle('active', nowFav);
+                btn.setAttribute('aria-pressed', String(nowFav));
+                btn.setAttribute('aria-label', nowFav ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen');
+                btn.setAttribute('title', nowFav ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen');
+                const svg = btn.querySelector('svg');
+                if (svg) svg.setAttribute('fill', nowFav ? 'currentColor' : 'none');
+
+                // If showing favorites only and we just unfavorited, re-render
+                if (showFavoritesOnly && !nowFav) {
+                    applyClientFiltersAndRender();
+                }
+            });
         });
     }
 
@@ -139,6 +258,7 @@
     }
 
     function setupEventListeners() {
+        // Search input with debounce
         const searchInput = document.getElementById('plantSearch');
         if (searchInput) {
             let timeout;
@@ -148,6 +268,7 @@
             });
         }
 
+        // Category filter buttons
         document.getElementById('categoryFilters')?.addEventListener('click', (e) => {
             const btn = e.target.closest('.category-btn');
             if (!btn) return;
@@ -158,6 +279,27 @@
             loadPlants(searchInput?.value?.trim() || '');
         });
 
+        // Sort dropdown
+        const sortSelect = document.getElementById('plantSort');
+        if (sortSelect) {
+            sortSelect.addEventListener('change', () => {
+                currentSort = sortSelect.value;
+                applyClientFiltersAndRender();
+            });
+        }
+
+        // Favorites toggle
+        const favToggle = document.getElementById('favoritesToggle');
+        if (favToggle) {
+            favToggle.addEventListener('click', () => {
+                showFavoritesOnly = !showFavoritesOnly;
+                favToggle.classList.toggle('active', showFavoritesOnly);
+                favToggle.setAttribute('aria-pressed', String(showFavoritesOnly));
+                applyClientFiltersAndRender();
+            });
+        }
+
+        // Escape to close modal
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
                 const modal = document.getElementById('plantModal');


### PR DESCRIPTION
## Summary
- **Sorting**: Name A-Z, Z-A, Category dropdown
- **Result count**: "X Pflanzen gefunden" updates on filter/search/sort
- **Favorites**: Heart toggle on cards, localStorage persistence, filter mode
- **Empty state**: "Keine Pflanzen gefunden" with hint

Closes #108

## Test plan
- [ ] Sort dropdown works (A-Z, Z-A, Category)
- [ ] Result count updates correctly
- [ ] Favorites persist across page reload
- [ ] Dark mode looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)