### PR TITLE
fix: replace internal registry URLs in lockfile for CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,7 +1769,7 @@
     },
     "node_modules/bcrypt": {
       "version": "6.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/bcrypt/-/bcrypt-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
       "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -1861,7 +1861,7 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
@@ -2373,7 +2373,7 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3942,7 +3942,7 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
       "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
       "dependencies": {
@@ -3964,13 +3964,13 @@
     },
     "node_modules/jsonwebtoken/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/ms/-/ms-2.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
@@ -3982,7 +3982,7 @@
     },
     "node_modules/jwa": {
       "version": "2.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jwa/-/jwa-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
       "dependencies": {
@@ -3993,7 +3993,7 @@
     },
     "node_modules/jws": {
       "version": "4.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/jws/-/jws-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
@@ -4033,43 +4033,43 @@
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
@@ -4283,7 +4283,7 @@
     },
     "node_modules/node-addon-api": {
       "version": "8.7.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
       "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
       "license": "MIT",
       "engines": {
@@ -4292,7 +4292,7 @@
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
       "bin": {
@@ -4557,7 +4557,7 @@
     },
     "node_modules/pg": {
       "version": "8.20.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pg/-/pg-8.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
       "dependencies": {
@@ -4584,20 +4584,20 @@
     },
     "node_modules/pg-cloudflare": {
       "version": "1.3.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
       "version": "2.12.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
       "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pg-int8/-/pg-int8-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
       "license": "ISC",
       "engines": {
@@ -4606,7 +4606,7 @@
     },
     "node_modules/pg-pool": {
       "version": "3.13.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pg-pool/-/pg-pool-3.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
       "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
       "license": "MIT",
       "peerDependencies": {
@@ -4615,13 +4615,13 @@
     },
     "node_modules/pg-protocol": {
       "version": "1.13.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
       "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pg-types/-/pg-types-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "license": "MIT",
       "dependencies": {
@@ -4637,7 +4637,7 @@
     },
     "node_modules/pgpass": {
       "version": "1.0.5",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/pgpass/-/pgpass-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
       "license": "MIT",
       "dependencies": {
@@ -4771,7 +4771,7 @@
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/postgres-array/-/postgres-array-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
       "license": "MIT",
       "engines": {
@@ -4780,7 +4780,7 @@
     },
     "node_modules/postgres-bytea": {
       "version": "1.0.1",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
       "engines": {
@@ -4789,7 +4789,7 @@
     },
     "node_modules/postgres-date": {
       "version": "1.0.7",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/postgres-date/-/postgres-date-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
       "license": "MIT",
       "engines": {
@@ -4798,7 +4798,7 @@
     },
     "node_modules/postgres-interval": {
       "version": "1.2.0",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
       "dependencies": {
@@ -5972,7 +5972,7 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "resolved": "https://repo.inform-software.com/artifactory/api/npm/npmjs/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
Replace 30 internal `repo.inform-software.com` resolved URLs with `registry.npmjs.org` in `package-lock.json`. New dependencies (pg, bcrypt, jsonwebtoken) were installed locally via internal proxy, but CI needs public URLs.

## Test plan
- [ ] Docker publish build succeeds