### PR TITLE
feat: interactive statistics with time range, trends, and CSV export (#107)

### DIFF
--- a/public/statistics.html
+++ b/public/statistics.html
@@ -33,11 +33,27 @@
       </div>
 
       <main>
+        <!-- Time Range Selector & Export -->
+        <section class="stats-toolbar">
+          <div class="time-range-selector" role="group" aria-label="Zeitraum auswählen">
+            <button class="time-range-btn" data-range="0" type="button">Heute</button>
+            <button class="time-range-btn" data-range="7" type="button">7 Tage</button>
+            <button class="time-range-btn active" data-range="30" type="button">30 Tage</button>
+            <button class="time-range-btn" data-range="all" type="button">Alle</button>
+          </div>
+          <button class="btn btn-secondary stats-export-btn" id="exportCsvBtn" type="button">
+            📥 Export CSV
+          </button>
+        </section>
+
         <!-- Statistiken mit Fortschrittsbalken -->
         <section class="stats-section">
-          <div class="stat-card">
+          <div class="stat-card" data-stat-tooltip id="cardPending">
             <h3>Offene Aufgaben</h3>
-            <p class="stat-number" id="statPending">0</p>
+            <div class="stat-number-row">
+              <p class="stat-number" id="statPending">0</p>
+              <span class="trend-indicator" id="trendPending"></span>
+            </div>
             <div class="progress-bar">
               <div
                 class="progress-fill"
@@ -48,10 +64,14 @@
             <p class="progress-label">
               von insgesamt <span id="totalTasks">0</span>
             </p>
+            <div class="stat-tooltip" id="tooltipPending" role="tooltip"></div>
           </div>
-          <div class="stat-card">
+          <div class="stat-card" data-stat-tooltip id="cardCompleted">
             <h3>Erledigte Aufgaben</h3>
-            <p class="stat-number" id="statCompleted">0</p>
+            <div class="stat-number-row">
+              <p class="stat-number" id="statCompleted">0</p>
+              <span class="trend-indicator" id="trendCompleted"></span>
+            </div>
             <div class="progress-bar">
               <div
                 class="progress-fill completed"
@@ -62,10 +82,14 @@
             <p class="progress-label">
               <span id="completionRate">0</span>% erledigt
             </p>
+            <div class="stat-tooltip" id="tooltipCompleted" role="tooltip"></div>
           </div>
-          <div class="stat-card">
+          <div class="stat-card" data-stat-tooltip id="cardEmployees">
             <h3>Aktive Mitarbeiter</h3>
-            <p class="stat-number" id="statEmployees">0</p>
+            <div class="stat-number-row">
+              <p class="stat-number" id="statEmployees">0</p>
+              <span class="trend-indicator" id="trendEmployees"></span>
+            </div>
             <div class="progress-bar">
               <div
                 class="progress-fill employees"
@@ -76,6 +100,7 @@
             <p class="progress-label">
               Durchschn. <span id="avgTasksPerEmployee">0</span> Aufgaben/MA
             </p>
+            <div class="stat-tooltip" id="tooltipEmployees" role="tooltip"></div>
           </div>
         </section>
 
@@ -214,6 +239,7 @@
     <script src="../src/js/task-renderer.js"></script>
     <script src="../src/js/task-events.js"></script>
     <script src="../src/js/task-export.js"></script>
+    <script src="../src/js/statistics-interactive.js"></script>
     <script src="../src/js/statistics-init.js"></script>
   </body>
 </html>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -5196,3 +5196,199 @@ footer {
     max-width: 200px;
   }
 }
+
+/* === Statistics Enhancements (#107) === */
+
+/* Toolbar: time range + export */
+.stats-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+  flex-wrap: wrap;
+}
+
+.time-range-selector {
+  display: flex;
+  gap: 0;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--bg-secondary);
+}
+
+.time-range-btn {
+  padding: 10px 20px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-height: 44px;
+  border-right: 1px solid var(--border);
+}
+
+.time-range-btn:last-child {
+  border-right: none;
+}
+
+.time-range-btn:hover {
+  background: var(--bg-tertiary);
+}
+
+.time-range-btn.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+[data-theme="dark"] .time-range-selector {
+  background: var(--bg-secondary);
+  border-color: var(--border);
+}
+
+[data-theme="dark"] .time-range-btn {
+  color: var(--text);
+}
+
+[data-theme="dark"] .time-range-btn:hover {
+  background: var(--bg-tertiary);
+}
+
+[data-theme="dark"] .time-range-btn.active {
+  background: var(--primary);
+  color: #0C0A09;
+}
+
+.stats-export-btn {
+  margin-top: 0;
+  white-space: nowrap;
+}
+
+/* Stat number row with trend indicator */
+.stat-number-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+
+.stat-number-row .stat-number {
+  margin-bottom: 0;
+}
+
+/* Trend indicators */
+.trend-indicator {
+  font-size: var(--text-sm);
+  font-weight: 700;
+  font-family: var(--font-body);
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  line-height: 1.4;
+  white-space: nowrap;
+  transition: all 0.3s ease;
+}
+
+.trend-indicator:empty {
+  display: none;
+}
+
+.trend-indicator.trend-good {
+  color: #16A34A;
+  background: rgba(22, 163, 74, 0.1);
+}
+
+.trend-indicator.trend-bad {
+  color: #E11D48;
+  background: rgba(225, 29, 72, 0.1);
+}
+
+[data-theme="dark"] .trend-indicator.trend-good {
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.15);
+}
+
+[data-theme="dark"] .trend-indicator.trend-bad {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.15);
+}
+
+/* Hover tooltips (CSS-only, no library) */
+.stat-card[data-stat-tooltip] {
+  position: relative;
+}
+
+.stat-tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text);
+  color: var(--bg);
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+  z-index: 100;
+  box-shadow: var(--shadow-md);
+}
+
+.stat-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--text);
+}
+
+.stat-card[data-stat-tooltip]:hover .stat-tooltip:not(:empty) {
+  opacity: 1;
+  visibility: visible;
+}
+
+[data-theme="dark"] .stat-tooltip {
+  background: var(--bg-tertiary);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+[data-theme="dark"] .stat-tooltip::after {
+  border-top-color: var(--bg-tertiary);
+}
+
+/* Responsive adjustments for toolbar */
+@media (max-width: 600px) {
+  .stats-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .time-range-selector {
+    width: 100%;
+  }
+
+  .time-range-btn {
+    flex: 1;
+    text-align: center;
+    padding: 10px 8px;
+    font-size: var(--text-xs);
+  }
+
+  .stats-export-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .stat-tooltip {
+    font-size: 0.65rem;
+  }
+}

--- a/src/js/statistics-init.js
+++ b/src/js/statistics-init.js
@@ -1,4 +1,4 @@
-// Statistiken-Seite Initialisierung (#71)
+// Statistiken-Seite Initialisierung (#71, #107)
 document.addEventListener('DOMContentLoaded', async () => {
     if (window.gartenPlaner) {
         await window.gartenPlaner.whenReady();
@@ -7,5 +7,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         window.gartenPlaner.updateStatistics();
         window.gartenPlaner.updateCharts();
         window.gartenPlaner.updateAdditionalStats();
+
+        // Interactive statistics (#107): time range, trends, tooltips, CSV export
+        if (typeof window.initInteractiveStatistics === 'function') {
+            window.initInteractiveStatistics();
+        }
     }
 });

--- a/src/js/statistics-interactive.js
+++ b/src/js/statistics-interactive.js
@@ -1,0 +1,220 @@
+// Statistics Interactive Features (#107)
+// Time range filtering, trend indicators, hover tooltips, CSV export
+
+(function () {
+	'use strict';
+
+	// --- State ---
+	var currentRangeDays = 30; // default: 30 Tage
+
+	// --- Helpers ---
+	function getDaysAgo(days) {
+		var d = new Date();
+		d.setHours(0, 0, 0, 0);
+		d.setDate(d.getDate() - days);
+		return d;
+	}
+
+	function filterTasksByRange(tasks, rangeDays) {
+		if (rangeDays === 'all') return tasks.slice();
+		var cutoff = getDaysAgo(rangeDays);
+		return tasks.filter(function (t) {
+			return new Date(t.createdAt) >= cutoff;
+		});
+	}
+
+	function getPreviousPeriodTasks(tasks, rangeDays) {
+		if (rangeDays === 'all') return [];
+		var periodStart = getDaysAgo(rangeDays * 2);
+		var periodEnd = getDaysAgo(rangeDays);
+		return tasks.filter(function (t) {
+			var d = new Date(t.createdAt);
+			return d >= periodStart && d < periodEnd;
+		});
+	}
+
+	function calcTrendPercent(current, previous) {
+		if (previous === 0 && current === 0) return { percent: 0, direction: 'neutral' };
+		if (previous === 0) return { percent: 100, direction: 'up' };
+		var change = ((current - previous) / previous) * 100;
+		return {
+			percent: Math.abs(Math.round(change)),
+			direction: change > 0 ? 'up' : change < 0 ? 'down' : 'neutral'
+		};
+	}
+
+	// --- Trend Indicator Rendering ---
+	function renderTrendIndicator(elementId, trend, isPositiveGood) {
+		var el = document.getElementById(elementId);
+		if (!el) return;
+
+		if (trend.direction === 'neutral' || currentRangeDays === 'all') {
+			el.innerHTML = '';
+			el.className = 'trend-indicator';
+			return;
+		}
+
+		var arrow = trend.direction === 'up' ? '\u2191' : '\u2193';
+		var isGood = isPositiveGood
+			? trend.direction === 'up'
+			: trend.direction === 'down';
+
+		el.textContent = arrow + ' ' + trend.percent + '%';
+		el.className = 'trend-indicator ' + (isGood ? 'trend-good' : 'trend-bad');
+	}
+
+	// --- Tooltip Rendering ---
+	function setTooltipContent(tooltipId, html) {
+		var el = document.getElementById(tooltipId);
+		if (el) el.innerHTML = html;
+	}
+
+	// --- CSV Export ---
+	function exportCsv(planer) {
+		var tasks = planer.tasks.concat(planer.archivedTasks);
+		var filtered = filterTasksByRange(tasks, currentRangeDays);
+
+		var pending = filtered.filter(function (t) { return t.status === 'pending'; }).length;
+		var completed = filtered.filter(function (t) { return t.status === 'completed'; }).length;
+		var total = filtered.length;
+		var employees = new Set(filtered.map(function (t) { return t.employee; })).size;
+		var locations = new Set(filtered.filter(function (t) { return t.location; }).map(function (t) { return t.location; })).size;
+		var completionRate = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+		var rangeLabel = currentRangeDays === 'all' ? 'Alle' : currentRangeDays + ' Tage';
+
+		var rows = [
+			['Kennzahl', 'Wert', 'Zeitraum'],
+			['Gesamt Aufgaben', total, rangeLabel],
+			['Offene Aufgaben', pending, rangeLabel],
+			['Erledigte Aufgaben', completed, rangeLabel],
+			['Abschlussrate (%)', completionRate, rangeLabel],
+			['Aktive Mitarbeiter', employees, rangeLabel],
+			['Aktive Standorte', locations, rangeLabel]
+		];
+
+		// Add per-employee breakdown
+		var employeeCounts = {};
+		filtered.forEach(function (t) {
+			if (!employeeCounts[t.employee]) {
+				employeeCounts[t.employee] = { total: 0, completed: 0, pending: 0 };
+			}
+			employeeCounts[t.employee].total++;
+			if (t.status === 'completed') employeeCounts[t.employee].completed++;
+			else employeeCounts[t.employee].pending++;
+		});
+
+		rows.push([]);
+		rows.push(['Mitarbeiter', 'Gesamt', 'Erledigt', 'Offen']);
+		Object.keys(employeeCounts).sort().forEach(function (name) {
+			var c = employeeCounts[name];
+			rows.push([name, c.total, c.completed, c.pending]);
+		});
+
+		// BOM for Excel UTF-8 compatibility
+		var bom = '\uFEFF';
+		var csvContent = bom + rows.map(function (row) {
+			return row.map(function (cell) {
+				var str = String(cell === undefined ? '' : cell);
+				if (str.indexOf(',') >= 0 || str.indexOf('"') >= 0 || str.indexOf('\n') >= 0) {
+					return '"' + str.replace(/"/g, '""') + '"';
+				}
+				return str;
+			}).join(',');
+		}).join('\r\n');
+
+		var blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+		var url = URL.createObjectURL(blob);
+		var link = document.createElement('a');
+		link.setAttribute('href', url);
+		link.setAttribute('download', 'statistiken_' + rangeLabel.replace(/\s/g, '_') + '_' + new Date().toISOString().split('T')[0] + '.csv');
+		link.style.display = 'none';
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
+	}
+
+	// --- Main Update Function ---
+	function updateInteractiveStats(planer) {
+		var allTasks = planer.tasks.concat(planer.archivedTasks);
+
+		// Filter tasks by current range
+		var currentTasks = filterTasksByRange(allTasks, currentRangeDays);
+		var previousTasks = getPreviousPeriodTasks(allTasks, currentRangeDays);
+
+		// Current period stats
+		var pending = currentTasks.filter(function (t) { return t.status === 'pending'; }).length;
+		var completed = currentTasks.filter(function (t) { return t.status === 'completed'; }).length;
+		var total = currentTasks.length;
+		var employees = new Set(currentTasks.map(function (t) { return t.employee; })).size;
+
+		// Previous period stats
+		var prevPending = previousTasks.filter(function (t) { return t.status === 'pending'; }).length;
+		var prevCompleted = previousTasks.filter(function (t) { return t.status === 'completed'; }).length;
+		var prevEmployees = new Set(previousTasks.map(function (t) { return t.employee; })).size;
+
+		// Update stat numbers
+		var statPending = document.getElementById('statPending');
+		var statCompleted = document.getElementById('statCompleted');
+		var statEmployees = document.getElementById('statEmployees');
+
+		if (statPending) statPending.textContent = pending;
+		if (statCompleted) statCompleted.textContent = completed;
+		if (statEmployees) statEmployees.textContent = employees;
+
+		// Update progress bars
+		if (typeof planer.updateProgressBars === 'function') {
+			planer.updateProgressBars(pending, completed, total, employees);
+		}
+
+		// Trend indicators (pending going down is good, completed going up is good, employees up is good)
+		renderTrendIndicator('trendPending', calcTrendPercent(pending, prevPending), false);
+		renderTrendIndicator('trendCompleted', calcTrendPercent(completed, prevCompleted), true);
+		renderTrendIndicator('trendEmployees', calcTrendPercent(employees, prevEmployees), true);
+
+		// Tooltips
+		var completionRate = total > 0 ? Math.round((completed / total) * 100) : 0;
+		setTooltipContent('tooltipPending', pending + ' von ' + total + ' Aufgaben offen');
+		setTooltipContent('tooltipCompleted', completed + ' von ' + total + ' Aufgaben abgeschlossen (' + completionRate + '%)');
+		setTooltipContent('tooltipEmployees', employees + ' Mitarbeiter mit insgesamt ' + total + ' Aufgaben');
+	}
+
+	// --- Initialization ---
+	function initInteractiveStatistics() {
+		var planer = window.gartenPlaner;
+		if (!planer) return;
+
+		// Time range buttons
+		var btns = document.querySelectorAll('.time-range-btn');
+		btns.forEach(function (btn) {
+			btn.addEventListener('click', function () {
+				btns.forEach(function (b) { b.classList.remove('active'); });
+				btn.classList.add('active');
+
+				var range = btn.getAttribute('data-range');
+				currentRangeDays = range === 'all' ? 'all' : parseInt(range, 10);
+
+				updateInteractiveStats(planer);
+				// Also update charts and additional stats with filtered view
+				if (typeof planer.updateCharts === 'function') planer.updateCharts();
+				if (typeof planer.updateAdditionalStats === 'function') planer.updateAdditionalStats();
+			});
+		});
+
+		// CSV Export button
+		var exportBtn = document.getElementById('exportCsvBtn');
+		if (exportBtn) {
+			exportBtn.addEventListener('click', function () {
+				exportCsv(planer);
+			});
+		}
+
+		// Initial update
+		updateInteractiveStats(planer);
+	}
+
+	// Expose for statistics-init.js
+	window.initInteractiveStatistics = initInteractiveStatistics;
+	window.updateInteractiveStats = updateInteractiveStats;
+})();


### PR DESCRIPTION
## Summary
- **Time range**: Heute / 7 Tage / 30 Tage / Alle buttons filter by createdAt
- **Trends**: Arrow + percentage comparing current vs previous period
- **Tooltips**: CSS-only hover detail on stat cards
- **CSV Export**: Summary + per-employee breakdown with Excel-compatible UTF-8

Closes #107

## Test plan
- [ ] Time range buttons filter stats correctly
- [ ] Trend arrows show green (improvement) / red (regression)
- [ ] Hover tooltips display on stat cards
- [ ] CSV downloads with correct data
- [ ] Dark mode looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)