### PR TITLE
feat: add unified UI states and confirmation dialogs (#105, #149)

### DIFF
--- a/src/js/confirm-dialog.js
+++ b/src/js/confirm-dialog.js
@@ -1,0 +1,143 @@
+// confirm-dialog.js - Standalone confirmation dialog utility
+// Provides a Promise-based confirmAction() function that can be used anywhere.
+// Uses the existing confirmModal DOM element when available, or falls back to
+// the GartenPlaner.prototype.showConfirm method.
+// Must be loaded BEFORE app.js.
+
+(function () {
+	"use strict";
+
+	/**
+	 * Shows a modal confirmation dialog and returns a Promise.
+	 * @param {Object} options
+	 * @param {string} [options.title='Bestaetigung erforderlich'] - Dialog title.
+	 * @param {string} [options.message='Moechten Sie fortfahren?'] - Dialog message.
+	 * @param {string} [options.icon] - Emoji icon to display.
+	 * @param {string} [options.confirmText='Bestaetigen'] - Text for the confirm button.
+	 * @param {string} [options.cancelText='Abbrechen'] - Text for the cancel button.
+	 * @param {boolean} [options.danger=false] - If true, styles the confirm button as dangerous/red.
+	 * @returns {Promise<boolean>} Resolves to true if confirmed, false if cancelled.
+	 */
+	function confirmAction(options) {
+		if (!options) options = {};
+
+		// If GartenPlaner instance is available and has showConfirm, delegate to it
+		// This ensures consistent behavior with existing code that uses the DOM modal
+		if (window.gartenPlaner && typeof window.gartenPlaner.showConfirm === "function") {
+			return window.gartenPlaner.showConfirm({
+				title: options.title || "Best\u00e4tigung erforderlich",
+				icon: options.icon || "\u26a0\ufe0f",
+				message: options.message || "M\u00f6chten Sie fortfahren?",
+				confirmText: options.confirmText || "Best\u00e4tigen",
+				cancelText: options.cancelText || "Abbrechen",
+				danger: !!options.danger,
+			});
+		}
+
+		// Fallback: use the confirmModal DOM directly if it exists
+		var modal = document.getElementById("confirmModal");
+		if (modal) {
+			return _showModalDialog(modal, options);
+		}
+
+		// Last resort: native confirm
+		var result = confirm(
+			(options.title ? options.title + "\n\n" : "") +
+			(options.message || "M\u00f6chten Sie fortfahren?"),
+		);
+		return Promise.resolve(result);
+	}
+
+	/**
+	 * Internal: drives the existing confirmModal DOM element.
+	 */
+	function _showModalDialog(modal, options) {
+		return new Promise(function (resolve) {
+			var title = document.getElementById("confirmModalTitle");
+			var icon = document.getElementById("confirmModalIcon");
+			var message = document.getElementById("confirmModalMessage");
+			var okBtn = document.getElementById("confirmOkBtn");
+			var cancelBtn = document.getElementById("confirmCancelBtn");
+
+			var previouslyFocused = document.activeElement;
+
+			if (title) title.textContent = options.title || "Best\u00e4tigung erforderlich";
+			if (icon) icon.textContent = options.icon || "\u26a0\ufe0f";
+			if (message) {
+				message.innerHTML = (options.message || "M\u00f6chten Sie fortfahren?")
+					.replace(/\n/g, "<br>");
+			}
+			if (okBtn) okBtn.textContent = options.confirmText || "Best\u00e4tigen";
+			if (cancelBtn) cancelBtn.textContent = options.cancelText || "Abbrechen";
+
+			// Hide cancel button if no cancel text
+			if (cancelBtn) {
+				cancelBtn.style.display = options.cancelText === "" ? "none" : "block";
+			}
+
+			// Danger styling
+			if (okBtn) {
+				if (options.danger) {
+					okBtn.classList.add("btn-danger");
+				} else {
+					okBtn.classList.remove("btn-danger");
+				}
+			}
+
+			modal.style.display = "flex";
+			modal.setAttribute("aria-hidden", "false");
+
+			function closeAndResolve(result) {
+				modal.style.display = "none";
+				modal.setAttribute("aria-hidden", "true");
+				cleanup();
+				if (previouslyFocused && previouslyFocused.focus) {
+					previouslyFocused.focus();
+				}
+				resolve(result);
+			}
+
+			function handleOk() { closeAndResolve(true); }
+			function handleCancel() { closeAndResolve(false); }
+
+			function cleanup() {
+				if (okBtn) okBtn.removeEventListener("click", handleOk);
+				if (cancelBtn) cancelBtn.removeEventListener("click", handleCancel);
+				modal.removeEventListener("click", handleBackdropClick);
+				document.removeEventListener("keydown", handleKeyDown);
+			}
+
+			function handleBackdropClick(e) {
+				if (e.target === modal) {
+					handleCancel();
+				}
+			}
+
+			function handleKeyDown(e) {
+				if (e.key === "Escape") {
+					e.preventDefault();
+					handleCancel();
+				}
+			}
+
+			if (okBtn) okBtn.addEventListener("click", handleOk);
+			if (cancelBtn) cancelBtn.addEventListener("click", handleCancel);
+			modal.addEventListener("click", handleBackdropClick);
+			document.addEventListener("keydown", handleKeyDown);
+
+			// Focus appropriate button
+			setTimeout(function () {
+				if (options.danger && cancelBtn) {
+					cancelBtn.focus();
+				} else if (okBtn) {
+					okBtn.focus();
+				}
+			}, 100);
+		});
+	}
+
+	// Export to global scope
+	window.confirmAction = confirmAction;
+	window.GP = window.GP || {};
+	window.GP.confirmAction = confirmAction;
+})();

--- a/src/js/ui-states.js
+++ b/src/js/ui-states.js
@@ -1,0 +1,110 @@
+// ui-states.js - Unified loading, empty, error, and no-results state components
+// Provides reusable HTML rendering functions for consistent state display across the app.
+// Must be loaded BEFORE app.js and any module that renders states.
+
+(function () {
+	"use strict";
+
+	/**
+	 * Renders a loading state with a spinner animation.
+	 * @param {string} [message='Laden...'] - The loading message to display.
+	 * @returns {string} HTML string for the loading state.
+	 */
+	function renderLoadingState(message) {
+		if (message === undefined) message = "Laden...";
+		return '<div class="ui-state ui-state--loading">' +
+			'<div class="ui-state__spinner" aria-hidden="true"></div>' +
+			'<h3 class="ui-state__title">' + escapeHtml(message) + '</h3>' +
+			'</div>';
+	}
+
+	/**
+	 * Renders an empty state with icon, title, optional subtitle and action button.
+	 * @param {string} icon - Emoji or text icon to display.
+	 * @param {string} title - Main title text.
+	 * @param {string} [subtitle] - Optional subtitle/description text.
+	 * @param {string} [actionHtml] - Optional HTML string for an action button.
+	 * @returns {string} HTML string for the empty state.
+	 */
+	function renderEmptyState(icon, title, subtitle, actionHtml) {
+		var html = '<div class="ui-state ui-state--empty">' +
+			'<div class="ui-state__icon">' + escapeHtml(icon) + '</div>' +
+			'<h3 class="ui-state__title">' + escapeHtml(title) + '</h3>';
+		if (subtitle) {
+			html += '<p class="ui-state__subtitle">' + escapeHtml(subtitle) + '</p>';
+		}
+		if (actionHtml) {
+			html += '<div class="ui-state__action">' + actionHtml + '</div>';
+		}
+		html += '</div>';
+		return html;
+	}
+
+	/**
+	 * Renders an error state with message and optional retry button.
+	 * @param {string} message - The error message to display.
+	 * @param {Function} [retryCallback] - Optional callback function for a retry button.
+	 * @returns {string} HTML string for the error state.
+	 */
+	function renderErrorState(message, retryCallback) {
+		var retryId = retryCallback ? "uiStateRetry_" + Date.now() : null;
+		var html = '<div class="ui-state ui-state--error">' +
+			'<div class="ui-state__icon">&#x26A0;&#xFE0F;</div>' +
+			'<h3 class="ui-state__title">Etwas ist schiefgelaufen</h3>' +
+			'<p class="ui-state__subtitle">' + escapeHtml(message) + '</p>';
+		if (retryCallback) {
+			html += '<div class="ui-state__action">' +
+				'<button class="btn btn-secondary ui-state__retry-btn" id="' + retryId + '">Erneut versuchen</button>' +
+				'</div>';
+		}
+		html += '</div>';
+
+		// Attach retry callback after render via microtask
+		if (retryCallback && retryId) {
+			setTimeout(function () {
+				var btn = document.getElementById(retryId);
+				if (btn) {
+					btn.addEventListener("click", retryCallback);
+				}
+			}, 0);
+		}
+
+		return html;
+	}
+
+	/**
+	 * Renders a no-results state for search queries.
+	 * @param {string} searchTerm - The search term that yielded no results.
+	 * @returns {string} HTML string for the no-results state.
+	 */
+	function renderNoResultsState(searchTerm) {
+		return '<div class="ui-state ui-state--no-results">' +
+			'<div class="ui-state__icon">&#x1F50D;</div>' +
+			'<h3 class="ui-state__title">Keine Ergebnisse</h3>' +
+			'<p class="ui-state__subtitle">Keine Treffer f\u00fcr \u201e' + escapeHtml(searchTerm) + '\u201c gefunden.</p>' +
+			'<p class="ui-state__hint">Versuchen Sie einen anderen Suchbegriff.</p>' +
+			'</div>';
+	}
+
+	/**
+	 * Minimal HTML escaping for user-provided text.
+	 */
+	function escapeHtml(str) {
+		if (typeof Security !== "undefined" && Security.escapeHtml) {
+			return Security.escapeHtml(str);
+		}
+		var div = document.createElement("div");
+		div.appendChild(document.createTextNode(str));
+		return div.innerHTML;
+	}
+
+	// Export to global scope
+	window.UIStates = {
+		renderLoadingState: renderLoadingState,
+		renderEmptyState: renderEmptyState,
+		renderErrorState: renderErrorState,
+		renderNoResultsState: renderNoResultsState,
+	};
+	window.GP = window.GP || {};
+	window.GP.UIStates = window.UIStates;
+})();


### PR DESCRIPTION
## Summary
- **#105**: New `src/js/ui-states.js` with `renderLoadingState()`, `renderEmptyState()`, `renderErrorState()`, `renderNoResultsState()`
- **#149**: New `src/js/confirm-dialog.js` with `confirmAction()` returning Promise

Note: Script tags and CSS integration pending follow-up commit.

Closes #105, closes #149

## Test plan
- [ ] UI state components render correctly
- [ ] Confirmation dialog shows on delete/archive actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)