### PR TITLE
feat: add automated PostgreSQL backup with retention (#143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,40 @@ curl -X POST http://localhost:8080/api/tasks \
   }
   ```
 
+## Backup & Restore
+
+Die PostgreSQL-Datenbank wird automatisch gesichert.
+
+### Automatisches Backup
+
+- Der `backup`-Service erstellt **täglich um 2:00 Uhr** ein komprimiertes Backup (`pg_dump | gzip`)
+- Es werden maximal **7 Backups** aufbewahrt, ältere werden automatisch gelöscht
+- Backups werden im Docker Volume `backup-data` unter `/backups/` gespeichert
+
+### Manuelles Backup
+
+```bash
+docker exec gartenplaner-backup /scripts/backup.sh
+```
+
+### Restore
+
+```bash
+# Verfügbare Backups anzeigen
+docker exec gartenplaner-backup /scripts/restore.sh
+
+# Bestimmtes Backup wiederherstellen
+docker exec gartenplaner-backup /scripts/restore.sh /backups/<dateiname>.sql.gz
+```
+
+### Backup-Speicherort
+
+Die Backups liegen im Docker Volume `backup-data`. Um sie lokal zu kopieren:
+
+```bash
+docker cp gartenplaner-backup:/backups/ ./local-backups/
+```
+
 ## Konfiguration
 
 Umgebungsvariablen (siehe `.env.example`):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,23 @@ services:
       timeout: 3s
       retries: 5
 
+  backup:
+    image: postgres:16-alpine
+    container_name: gartenplaner-backup
+    environment:
+      - PGPASSWORD=gartenplaner
+    volumes:
+      - ./scripts:/scripts:ro
+      - backup-data:/backups
+    depends_on:
+      db:
+        condition: service_healthy
+    entrypoint: /bin/sh
+    command: >
+      -c "echo '0 2 * * * /scripts/backup.sh >> /var/log/backup.log 2>&1' | crontab - && crond -f -l 2"
+    restart: unless-stopped
+
 volumes:
   gartenplaner-data:
   db-data:
+  backup-data:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+BACKUP_DIR="/backups"
+TIMESTAMP=$(date +%Y-%m-%d_%H%M%S)
+FILENAME="gartenplaner_${TIMESTAMP}.sql.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "[$(date)] Starting backup..."
+pg_dump -h db -U gartenplaner gartenplaner | gzip > "${BACKUP_DIR}/${FILENAME}"
+echo "[$(date)] Backup saved: ${FILENAME} ($(du -h "${BACKUP_DIR}/${FILENAME}" | cut -f1))"
+
+# Keep only last 7 backups
+ls -t "${BACKUP_DIR}"/gartenplaner_*.sql.gz 2>/dev/null | tail -n +8 | xargs -r rm
+echo "[$(date)] Cleanup done. Backups: $(ls "${BACKUP_DIR}"/gartenplaner_*.sql.gz 2>/dev/null | wc -l)"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: ./scripts/restore.sh <backup-file.sql.gz>"
+    echo "Available backups:"
+    ls -lh /backups/gartenplaner_*.sql.gz 2>/dev/null || echo "No backups found"
+    exit 1
+fi
+
+echo "[$(date)] Restoring from $1..."
+gunzip -c "$1" | psql -h db -U gartenplaner gartenplaner
+echo "[$(date)] Restore complete."


### PR DESCRIPTION
## Summary
- `scripts/backup.sh` — daily pg_dump, gzip compressed, 7 backups retained
- `scripts/restore.sh` — restore from backup file
- Docker Compose `backup` service with cron (daily 2am)
- README section with backup/restore docs

Closes #143

## Test plan
- [ ] `docker exec gartenplaner-backup /scripts/backup.sh` creates backup
- [ ] Backup file in `backup-data` volume
- [ ] Restore works with `restore.sh`