### PR TITLE
feat: add comprehensive plant care guides to library (#51)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"02ad7776-dddb-4c05-b4f0-b1c0a07f71e6","pid":16280,"acquiredAt":1774985784188}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -84,7 +84,8 @@
       "Bash(node -e \"const p = require\\(''./package-lock.json''\\); const pkg = p.packages[''node_modules/picomatch'']; console.log\\(JSON.stringify\\(pkg, null, 2\\)\\);\")",
       "Bash(npm pack:*)",
       "Bash(cmd //c \"mklink /J \"\"C:\\\\Git\\\\GardenPlanner\\\\.claude\\\\worktrees\\\\agent-a2cf477e\\\\node_modules\"\" \"\"C:\\\\Git\\\\GardenPlanner\\\\.claude\\\\worktrees\\\\agent-a9c844b1\\\\node_modules\"\"\")",
-      "Bash(cmd.exe /c 'mklink /J node_modules \"\"C:\\\\Git\\\\GardenPlanner\\\\.claude\\\\worktrees\\\\agent-a9c844b1\\\\node_modules\"\"')"
+      "Bash(cmd.exe /c 'mklink /J node_modules \"\"C:\\\\Git\\\\GardenPlanner\\\\.claude\\\\worktrees\\\\agent-a9c844b1\\\\node_modules\"\"')",
+      "Bash(GIT_EDITOR=true git rebase --continue)"
     ]
   }
 }

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,414 @@
+# GardenPlanner - Implementation Plan
+
+> Generated: 2026-03-30 | Status: Active
+> Based on: Full Team Review (Designer, Frontend-Dev, Backend-Dev, Security-Dev, Reviewer)
+
+---
+
+## Overview
+
+| Phase | Focus | Effort | Issues |
+|-------|-------|--------|--------|
+| **Phase 1** | Quick Wins: Security & Performance | 1-2 hours | 6 issues |
+| **Phase 2** | Critical Security Hardening | 1-2 weeks | 5 issues |
+| **Phase 3** | Frontend Consolidation | 3-5 days | 4 issues |
+| **Phase 4** | Code Quality & DX | 1-2 weeks | 5 issues |
+| **Phase 5** | Feature Enhancements | 1-2 weeks | 4 issues |
+| **Phase 6** | Major Features | 3-6 weeks | 3 issues |
+| **Phase 7** | PWA & Polish | 1-2 weeks | 3 issues |
+
+**Total estimated effort:** 10-16 weeks (single developer)
+
+---
+
+## Phase 1: Quick Wins - Security & Performance Hardening
+
+> **Goal:** Low-risk, high-impact improvements. All server-config changes, each under 15 minutes.
+> **Effort:** 1-2 hours | **Risk:** Low
+
+### Tasks
+
+- [ ] **#114** Remove deprecated X-XSS-Protection header `[security, backend, low]`
+  - Remove the X-XSS-Protection header line from security middleware
+  - CSP is already in place and sufficient
+  - File: `src/server/middleware/security.js`
+
+- [ ] **#116** Add Strict-Transport-Security (HSTS) header `[security, backend, low]`
+  - Add HSTS header in production mode only
+  - Protects against HTTPS downgrade attacks
+  - File: `src/server/middleware/security.js`
+
+- [ ] **#115** Block /src route in production mode `[security, backend, low]`
+  - Prevent source code exposure in production
+  - Analog to existing /tests, /docs blocking
+  - File: `src/server/app.js`
+
+- [ ] **#122** Remove unused cors dependency `[backend, code-quality, low]`
+  - `npm uninstall cors` and clean package.json
+  - Dead code removal
+
+- [ ] **#118** Scope rate limiter to /api routes only `[backend, performance, low]`
+  - Change `app.use(limiter)` to `app.use('/api', limiter)`
+  - Prevents double rate-limiting of static assets
+  - File: `src/server/app.js`
+
+- [ ] **#119** Add Cache-Control headers for static assets `[frontend, backend, performance, low]`
+  - Add `maxAge: '1d'` to express.static middleware
+  - File: `src/server/app.js`
+
+### Suggested PRs
+1. PR: Security Headers (#114 + #116)
+2. PR: Cleanup (#115 + #122)
+3. PR: Performance (#118 + #119)
+
+### Done Criteria
+- [ ] All 6 issues closed
+- [ ] Server starts without errors
+- [ ] Existing tests pass
+
+---
+
+## Phase 2: Critical Security Hardening
+
+> **Goal:** Address critical security findings from the team review.
+> **Effort:** 1-2 weeks | **Risk:** Medium-High (auth changes affect all users)
+
+### Dependencies
+- Phase 1 completed (security baseline)
+
+### Tasks
+
+- [ ] **#137** Implement JWT authentication replacing localStorage API-Key `[security, high]`
+  - Replace plaintext API-Key in localStorage with JWT + HttpOnly Cookie
+  - JWT with 1h TTL, refresh token logic
+  - Key rotation mechanism
+  - Files: `src/server/routes/auth.js`, `src/js/api.js`, `src/server/middleware/auth.js`
+
+- [ ] **#138** Sanitize error messages in production `[security, high]`
+  - Generic error messages to client in production
+  - Detailed logs only server-side
+  - No internal structure exposure (e.g. "Lock timeout for tasks.json")
+  - Files: `src/server/middleware/error-handler.js`, `src/server/logger.js`
+
+- [ ] **#139** Implement per-IP/per-key rate limiting `[security, backend, high]`
+  - Goes beyond #118 (which only scopes to /api)
+  - Use express-rate-limit with store (redis/memstore)
+  - Per-IP + per-key tracking to prevent DoS
+  - File: `src/server/app.js`, new `src/server/middleware/rate-limit.js`
+
+- [ ] **#140** CSP hardening: remove unsafe-inline `[security, medium]`
+  - Generate nonce server-side for style-src
+  - Remove `unsafe-inline` from Content Security Policy
+  - Add Report-Only mode for monitoring
+  - Files: `src/server/middleware/security.js`, `public/*.html`
+
+- [ ] **#141** Fix npm audit in Dockerfile `[security, medium]`
+  - Remove `|| true` from `npm audit` in Dockerfile
+  - Make security findings fail the build
+  - File: `Dockerfile`
+
+### Suggested PRs
+1. PR: JWT Authentication (largest change, separate branch)
+2. PR: Error Sanitization + CSP Hardening
+3. PR: Rate Limiting
+4. PR: Dockerfile Security
+
+### Done Criteria
+- [ ] API-Key no longer stored in localStorage
+- [ ] JWT auth working with token refresh
+- [ ] Error messages generic in production
+- [ ] Per-IP rate limiting active
+- [ ] CSP without unsafe-inline
+- [ ] npm audit passes in Docker build
+
+---
+
+## Phase 3: Frontend Consolidation
+
+> **Goal:** Create consistent UI foundation for all future feature work.
+> **Effort:** 3-5 days | **Risk:** Low-Medium
+
+### Dependencies
+- Phase 2 completed (auth changes affect frontend)
+
+### Tasks
+
+- [ ] **#106** Move logs page inline CSS to stylesheet and fix semantic HTML `[frontend, code-quality, medium]`
+  - Extract 294 lines of inline CSS to external stylesheet
+  - Add semantic HTML structure and ARIA roles
+  - Add confirmation dialog for "Delete Logs"
+  - Files: `public/logs.html`, `src/css/styles.css`
+
+- [ ] **#105** Unify loading, empty, error, and no-results states `[enhancement, frontend, medium]`
+  - Create reusable state components (Loading/Skeleton, Empty, Error, No-Results)
+  - Migrate all 5+ existing inconsistent variants
+  - Test in Dark Mode
+  - **Blocked by:** #106
+
+- [ ] **#149** Add confirmation dialogs for critical actions `[frontend, UX, medium]`
+  - Task deletion, API-Key changes, bulk operations
+  - With undo possibility
+  - Files: `src/js/`
+
+- [ ] **#150** Fix tempSubtasks potential memory leak `[frontend, medium]`
+  - Implement cleanup mechanism for tempSubtasks state
+  - Verify no orphaned state after modal close/navigation
+  - Files: `src/js/`
+
+### Suggested PRs
+1. PR: Logs page refactoring (#106)
+2. PR: Unified state components (#105) — after #106
+3. PR: Confirmation dialogs + memory leak fix
+
+### Done Criteria
+- [ ] No inline CSS in logs page
+- [ ] All state displays use unified components
+- [ ] Confirmation dialogs on destructive actions
+- [ ] No memory leaks in subtask handling
+
+---
+
+## Phase 4: Code Quality & Developer Experience
+
+> **Goal:** Improve maintainability, reduce tech debt, establish better DX.
+> **Effort:** 1-2 weeks | **Risk:** Low
+
+### Dependencies
+- Phase 3 completed (CSS consolidated before build pipeline)
+
+### Tasks
+
+- [ ] **#144** Deduplicate escapeHtml() and sanitizeTaskData() `[code-quality, medium]`
+  - Create shared validation module
+  - Remove duplicates from `src/js/security.js` and `src/server/validation/task-validator.js`
+  - DRY principle
+
+- [ ] **#145** Replace magic numbers with central configuration `[code-quality, medium]`
+  - Rate limits, lock timeout, cache age, pagination defaults
+  - Create central config with named constants
+  - Files: `rate-limiter.js`, `json-store.js`, `api.js`
+
+- [ ] **#146** Unify error return types in services `[code-quality, medium]`
+  - Consistent `{ error, status, message, errors? }` format
+  - All service methods follow same pattern
+  - File: `src/server/services/task-service.js`
+
+- [ ] **#147** Migrate frontend tests from HTML to Jest `[testing, medium]`
+  - Convert `encryption-test.html`, `security-test.html` etc. to Jest
+  - CI-compatible test runner
+  - Target: 60% coverage minimum
+  - Files: `tests/`
+
+- [ ] **#148** Add JSDoc type hints `[code-quality, medium]`
+  - Start with server functions, then client
+  - Create `types.js` with shared type definitions
+  - Preparation for potential TypeScript migration
+
+### Suggested PRs
+1. PR: Shared validation module (deduplication)
+2. PR: Central config constants
+3. PR: Error response unification
+4. PR: Jest frontend tests
+5. PR: JSDoc types
+
+### Done Criteria
+- [ ] No duplicated validation code
+- [ ] All magic numbers in central config
+- [ ] Consistent error responses
+- [ ] Frontend tests run in Jest/CI
+- [ ] JSDoc on all public functions
+
+---
+
+## Phase 5: Feature Enhancements (Existing Pages)
+
+> **Goal:** Enhance existing pages with better UX and functionality.
+> **Effort:** 1-2 weeks | **Risk:** Low
+
+### Dependencies
+- Phase 3 completed (unified state components available)
+
+### Tasks
+
+- [ ] **#108** Add sorting, result count, and favorites to plant library `[enhancement, frontend, low]`
+  - Sorting options for plants
+  - Result counter display
+  - Favorites via localStorage
+  - "No results" feedback using unified state component
+  - **Blocked by:** #105
+
+- [ ] **#107** Make statistics page interactive with time range and trends `[enhancement, frontend, medium]`
+  - Time range selector
+  - Trend indicators
+  - Hover tooltips
+  - Export (PDF/CSV)
+  - History filter and search
+  - **Blocked by:** #105
+
+- [ ] **#153** WCAG color contrast documentation `[accessibility, low]`
+  - Verify and document AA/AAA compliance
+  - Create contrast reference in docs
+
+- [ ] **#154** Weather API offline fallback `[frontend, low]`
+  - Graceful degradation when API unreachable
+  - Show cached/placeholder data
+  - File: `src/js/api.js`
+
+### Suggested PRs
+1. PR: Plant library enhancements (#108)
+2. PR: Statistics page (#107)
+3. PR: Accessibility + Weather fallback
+
+### Done Criteria
+- [ ] Plant library has sorting, favorites, result count
+- [ ] Statistics page is interactive with export
+- [ ] WCAG compliance documented
+- [ ] Weather works offline with cached data
+
+---
+
+## Phase 6: Major Features & Infrastructure
+
+> **Goal:** Core features that define the application + infrastructure for scale.
+> **Effort:** 3-6 weeks | **Risk:** High (major architecture changes)
+
+### Dependencies
+- Phase 4 completed (build pipeline, tests in place)
+
+### Tasks
+
+- [ ] **#142** Replace JSON file storage with PostgreSQL `[backend, high]`
+  - Design DB schema (tasks, users, audit_log, settings)
+  - Create migrations (Knex/Flyway)
+  - Update task-service.js for DB queries
+  - Add PostgreSQL service to docker-compose.yml
+  - Files: new `src/server/storage/postgres-store.js`, `docker-compose.yml`
+
+- [ ] **#143** Implement backup strategy `[devops, high]`
+  - Automated daily backups (pg_dump)
+  - Restore procedure tested
+  - **Blocked by:** PostgreSQL migration
+  - Files: new `scripts/backup.sh`, `Dockerfile`
+
+- [ ] **#47** Optimize Performance: Minification and Lazy Loading `[enhancement]`
+  - Set up Vite for frontend build (HMR, tree-shaking, minification)
+  - Code splitting and lazy loading
+  - **Note:** Related new issue about build pipeline (Phase 4) is prerequisite thinking
+
+- [ ] **#51** Plant Library with Care Guides `[enhancement]`
+  - Comprehensive plant database with care tips
+  - Integration into garden plans
+  - **Should complete before #48**
+
+- [ ] **#48** Interactive Garden Layout Planner `[enhancement]`
+  - Drag-and-drop interface for visual garden planning
+  - Grid system for beds, paths, plant placement
+  - **THE core feature of the entire application**
+  - **Blocked by:** #51 (needs plant data)
+  - Recommendation: Create technical design doc before implementation
+
+### Suggested PRs
+1. PR: PostgreSQL migration (separate branch, thorough review)
+2. PR: Backup strategy
+3. PR: Vite build pipeline (#47)
+4. PR: Plant Library (#51)
+5. PR: Garden Planner (#48) — largest feature, may need multiple PRs
+
+### Done Criteria
+- [ ] PostgreSQL running in Docker Compose
+- [ ] Daily automated backups with tested restore
+- [ ] Vite build producing optimized bundles
+- [ ] Plant library with care guides live
+- [ ] Interactive garden planner functional
+
+---
+
+## Phase 7: PWA, Monitoring & Polish
+
+> **Goal:** Production readiness, offline capability, observability.
+> **Effort:** 1-2 weeks | **Risk:** Medium
+
+### Dependencies
+- Phase 6 completed (features should be stable before PWA caching)
+
+### Tasks
+
+- [ ] **#46** Convert Application to Progressive Web App (PWA) `[enhancement]`
+  - Service Worker with caching strategy
+  - Web App Manifest for installability
+  - Offline fallback pages
+  - **Blocked by:** #47 (optimized assets for efficient caching)
+
+- [ ] **#151** Integrate Sentry for error monitoring `[devops, medium]`
+  - @sentry/node server-side
+  - @sentry/browser client-side
+  - Error capture and alerting
+  - Files: `src/server/app.js`, `src/js/app.js`
+
+- [ ] **#155** Multi-tab synchronization `[frontend, low]`
+  - BroadcastChannel API or Storage Events
+  - Sync task changes across browser tabs
+
+- [ ] **#156** Prepare API versioning `[backend, low]`
+  - Add /api/v1 prefix
+  - Backward compatibility for transition period
+  - Files: `src/server/routes/`
+
+- [ ] **#157** Evaluate encryption key storage `[security, low]`
+  - Review AES-GCM keys in IndexedDB
+  - Document threat boundaries
+  - Evaluate server-side encryption for sensitive data
+
+### Suggested PRs
+1. PR: PWA implementation (#46)
+2. PR: Sentry integration
+3. PR: Multi-tab sync + API versioning + encryption review
+
+### Done Criteria
+- [ ] App installable as PWA
+- [ ] Works offline with cached data
+- [ ] Errors tracked in Sentry
+- [ ] Tabs stay in sync
+- [ ] API versioned under /api/v1
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (Quick Wins)
+  │
+  ▼
+Phase 2 (Security) ──────────────────┐
+  │                                   │
+  ▼                                   │
+Phase 3 (Frontend) ──► Phase 5 (UX)  │
+  │                                   │
+  ▼                                   │
+Phase 4 (Quality/DX) ◄───────────────┘
+  │
+  ▼
+Phase 6 (Major Features)
+  │
+  ▼
+Phase 7 (PWA & Polish)
+```
+
+**Parallelization opportunities:**
+- Phase 3 + Phase 4 can partially overlap (different developers)
+- Phase 5 can start after Phase 3, parallel to Phase 4
+- In Phase 6: #51 + #47 can run in parallel, #48 starts after #51
+
+---
+
+## How to Use This Plan
+
+1. **Start a phase:** Create a branch for each PR grouping
+2. **Track progress:** Check off tasks as issues are closed
+3. **Review gates:** Each phase has "Done Criteria" — verify before moving on
+4. **Adapt:** Re-evaluate priorities after each phase completion
+5. **All issues are tracked in GitHub** (see issue tracker)
+
+---
+
+*This plan was generated from a full team review (Designer, Frontend-Dev, Backend-Dev, Security-Dev, Reviewer) of the GardenPlanner repository.*

--- a/docs/design-research-and-mockups.md
+++ b/docs/design-research-and-mockups.md
@@ -1,0 +1,1392 @@
+# GardenPlanner -- Design-Recherche, Analyse und Mock-Up-Konzepte
+
+---
+
+## Aufgabe 1: Recherche der 20 beliebtesten Garten-Planer Webseiten und Apps
+
+> **Hinweis:** Die Web-Suche war nicht verfuegbar. Die folgende Liste basiert auf vorhandenem Fachwissen (Stand: bis Mai 2025). Die Einschaetzungen zu Design und Features sind aus direkter Kenntnis der Produkte abgeleitet.
+
+---
+
+### 1. GrowVeg (growveg.com)
+- **Design-Stil:** Flach mit illustrativen Elementen, warme Erdtoene
+- **Besondere UI-Features:** Drag-and-Drop Beet-Planer, automatische Fruchtfolge-Empfehlungen, monatlicher E-Mail-Planer
+- **Beliebtheit:** Marktfuehrer bei Online-Gartenplanern; extrem intuitive Bedienung, grosse Pflanzen-Datenbank
+
+### 2. Garden Planner by SmallBluePrinter (smallblueprinter.com)
+- **Design-Stil:** Skeuomorph mit realistischen Pflanzensymbolen auf Raster-Hintergrund
+- **Besondere UI-Features:** Desktop-App-Feeling im Browser, Drag-and-Drop, Druckfunktion mit Massstaeben
+- **Beliebtheit:** Einer der aeltesten Online-Gartenplaner, bewaeehrte UX
+
+### 3. Planner Garden (plannergarden.com)
+- **Design-Stil:** Minimalistisch, flaches Design, helle Gruenetoene
+- **Besondere UI-Features:** Einfacher Grid-basierter Beet-Editor, responsive Design
+- **Beliebtheit:** Kostenlose Nutzung, einfacher Einstieg
+
+### 4. Gardena myGarden (my-garden.gardena.com)
+- **Design-Stil:** Modernes Flat-Design, Corporate Tuerkis/Orange
+- **Besondere UI-Features:** 3D-Gartenansicht, Bewaesserungsplanung, Produktintegration
+- **Beliebtheit:** Starke Marke, professionelle Bewaesserungsplanung, kostenlos
+
+### 5. iScape (iscapeapps.com)
+- **Design-Stil:** Modern, iOS-nativ, AR-basiert
+- **Besondere UI-Features:** Augmented Reality zur Gartenvisualisierung, Foto-basiertes Design
+- **Beliebtheit:** AR-Innovation, starke iOS-Integration, professionelle Ergebnisse
+
+### 6. Garden Puzzle (gardenpuzzle.com)
+- **Design-Stil:** Fotorealistisch mit Overlay-Elementen
+- **Besondere UI-Features:** Foto-Upload und Pflanzen-Overlay, realistische Vorschau
+- **Beliebtheit:** Einzigartiger Foto-basierter Ansatz, Community-Galerie
+
+### 7. Vegplotter (vegplotter.com)
+- **Design-Stil:** Einfach, flat, gruene Toene mit weissem Hintergrund
+- **Besondere UI-Features:** Companion-Planting-Hinweise, Aussaat-Kalender, Ernte-Tracker
+- **Beliebtheit:** Spezialisierung auf Gemuese, kostenlos, Community
+
+### 8. Almanac Garden Planner (garden.org/apps)
+- **Design-Stil:** Traditionell, editorial, warme Farben
+- **Besondere UI-Features:** Frostdatum-basierte Empfehlungen, regionale Anpassung, Pflanzensuche
+- **Beliebtheit:** The Old Farmer's Almanac -- enormes Vertrauen und Wissensbasis
+
+### 9. Planta (getplanta.com)
+- **Design-Stil:** Modern, Flat, sanfte Pastelltoene, organische Formen
+- **Besondere UI-Features:** KI-basierte Pflanzenidentifikation, Giessplan, Push-Notifications, Light-Meter
+- **Beliebtheit:** Top-bewertete App fuer Zimmerpflanzen, hervorragendes Onboarding
+
+### 10. PictureThis (picturethisai.com)
+- **Design-Stil:** Clean, weiss-dominiert, grosse Fotos
+- **Besondere UI-Features:** KI-Pflanzenerkennung per Foto, Krankheitsdiagnose, Pflegetipps
+- **Beliebtheit:** Ueber 100 Mio Downloads, marktfuehrend bei Pflanzenerkennung
+
+### 11. Gardenize (gardenize.com)
+- **Design-Stil:** Skandinavisch-minimalistisch, helles Gruen, viel Weissraum
+- **Besondere UI-Features:** Pflanzen-Tagebuch, Foto-Dokumentation, Kalender-Integration
+- **Beliebtheit:** Schwedisches Design, starkes Garten-Tagebuch-Konzept
+
+### 12. Moon & Garden (Google Play)
+- **Design-Stil:** Dunkel mit kosmischen Elementen, violett/blau
+- **Besondere UI-Features:** Mondphasen-basierte Gartenplanung, Biodynamik-Kalender
+- **Beliebtheit:** Nische der biodynamischen Gaertner, einzigartiges Konzept
+
+### 13. Crocus (crocus.co.uk)
+- **Design-Stil:** Editorial, E-Commerce-optimiert, Weiss mit Gruenakzent
+- **Besondere UI-Features:** Pflanzenfinder mit visuellen Filtern, Garteninspirationen
+- **Beliebtheit:** Groesster Online-Pflanzenhaendler UK, vertrauenswuerdige Empfehlungen
+
+### 14. Gardenia.net
+- **Design-Stil:** Informationsreich, editorial, gruene Toene
+- **Besondere UI-Features:** Garden Design Ideas Tool, Pflanzenkombinationen, regionale Empfehlungen
+- **Beliebtheit:** Umfangreiche Wissensdatenbank, kuratierte Gartendesigns
+
+### 15. Shoot Gardening (shootgardening.co.uk)
+- **Design-Stil:** Modern-editorial, helle sanfte Farben
+- **Besondere UI-Features:** Personalisierter Pflege-Kalender, Pflanzen-ID, Community
+- **Beliebtheit:** Britische Premium-Gartenplaner-App, kuratierte Inhalte
+
+### 16. SmartPlant (smartplantapp.com)
+- **Design-Stil:** Gruen-dominiert, kartenbasiertes Layout
+- **Besondere UI-Features:** Chat-basierte Pflanzenberatung, Experten-Antworten, Diagnose
+- **Beliebtheit:** Einzigartiger Chat-Support durch echte Gartenexperten
+
+### 17. Hortisketch
+- **Design-Stil:** Skizzenhaft, handgezeichnetes Feeling, warm
+- **Besondere UI-Features:** iPad-optimiert, Freihand-Gartenzeichnung, Layer-System
+- **Beliebtheit:** Kreativitaet und kuenstlerischer Ansatz, Landschaftsarchitekten
+
+### 18. Home Outside (homeoutside.com)
+- **Design-Stil:** Professionell, clean, grau/gruen
+- **Besondere UI-Features:** Drag-and-Drop Landschaftsdesign, Symbol-Bibliothek, Massstabsgetreu
+- **Beliebtheit:** Professionelle Landschaftsplaner nutzen es, praesentationsfaehige Outputs
+
+### 19. PRO Landscape (prolandscape.com)
+- **Design-Stil:** Business-professionell, dunkel, CAD-artig
+- **Besondere UI-Features:** Foto-Imaging, 3D-Rendering, CAD-Integration, Kostenkalkulation
+- **Beliebtheit:** Industriestandard fuer Landschaftsbau-Firmen
+
+### 20. BeeGarden (beegarden.app)
+- **Design-Stil:** Verspielt, illustrativ, helle Farben, Bienenthema
+- **Besondere UI-Features:** Bienenfreundliche Pflanzenempfehlungen, Bluetezeiten-Kalender
+- **Beliebtheit:** Oekologischer Fokus, Gamification, Community-Aspekt
+
+---
+
+### Zusammenfassung der Design-Trends bei Gartenplaner-Apps
+
+| Trend | Haeufigkeit | Beispiele |
+|-------|------------|-----------|
+| Flat Design mit Naturfarben | Sehr haeufig | GrowVeg, Vegplotter, Gardenize |
+| KI/AR-Integration | Zunehmend | iScape, PictureThis, Planta |
+| Kartenbasiertes Layout (Cards) | Sehr haeufig | Planta, Gardenize, SmartPlant |
+| Drag-and-Drop Editor | Haeufig | GrowVeg, SmallBluePrinter, Home Outside |
+| Community/Social Features | Haeufig | Garden Puzzle, BeeGarden, Vegplotter |
+| Dunkelmodus-Support | Zunehmend | Planta, Moon & Garden |
+| Mobile-First | Standard | Planta, PictureThis, iScape |
+
+---
+
+## Aufgabe 2: Analyse des bestehenden GardenPlanner-Designs
+
+### 2.1 Aktuelles Design-System
+
+#### Farben (CSS Custom Properties)
+
+**Light Mode:**
+| Token | Wert | Verwendung |
+|-------|------|------------|
+| `--primary` | `#1b5e3f` | Hauptfarbe (Dunkelgruen) |
+| `--primary-light` | `#2d6a4f` | Hover-Zustaende |
+| `--primary-dark` | `#0f3725` | Aktive Zustaende |
+| `--accent` | `#2d6a4f` | Akzente |
+| `--danger` | `#b91c1c` | Loeschen/Fehler |
+| `--text` | `#0a0a0a` | Haupttext |
+| `--text-light` | `#525252` | Sekundaertext |
+| `--bg` | `#f5f5f5` | Hintergrund |
+| `--bg-secondary` | `#fff` | Karten/Container |
+| `--border` | `#d4d4d4` | Rahmenlinien |
+| `--success` | `#16a34a` | Erfolgsmeldungen |
+| `--warning` | `#ea580c` | Warnungen |
+| `--error` | `#dc2626` | Fehler |
+| `--info` | `#2563eb` | Informationen |
+
+**Dark Mode:**
+| Token | Wert | Verwendung |
+|-------|------|------------|
+| `--primary` | `#4ade80` | Hauptfarbe (Hellgruen) |
+| `--bg` | `#0f0f0f` | Hintergrund |
+| `--bg-secondary` | `#1c1c1c` | Karten |
+| `--bg-tertiary` | `#262626` | Eingabefelder |
+| `--text` | `#f5f5f5` | Haupttext |
+| `--text-light` | `#a3a3a3` | Sekundaertext |
+| `--border` | `#333` | Rahmenlinien |
+
+#### Typografie
+- **Font-Family:** `-apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", "Helvetica Neue", Arial, sans-serif` (System-Font-Stack)
+- **Scale:** 0.75rem (xs) bis 2rem (3xl) -- 8 Stufen
+- **Gewichte:** 400 (Body), 500 (Nav), 600 (Labels, Buttons, Headings), 700 (H1), 800 (Wetter-Temp)
+- **Line-Height:** 1.6 (Body)
+
+#### Spacing
+- **Basis:** 4px (0.25rem)
+- **Scale:** xs (0.25rem), sm (0.5rem), md (1rem), lg (1.5rem), xl (2rem), 2xl (3rem)
+
+#### Radii
+- sm: 4px, md: 8px, lg: 12px, xl: 16px, full: 9999px
+
+#### Schatten (Elevation)
+- sm, md, lg, xl -- jeweils separate Light/Dark Varianten
+
+### 2.2 UI-Komponenten
+
+| Komponente | Beschreibung | Datei |
+|-----------|-------------|-------|
+| **Navigation** | Horizontale Tab-Leiste mit Unterstrichen, Emoji-Icons | styles.css |
+| **Buttons** | Primary (gruen), Secondary (grau, Rahmen), Danger (rot) | styles.css |
+| **Forms** | Labels oben, 2px Border-Inputs, Focus-Ring | styles.css |
+| **Cards** | Stat-Cards mit Zahlen, Plant-Cards mit Emoji-Icon | styles.css, plants.css |
+| **Modals** | Zentriert mit Overlay, Header/Body/Footer-Struktur | styles.css |
+| **Tables** | Log-Tabelle mit farbigen Level-Badges | logs.css |
+| **Filters** | Select-Dropdowns und Suchfelder | styles.css |
+| **Progress Bars** | Einfache gefuellte Balken | styles.css |
+| **Theme Toggle** | FAB-Button unten rechts (56x56px, rund) | styles.css |
+| **Weather Cards** | Grid-Cards mit Emoji-Icons und Temperatur | styles.css |
+| **Subtask Manager** | Input + Button + Liste | styles.css |
+| **Bulk Toolbar** | Horizontale Aktions-Leiste | styles.css |
+
+### 2.3 Layout-Struktur
+
+```
++----------------------------------------------------------+
+| HEADER: Logo + Titel + Untertitel                        |
+| Border-bottom: 3px solid primary                         |
++----------------------------------------------------------+
+| NAV: Horizontal Tabs (Emoji + Text)                      |
+| [Neue Aufgabe] [Dashboard] [Statistiken] [Pflanzen] [Logs]|
++----------------------------------------------------------+
+| MAIN CONTENT                                             |
+|                                                          |
+| Desktop (>1200px): 2-Spalten-Grid                        |
+|   Links: Wetter-Sidebar (280px, sticky)                  |
+|   Rechts: Aufgabenliste                                  |
+|   Oben: Stats + Filter (volle Breite)                    |
+|   Unten: Datenverwaltung (volle Breite)                  |
+|                                                          |
+| Mobil (<768px): Einspaltiges Layout                      |
++----------------------------------------------------------+
+| FOOTER: Copyright                                        |
++----------------------------------------------------------+
+| [Theme Toggle FAB] (fixed, unten rechts)                 |
++----------------------------------------------------------+
+```
+
+### 2.4 User Flow
+
+```
+Startseite (index.html)          Dashboard (dashboard.html)
++------------------------+       +-----------------------------+
+| Neue Aufgabe erstellen | ----> | Aufgabenuebersicht          |
+| - Titel (required)     |       | - Stats (offen/erledigt)    |
+| - Standort (required)  |       | - Wetter-Widget             |
+| - Beschreibung         |       | - Filter (MA/Ort/Status)    |
+| - [Weitere Optionen]   |       | - Suche                     |
+|   - Mitarbeiter        |       | - Aufgabenliste             |
+|   - Wiederholung       |       |   - Bearbeiten (Modal)      |
+|   - Teilaufgaben       |       |   - Loeschen                |
++------------------------+       |   - Erledigen               |
+                                 |   - Archivieren             |
+                                 | - Bulk-Aktionen             |
+                                 | - Export (PDF/JSON)         |
+                                 +-----------------------------+
+                                          |
+                    +---------------------+---------------------+
+                    v                                           v
+    Statistiken (statistics.html)           Pflanzen (plants.html)
+    +---------------------------+          +------------------------+
+    | Erweiterte Stats          |          | Suchfeld               |
+    | - Fortschrittsbalken      |          | Kategorie-Filter       |
+    | - Mitarbeiter-Chart       |          | Pflanzen-Grid (Cards)  |
+    | - Standort-Chart          |          | Detail-Modal           |
+    | - Aktivitaets-Timeline    |          |   - Pflanzinfo         |
+    | - Abschluss-Trend         |          |   - Pflege-Tipps       |
+    | - Weitere Kennzahlen      |          |   - Companion Plants   |
+    | - Aufgaben-Historie       |          +------------------------+
+    +---------------------------+
+```
+
+### 2.5 Staerken und Schwaechen des aktuellen Designs
+
+**Staerken:**
+- Gut definiertes Token-System (CSS Custom Properties)
+- Dark-Mode vollstaendig implementiert
+- Accessibility-Grundlagen vorhanden (ARIA, Focus-Visible, SR-Only)
+- Responsive Breakpoints definiert
+- Konsistente Spacing-Skala
+
+**Schwaechen:**
+- Keine echte Sidebar-Navigation (horizontal bei jeder Seitengroesse)
+- Emoji-basierte Icons statt eines konsistenten Icon-Systems
+- Inkonsistente Navigation (index.html hat andere Nav-Struktur als andere Seiten)
+- Kein einheitliches Komponenten-System (logs.html hat Inline-Styles)
+- Fehlender visueller Garten-Editor (nur Aufgaben-Verwaltung)
+- Keine Breadcrumbs oder Seitenhierarchie
+- Container nutzt `max-width: 100%` statt begrenzter Breite -- wirkt auf grossen Bildschirmen gestreckt
+- Gradient im Log-Stats-Bereich (`linear-gradient(135deg, #667eea 0%, #764ba2 100%)`) passt nicht zum gruenen Farbschema
+
+---
+
+## Aufgabe 3: 5 Mock-Up-Konzepte fuer ein komplettes Redesign
+
+---
+
+### Konzept 1: "GardenFlow"
+
+#### Design-Philosophie
+Ein fliessender, organischer Ansatz, der die natuerlichen Zyklen des Gaertnerns widerspiegelt. Alles dreht sich um den "Flow" -- von der Planung ueber die Ausfuehrung bis zur Ernte. Die UI soll sich wie ein digitaler Gartenbegleiter anfuehlen, nicht wie eine Buero-Software.
+
+#### Farbpalette
+| Rolle | Farbe | Hex |
+|-------|-------|-----|
+| Primaer | Moosgruen | `#2D5F3E` |
+| Sekundaer | Salbei | `#87A96B` |
+| Akzent | Terracotta | `#C45B28` |
+| Hintergrund | Warmweiss | `#FAFAF7` |
+| Oberflaeche | Reinweiss | `#FFFFFF` |
+| Text Primaer | Kohle | `#1A1A1A` |
+| Text Sekundaer | Steingrau | `#6B7280` |
+| Border | Nebelgrau | `#E5E7EB` |
+| Erfolg | Blattgruen | `#16A34A` |
+| Warnung | Sonnenblume | `#EAB308` |
+| Fehler | Herbstrot | `#DC2626` |
+| Dark BG | Nachterde | `#111111` |
+| Dark Surface | Dunkelerde | `#1C1C1C` |
+
+#### Typografie
+- **Font-Family:** `"Inter", "Segoe UI", system-ui, sans-serif`
+- **H1:** 28px / 700 / -0.02em Letter-Spacing
+- **H2:** 20px / 600 / -0.01em
+- **H3:** 16px / 600
+- **Body:** 15px / 400 / 1.6 Line-Height
+- **Small:** 13px / 400
+- **Caption:** 11px / 500 / 0.05em (Uppercase)
+
+#### Layout-Wireframe: Dashboard/Hauptseite
+
+```
++--------+-------------------------------------------------------------------+
+| SIDE   |  TOP BAR                                                          |
+| BAR    |  +-------------------------------------------+--+------+--+----+  |
+|        |  | [Q] Aufgaben durchsuchen...               |  | Mo.. |  | NM |  |
+| [Logo] |  +-------------------------------------------+--+------+--+----+  |
+| Garden |                                                                   |
+| Flow   +-------------------------------------------------------------------+
+|        |                                                                   |
+| ----   |  WILLKOMMEN ZURUECK, [NAME]            Montag, 30. Maerz 2026    |
+|        |                                                                   |
+| [ico]  |  +---------------+ +---------------+ +---------------+ +--------+ |
+| Dash-  |  | OFFEN         | | ERLEDIGT      | | MITARBEITER   | | WETTER | |
+| board  |  |      12       | |      34       | |       5       | | 18°C   | |
+|        |  | +4 diese Wo.  | | 73% Rate      | | 6.2 Aufg/MA   | | Sonnig | |
+| [ico]  |  +---------------+ +---------------+ +---------------+ +--------+ |
+| Auf-   |                                                                   |
+| gaben  |  HEUTIGE AUFGABEN                            [+ Neue Aufgabe]     |
+|        |  +---------------------------------------------------------------+|
+| [ico]  |  | [ ] Tomaten giessen          Gewaechshaus 1    Max M.   14:00 ||
+| Pflan- |  +---------------------------------------------------------------+|
+| zen    |  | [ ] Unkraut jaeten           Beet 3             --       Offen ||
+|        |  +---------------------------------------------------------------+|
+| [ico]  |  | [x] Kompost umsetzen         Kompost           Lisa S.  Done  ||
+| Sta-   |  +---------------------------------------------------------------+|
+| tis-   |                                                                   |
+| tiken  |  WETTER-WOCHE                                                     |
+|        |  +--------+--------+--------+--------+--------+--------+--------+ |
+| ----   |  | Mo     | Di     | Mi     | Do     | Fr     | Sa     | So     | |
+|        |  | 18°    | 16°    | 20°    | 22°    | 19°    | 21°    | 17°    | |
+| [ico]  |  | Sonne  | Wolken | Sonne  | Sonne  | Regen  | Bewlkt | Regen  | |
+| Logs   |  +--------+--------+--------+--------+--------+--------+--------+ |
+|        |                                                                   |
+| ----   |  LETZTE AKTIVITAETEN                                              |
+|        |  +---------------------------------------------------------------+|
+| [Tog-  |  | 10:30  Max M. hat "Tomaten giessen" erledigt                  ||
+| gle]   |  | 09:15  Neue Aufgabe "Erdbeeren mulchen" erstellt              ||
+| Theme  |  | Gestern  Lisa S. hat 3 Aufgaben archiviert                    ||
+|        |  +---------------------------------------------------------------+|
++--------+-------------------------------------------------------------------+
+```
+
+#### Layout-Wireframe: Garten-Editor (Aufgabe erstellen/bearbeiten)
+
+```
++--------+-------------------------------------------------------------------+
+| SIDE   |  NEUE AUFGABE ERSTELLEN                                           |
+| BAR    |                                                                   |
+|  ...   |  +-----------------------------+  +-----------------------------+  |
+|        |  | Aufgabe *                   |  | Standort *                  |  |
+|        |  | [Tomaten pflanzen         ] |  | [Gewaechshaus 1          ] |  |
+|        |  +-----------------------------+  +-----------------------------+  |
+|        |                                                                   |
+|        |  +-------------------------------------------------------------+  |
+|        |  | Beschreibung (optional)                                     |  |
+|        |  | [                                                         ] |  |
+|        |  | [                                                         ] |  |
+|        |  +-------------------------------------------------------------+  |
+|        |                                                                   |
+|        |  +--- Weitere Optionen -------------------------------------------+|
+|        |  |                                                               ||
+|        |  | +------------------+  +-------------------+                   ||
+|        |  | | Mitarbeiter      |  | Wiederholung      |                   ||
+|        |  | | [Max Mustermann] |  | [Woechentlich  v] |                   ||
+|        |  | +------------------+  +-------------------+                   ||
+|        |  |                                                               ||
+|        |  | TEILAUFGABEN                                                  ||
+|        |  | +-------------------------------------------+  +---+         ||
+|        |  | | Neue Teilaufgabe...                       |  | + |         ||
+|        |  | +-------------------------------------------+  +---+         ||
+|        |  | [ ] Boden vorbereiten                        [x]              ||
+|        |  | [ ] Setzlinge kaufen                         [x]              ||
+|        |  | [ ] Stuetzen aufstellen                      [x]              ||
+|        |  +---------------------------------------------------------------+|
+|        |                                                                   |
+|        |  +-------------------------------------------------------------+  |
+|        |  |              AUFGABE ERSTELLEN                               |  |
+|        |  +-------------------------------------------------------------+  |
++--------+-------------------------------------------------------------------+
+```
+
+#### Layout-Wireframe: Pflanzen-Bibliothek
+
+```
++--------+-------------------------------------------------------------------+
+| SIDE   |  PFLANZENBIBLIOTHEK                                               |
+| BAR    |                                                                   |
+|  ...   |  +--------------------------------------------------+             |
+|        |  | [Q] Pflanze suchen...                             |             |
+|        |  +--------------------------------------------------+             |
+|        |                                                                   |
+|        |  [Alle] [Gemuese] [Obst] [Kraeuter] [Blumen] [Baeume]            |
+|        |                                                                   |
+|        |  +-------------------+  +-------------------+  +----------------+ |
+|        |  | +--+              |  | +--+              |  | +--+           | |
+|        |  | |To| Tomate       |  | |Ka| Karotte      |  | |Ba| Basilikum| |
+|        |  | +--+              |  | +--+              |  | +--+           | |
+|        |  | Gemuese           |  | Gemuese           |  | Kraeuter      | |
+|        |  | [Einfach] [Sonne] |  | [Mittel] [Sonne]  |  | [Einfach]     | |
+|        |  +-------------------+  +-------------------+  +----------------+ |
+|        |                                                                   |
+|        |  +-------------------+  +-------------------+  +----------------+ |
+|        |  | +--+              |  | +--+              |  | +--+           | |
+|        |  | |Zu| Zucchini     |  | |Er| Erdbeere     |  | |La| Lavendel | |
+|        |  | +--+              |  | +--+              |  | +--+           | |
+|        |  | Gemuese           |  | Obst              |  | Blumen        | |
+|        |  | [Einfach]         |  | [Mittel]          |  | [Einfach]     | |
+|        |  +-------------------+  +-------------------+  +----------------+ |
+|        |                                                                   |
+|        |  +-------------------+  +-------------------+  +----------------+ |
+|        |  | +--+              |  | +--+              |  | +--+           | |
+|        |  | |Gu| Gurke        |  | |Pe| Petersilie   |  | |So| Sonnen-  | |
+|        |  | +--+              |  | +--+              |  | +--+ blume    | |
+|        |  | Gemuese           |  | Kraeuter          |  | Blumen        | |
+|        |  | [Mittel]          |  | [Einfach]         |  | [Einfach]     | |
+|        |  +-------------------+  +-------------------+  +----------------+ |
++--------+-------------------------------------------------------------------+
+```
+
+#### Layout-Wireframe: Navigation (Sidebar)
+
+```
++--------+
+|        |
+| [Logo] |   <-- 40x40px Icon, Moosgruen auf Weiss
+| Garden |   <-- 13px, 700, Uppercase
+| Flow   |
+|        |
+| ====== |   <-- 1px Border, #E5E7EB
+|        |
+| [>] Da |   <-- 20px SVG Icon + 13px Label
+|    sh- |       Active: BG #F0FDF4, Text #2D5F3E
+|    boa- |      Border-left: 3px solid #2D5F3E
+|    rd   |
+|        |
+| [ ] Au |   <-- Inactive: Text #6B7280
+|    fg-  |      Hover: BG #F9FAFB
+|    aben |
+|        |
+| [ ] Pf |
+|    la-  |
+|    nzen |
+|        |
+| [ ] St |
+|    at-  |
+|    is-  |
+|    tik  |
+|        |
+| ====== |
+|        |
+| [ ] Lo |
+|    gs   |
+|        |
+| ====== |
+|        |
+| [Moon] |   <-- Theme Toggle, 36x36px
+| Dark   |
+| Mode   |
+|        |
++--------+
+  72px     <-- Breite collapsed: 72px
+  240px    <-- Breite expanded: 240px
+```
+
+#### Komponenten-Design
+
+**Buttons:**
+- Primary: BG `#2D5F3E`, Text `#FFFFFF`, Radius 8px, Padding 12px 24px, Hover: `#1A4A2E`
+- Secondary: BG transparent, Border 1.5px `#E5E7EB`, Text `#1A1A1A`, Hover: BG `#F9FAFB`
+- Danger: BG `#DC2626`, Text `#FFFFFF`, Hover: `#B91C1C`
+- Ghost: BG transparent, Text `#6B7280`, Hover: BG `#F9FAFB`
+
+**Cards:**
+- BG `#FFFFFF`, Border 1px `#E5E7EB`, Radius 12px, Padding 20px
+- Hover: Border `#2D5F3E` (subtle), translateY(-1px)
+- Kein Box-Shadow im Ruhezustand (flach!)
+
+**Inputs:**
+- Border 1.5px `#E5E7EB`, Radius 8px, Padding 12px 16px, Font 15px
+- Focus: Border `#2D5F3E`, Ring 3px `rgba(45, 95, 62, 0.12)`
+- Kein Box-Shadow
+
+**Modals:**
+- Overlay: `rgba(0, 0, 0, 0.4)` mit `backdrop-filter: blur(4px)`
+- Content: BG `#FFFFFF`, Radius 16px, max-width 560px, Padding 32px
+- Header mit Border-bottom 1px
+
+#### Besondere Features
+- **Kollabierbare Sidebar** mit Icon-Only-Modus (72px) und Expanded-Modus (240px)
+- **Tagesansicht im Dashboard** -- zeigt nur heutige Aufgaben prominent
+- **Inline-Wetter** in der Stat-Leiste statt separater Sektion
+- **Aktivitaets-Feed** am Dashboard als Timeline
+
+#### Inspirationsquellen
+- Gardenize (skandinavische Klarheit)
+- Planta (organische Waerme)
+- Linear.app (Sidebar-Navigation, Aufgaben-Management)
+
+#### Vorteile
+- Sidebar-Navigation spart vertikalen Platz und skaliert auf Desktop
+- Tagesansicht reduziert kognitive Belastung
+- Warmes, aber professionelles Farbschema
+- Klare Informationshierarchie
+
+#### Nachteile
+- Sidebar auf Mobilgeraeten muss als Overlay geloest werden
+- Erfordert SVG-Icon-Set (Mehraufwand vs. Emojis)
+- Zwei Navigations-Modi (collapsed/expanded) erhoehen Komplexitaet
+
+---
+
+### Konzept 2: "Gruen & Klar"
+
+#### Design-Philosophie
+Radikal minimalistisch. Inspiriert von Notizbuch-Apps wie Notion und Bear. Fokus auf Inhalt, nicht auf Dekoration. Jede Seite ist wie eine "Seite" in einem Garten-Notizbuch. Maximale Lesbarkeit, maximaler Weissraum.
+
+#### Farbpalette
+| Rolle | Farbe | Hex |
+|-------|-------|-----|
+| Primaer | Tannengruen | `#14532D` |
+| Sekundaer | Minzgruen | `#86EFAC` |
+| Akzent | Bernstein | `#D97706` |
+| Hintergrund | Papierweiss | `#FDFDFC` |
+| Oberflaeche | Schneeweiss | `#FFFFFF` |
+| Text Primaer | Tinte | `#111827` |
+| Text Sekundaer | Bleistift | `#9CA3AF` |
+| Border | Lineal | `#F3F4F6` |
+| Tag BG | Minthauch | `#ECFDF5` |
+| Dark BG | Schiefertafel | `#0A0A0A` |
+| Dark Surface | Kreide-Dunkel | `#161616` |
+
+#### Typografie
+- **Font-Family:** `"Literata", "Georgia", serif` (Headings) / `"Inter", system-ui, sans-serif` (Body)
+- **H1:** 32px / 700 / Literata (Serif fuer Eleganz)
+- **H2:** 22px / 600 / Literata
+- **H3:** 16px / 600 / Inter
+- **Body:** 15px / 400 / Inter / 1.7 Line-Height
+- **Small:** 13px / 400 / Inter
+- **Mono:** `"JetBrains Mono", monospace` (Zahlen, Codes)
+
+#### Layout-Wireframe: Dashboard/Hauptseite
+
+```
++=========================================================================+
+|                                                                         |
+|  Gartenplaner                          [Suche]  [+ Neue Aufgabe]  [DM] |
+|                                                                         |
+|  [Dashboard]  [Aufgaben]  [Pflanzen]  [Statistiken]  [Logs]            |
+|  ________________________________________________________________________
+|                                                                         |
+|                                                                         |
+|     Guten Morgen! Hier ist dein Garten-Ueberblick.                      |
+|                                                                         |
+|     12 offen   .   34 erledigt   .   5 Mitarbeiter   .   73% Quote     |
+|                                                                         |
+|     -----------------------------------------------------------------   |
+|                                                                         |
+|     Heute, Montag 30. Maerz                                             |
+|                                                                         |
+|     [ ]  Tomaten giessen                                                |
+|          Gewaechshaus 1  --  Max Mustermann  --  14:00                  |
+|          ................................................................|
+|                                                                         |
+|     [ ]  Unkraut jaeten                                                 |
+|          Beet 3  --  nicht zugewiesen                                   |
+|          ................................................................|
+|                                                                         |
+|     [x]  Kompost umsetzen                                               |
+|          Kompost  --  Lisa Schmidt  --  Erledigt um 11:30               |
+|          ................................................................|
+|                                                                         |
+|     -----------------------------------------------------------------   |
+|                                                                         |
+|     Diese Woche                                                         |
+|                                                                         |
+|     Dienstag   Erdbeeren mulchen, Rasen maehen                          |
+|     Mittwoch   Bewaesserung pruefen                                     |
+|     Donnerstag Neue Setzlinge pflanzen                                  |
+|     Freitag    Kompost umsetzen (Wiederholung)                          |
+|                                                                         |
+|     -----------------------------------------------------------------   |
+|                                                                         |
+|     Wetter                                                              |
+|     Mo 18°  Di 16°  Mi 20°  Do 22°  Fr 19°  Sa 21°  So 17°            |
+|                                                                         |
+|  ______________________________________________________________________ |
+|  Gartenplaner (c) 2026                                                  |
++=========================================================================+
+```
+
+#### Layout-Wireframe: Aufgaben-Seite
+
+```
++=========================================================================+
+|  Gartenplaner                          [Suche]  [+ Neue Aufgabe]  [DM] |
+|  [Dashboard]  [Aufgaben]  [Pflanzen]  [Statistiken]  [Logs]            |
+|  ________________________________________________________________________
+|                                                                         |
+|     Alle Aufgaben                                    [Filter v] [Sort v]|
+|                                                                         |
+|     +-------+ +------------+ +----------+                               |
+|     | Alle  | | Ausstehend | | Erledigt |                               |
+|     +-------+ +------------+ +----------+                               |
+|                                                                         |
+|     -----------------------------------------------------------------   |
+|                                                                         |
+|     HEUTE  (3 Aufgaben)                                                 |
+|                                                                         |
+|     [ ]  Tomaten giessen .......................... Max M.  Gew.haus 1  |
+|     [ ]  Unkraut jaeten .......................... --       Beet 3      |
+|     [x]  Kompost umsetzen ........................ Lisa S.  Kompost     |
+|                                                                         |
+|     MORGEN  (2 Aufgaben)                                                |
+|                                                                         |
+|     [ ]  Erdbeeren mulchen ....................... --       Beet 1      |
+|     [ ]  Rasen maehen ........................... Tom K.   Rasen       |
+|                                                                         |
+|     DIESE WOCHE  (4 Aufgaben)                                           |
+|                                                                         |
+|     [ ]  Bewaesserung pruefen ................... Max M.  Gew.haus 2   |
+|     [ ]  Neue Setzlinge ......................... Lisa S. Gew.haus 1   |
+|     [ ]  Kompost umsetzen ....................... Max M.  Kompost      |
+|     [ ]  Duenger bestellen ...................... --      Lager        |
+|                                                                         |
+|     SPAETER                                                             |
+|                                                                         |
+|     [ ]  Herbstschnitt .......................... --      Obstbaeume   |
+|                                                                         |
++=========================================================================+
+```
+
+#### Layout-Wireframe: Pflanzen-Bibliothek
+
+```
++=========================================================================+
+|  Gartenplaner                          [Suche]  [+ Neue Aufgabe]  [DM] |
+|  [Dashboard]  [Aufgaben]  [Pflanzen]  [Statistiken]  [Logs]            |
+|  ________________________________________________________________________
+|                                                                         |
+|     Pflanzenbibliothek                                                  |
+|     Pflegeanleitungen und Tipps fuer Ihren Garten                       |
+|                                                                         |
+|     +--------------------------------------------------+               |
+|     | Pflanze suchen...                                 |               |
+|     +--------------------------------------------------+               |
+|                                                                         |
+|     Alle . Gemuese . Obst . Kraeuter . Blumen . Baeume                 |
+|     _____                                                               |
+|                                                                         |
+|     +----------------------------+  +----------------------------+      |
+|     |                            |  |                            |      |
+|     |  Tomate                    |  |  Karotte                   |      |
+|     |  Solanum lycopersicum      |  |  Daucus carota             |      |
+|     |                            |  |                            |      |
+|     |  Gemuese                   |  |  Gemuese                   |      |
+|     |  Einfach . Sonne . 60-90d  |  |  Mittel . Sonne . 70-80d  |      |
+|     |                            |  |                            |      |
+|     +----------------------------+  +----------------------------+      |
+|                                                                         |
+|     +----------------------------+  +----------------------------+      |
+|     |                            |  |                            |      |
+|     |  Basilikum                 |  |  Erdbeere                  |      |
+|     |  Ocimum basilicum          |  |  Fragaria                  |      |
+|     |                            |  |                            |      |
+|     |  Kraeuter                  |  |  Obst                      |      |
+|     |  Einfach . Sonne . 45-60d  |  |  Mittel . Halbsch. . 90d  |      |
+|     |                            |  |                            |      |
+|     +----------------------------+  +----------------------------+      |
+|                                                                         |
++=========================================================================+
+```
+
+#### Komponenten-Design
+
+**Buttons:**
+- Primary: BG `#14532D`, Text `#FFFFFF`, Radius 6px, Padding 10px 20px, **kein Shadow**
+- Secondary: BG transparent, Border 1px `#F3F4F6`, Text `#111827`, Radius 6px
+- Text-Button: Kein BG, kein Border, Text `#14532D`, Underline on Hover
+- Danger: BG `#FEF2F2`, Text `#DC2626`, Border 1px `#FECACA`
+
+**Cards:**
+- BG `#FFFFFF`, **kein Border** (nur Whitespace als Trennung), Radius 8px, Padding 24px
+- Oder: nur Border-bottom 1px `#F3F4F6` (Listenansicht)
+- Kein Hover-Effekt (Klick-Target ueber gesamte Zeile)
+
+**Inputs:**
+- Border-bottom only: 1.5px `#E5E7EB` (kein vollstaendiger Border!)
+- Focus: Border-bottom `#14532D`
+- Padding 10px 0 (kein seitliches Padding)
+- Floating Label Pattern
+
+**Modals:**
+- Overlay: `rgba(0, 0, 0, 0.3)`
+- Content: BG `#FFFFFF`, Radius 12px, max-width 480px, Padding 40px
+- Keine Header-Linie, groesserer Titel
+
+#### Besondere Features
+- **Serif-Headings** fuer eine "Notizbuch"-Aesthetik
+- **Zeitbasierte Gruppierung** der Aufgaben (Heute/Morgen/Diese Woche/Spaeter)
+- **Punkt-getrennte Inline-Stats** statt separater Karten
+- **Minimale Farbnutzung** -- Farbe nur fuer Status und CTAs
+- **Ganzzeilige Aufgaben** mit Dot-Leader fuer Zuordnungen
+
+#### Inspirationsquellen
+- Notion (minimales, content-zentriertes Design)
+- Bear Notes (Serif-Headings, Fokus auf Schreiben)
+- Things 3 (Aufgaben-Gruppierung nach Zeitraum)
+
+#### Vorteile
+- Extrem saubere, ablenkungsfreie Oberflaeche
+- Zeitbasierte Gruppierung ist natuerlicher fuer Gaertner
+- Weniger visuelles "Rauschen" als kartenbasierte Layouts
+- Serif-Headings geben Charakter ohne Kitsch
+
+#### Nachteile
+- Kann zu "kahl" wirken fuer Nutzer, die visuelle Reize erwarten
+- Serif + Sans-Serif-Mix kann inkongruent wirken wenn nicht sorgfaeltig umgesetzt
+- Border-bottom-only Inputs sind weniger erkennbar fuer aeltere Nutzer
+- Fehlende visuelle Landmarks koennen Orientierung erschweren
+
+---
+
+### Konzept 3: "Terra Dashboard"
+
+#### Design-Philosophie
+Daten-zentrierter Ansatz, inspiriert von modernen SaaS-Dashboards. Der Garten wird als Projekt behandelt, die Aufgaben als Tickets, die Pflanzen als Assets. Klare Hierarchie, viele strukturierte Informationen auf einen Blick, ohne ueberladen zu wirken.
+
+#### Farbpalette
+| Rolle | Farbe | Hex |
+|-------|-------|-----|
+| Primaer | Waldgruen | `#166534` |
+| Sekundaer | Lindgruen | `#4ADE80` |
+| Akzent | Ozeanblau | `#0EA5E9` |
+| Hintergrund | Kuehlgrau | `#F8FAFC` |
+| Oberflaeche | Weiss | `#FFFFFF` |
+| Text Primaer | Graphit | `#0F172A` |
+| Text Sekundaer | Schiefergrau | `#64748B` |
+| Border | Silber | `#E2E8F0` |
+| Success | Gruen | `#22C55E` |
+| Warning | Amber | `#F59E0B` |
+| Error | Rot | `#EF4444` |
+| Info | Blau | `#3B82F6` |
+| Dark BG | Obsidian | `#020617` |
+| Dark Surface | Schiefer | `#0F172A` |
+| Dark Border | Grauschiefer | `#1E293B` |
+
+#### Typografie
+- **Font-Family:** `"Inter", system-ui, sans-serif`
+- **H1:** 24px / 700 / -0.025em
+- **H2:** 18px / 600 / -0.01em
+- **H3:** 14px / 600 / 0.02em (Uppercase, letter-spaced)
+- **Body:** 14px / 400 / 1.5 Line-Height
+- **Small:** 12px / 500
+- **Mono:** `"IBM Plex Mono", monospace` (Statistiken, Zahlen)
+
+#### Layout-Wireframe: Dashboard/Hauptseite
+
+```
++---+====================================================================+
+|   |  Gartenplaner    [____ Globale Suche ____]    [?] [Bell] [NM]      |
+| S |====================================================================|
+| I |                                                                     |
+| D |  +------------+ +------------+ +------------+ +------------+       |
+| E |  | OFFEN      | | ERLEDIGT   | | QUOTE      | | MITARBEITER|       |
+| B |  |            | |            | |            | |            |       |
+| A |  |    12      | |    34      | |   73.9%    | |     5      |       |
+| R |  |            | |            | |            | |            |       |
+|   |  | +4 vs. lW  | | +8 vs. lW | | [====>   ] | | 6.8 A/MA   |       |
+| D |  +------------+ +------------+ +------------+ +------------+       |
+| a |                                                                     |
+| s |  +------------------------------------------+ +------------------+ |
+| h |  | AUFGABEN NACH STATUS                     | | WETTER 7 TAGE    | |
+| b |  |                                          | |                  | |
+| o |  |  Offen      ████████████████     12  26% | | Mo  18°  Sonnig  | |
+| a |  |  In Arbeit  ██████                4   9% | | Di  16°  Wolken  | |
+| r |  |  Erledigt   █████████████████████ 24  52%| | Mi  20°  Sonnig  | |
+| d |  |  Archiviert ██████                6  13% | | Do  22°  Sonnig  | |
+|   |  |                                          | | Fr  19°  Regen   | |
+| A |  +------------------------------------------+ | Sa  21°  Bewlkt  | |
+| u |                                                | So  17°  Regen   | |
+| f |  +------------------------------------------+ +------------------+ |
+| g |  | NAECHSTE AUFGABEN             [Alle ->]  |                      |
+| a |  |                                          |                      |
+| b |  | Prio  Aufgabe          Standort     Wer  |                      |
+| e |  | ----  ---------------  -----------  ---- |                      |
+| n |  |  !    Tomaten giessen  Gew.haus 1   MM   |                      |
+|   |  |  .    Unkraut jaeten   Beet 3       --   |                      |
+| P |  |  .    Erdbeeren mulch  Beet 1       --   |                      |
+| f |  |  .    Rasen maehen     Rasen        TK   |                      |
+| l |  |  .    Bewaesserung     Gew.haus 2   MM   |                      |
+| a |  +------------------------------------------+                      |
+| n |                                                                     |
+| z |  +-------------------------------+ +------------------------------+ |
+| e |  | AKTIVITAET (30 TAGE)          | | TOP MITARBEITER              | |
+| n |  |                               | |                              | |
+|   |  |     .  .                      | | Max M.      ████████  12     | |
+| S |  |  .  .  . .     .             | | Lisa S.     ██████    8     | |
+| t |  | .. .. .. .. . . . .           | | Tom K.      █████     7     | |
+| a |  | .. .. .. .. .... ....  .      | | Anna B.     ███       4     | |
+| t |  | ________________________     | | Peter L.    ██        3     | |
+|   |  | W1  W2  W3  W4  W5  W6       | |                              | |
+| L |  +-------------------------------+ +------------------------------+ |
+| o |                                                                     |
+| g +=====================================================================+
++---+
+```
+
+#### Layout-Wireframe: Aufgaben-Seite (Tabellen-Ansicht)
+
+```
++---+====================================================================+
+|   |  AUFGABEN                            [+ Neue Aufgabe] [Export v]   |
+| S |                                                                     |
+| I |  +----------+ +----------+ +----------+ +----------+              |
+| D |  | Alle (46)| | Offen(12)| | Erled(24)| | Archiv(6)|              |
+| E |  +----------+ +----------+ +----------+ +----------+              |
+| B |                                                                     |
+| A |  Mitarbeiter: [Alle v]  Standort: [Alle v]  Suche: [________]      |
+| R |                                                                     |
+|   |  +================================================================+ |
+|   |  | [ ] | Aufgabe            | Standort    | Wer     | Status | .. | |
+|   |  |-----|--------------------+-------------+---------+--------+----| |
+|   |  | [ ] | Tomaten giessen    | Gew.haus 1  | Max M.  | OFFEN  | : | |
+|   |  | [ ] | Unkraut jaeten     | Beet 3      | --      | OFFEN  | : | |
+|   |  | [x] | Kompost umsetzen   | Kompost     | Lisa S. | DONE   | : | |
+|   |  | [ ] | Erdbeeren mulchen  | Beet 1      | --      | OFFEN  | : | |
+|   |  | [ ] | Rasen maehen       | Rasen       | Tom K.  | OFFEN  | : | |
+|   |  | [x] | Duenger verteilen  | Gew.haus 2  | Max M.  | DONE   | : | |
+|   |  | [ ] | Bewaesserung       | Gew.haus 2  | Max M.  | OFFEN  | : | |
+|   |  | [x] | Setzlinge kaufen   | --          | Lisa S. | DONE   | : | |
+|   |  +================================================================+ |
+|   |                                                                     |
+|   |  Zeige 1-8 von 46         [< 1 2 3 4 5 6 >]                       |
++---+====================================================================+
+```
+
+#### Komponenten-Design
+
+**Buttons:**
+- Primary: BG `#166534`, Text `#FFF`, Radius 6px, Padding 8px 16px, Font 13px/600
+- Secondary: BG `#F8FAFC`, Border 1px `#E2E8F0`, Text `#0F172A`, Radius 6px
+- Danger: BG `#FEF2F2`, Text `#EF4444`, Border 1px `#FECACA`, Radius 6px
+- Icon-Button: 32x32px, Radius 6px, BG transparent, Hover BG `#F1F5F9`
+
+**Cards (Stat-Cards):**
+- BG `#FFFFFF`, Border 1px `#E2E8F0`, Radius 8px, Padding 20px
+- Zahl: 32px / 700 / IBM Plex Mono
+- Label: 12px / 500 / Uppercase / `#64748B`
+- Trend-Indikator: 12px, gruen/rot je nach Richtung
+
+**Inputs:**
+- BG `#F8FAFC`, Border 1px `#E2E8F0`, Radius 6px, Padding 8px 12px, Font 14px
+- Focus: Border `#166534`, kein Shadow, nur Border-Farbwechsel
+- Select: Custom-Arrow-Icon
+
+**Tabellen:**
+- Header: BG `#F8FAFC`, Font 12px/600/Uppercase, Padding 12px 16px
+- Body: Font 14px/400, Padding 12px 16px
+- Row-Hover: BG `#F1F5F9`
+- Zebra: Kein alternating -- nur Hover-Highlight
+
+#### Besondere Features
+- **Tabellen-basierte Aufgabenansicht** mit Sortierung und Pagination
+- **Trend-Indikatoren** (+/- gegenueber Vorwoche) in Stat-Cards
+- **Horizontale Bar-Charts** direkt im Dashboard (CSS-only, keine Chart-Library)
+- **Mini-Sparkline** fuer 30-Tage-Aktivitaet
+- **Monospace-Zahlen** fuer professionellen Dashboard-Look
+
+#### Inspirationsquellen
+- Vercel Dashboard (klare SaaS-Aesthetik)
+- Linear (Aufgabenmanagement, Tabellen)
+- Grafana (Daten-Visualisierung, aber vereinfacht)
+- GrowVeg (Gartenplanung-Kontext)
+
+#### Vorteile
+- Maximale Informationsdichte ohne Unuebersichtlichkeit
+- Tabellen-Ansicht perfekt fuer viele Aufgaben
+- Professioneller, "ernsthafter" Look
+- Trend-Daten geben Kontext zu Zahlen
+
+#### Nachteile
+- Kann steril/technisch wirken -- wenig "Garten-Gefuehl"
+- Hohe Informationsdichte kann neue Nutzer ueberfordern
+- Tabellen-Layout auf Mobilgeraeten problematisch
+- Erfordert mehr Datenaufbereitung im Backend
+
+---
+
+### Konzept 4: "Botanical"
+
+#### Design-Philosophie
+Die Schoenheit des Gaertnerns einfangen. Inspiriert von botanischen Illustrationen und modernen Wellness-Apps. Sanfte, pastellige Toene, viel Luft, abgerundete Formen. Die App soll sich anfuehlen wie ein schoenes Gartenbuch, das man gerne in die Hand nimmt.
+
+#### Farbpalette
+| Rolle | Farbe | Hex |
+|-------|-------|-----|
+| Primaer | Efeugruen | `#365E3D` |
+| Sekundaer | Pistazie | `#A8D5BA` |
+| Akzent | Pflaume | `#7C3AED` |
+| Akzent Warm | Aprikose | `#FBBF24` |
+| Hintergrund | Creme | `#FBF9F4` |
+| Oberflaeche | Milchweiss | `#FFFFFF` |
+| Text Primaer | Espresso | `#1C1917` |
+| Text Sekundaer | Steingrau | `#78716C` |
+| Border | Sandstein | `#E7E5E4` |
+| Success | Basilikum | `#16A34A` |
+| Warning | Honig | `#EA580C` |
+| Error | Beeren | `#E11D48` |
+| Dark BG | Humus | `#0C0A09` |
+| Dark Surface | Dunkle Erde | `#1C1917` |
+| Dark Accent | Lavendel | `#A78BFA` |
+
+#### Typografie
+- **Font-Family:** `"DM Sans", "Inter", system-ui, sans-serif`
+- **Display:** 36px / 700 / -0.03em (nur Seitentitel)
+- **H1:** 26px / 700 / -0.02em
+- **H2:** 20px / 600
+- **H3:** 15px / 600
+- **Body:** 15px / 400 / 1.65 Line-Height
+- **Small:** 13px / 400
+- **Tag:** 11px / 600 / 0.04em
+
+#### Layout-Wireframe: Dashboard/Hauptseite
+
+```
++=========================================================================+
+|                                                                         |
+|  +-------------------------------------------------------------------+ |
+|  |                                                                   | |
+|  |  Gartenplaner            [Suche]    [Benachrichtigungen]    [NM]  | |
+|  |                                                                   | |
+|  +-------------------------------------------------------------------+ |
+|                                                                         |
+|  [Dashboard]   [Aufgaben]   [Pflanzen]   [Statistiken]   [Logs]        |
+|                                                                         |
+|  +-------------------------------------------------------------------+ |
+|  |                                                                   | |
+|  |     Hallo, Gaertner!                                              | |
+|  |                                                                   | |
+|  |     Heute ist ein guter Tag zum Gaertnern.                        | |
+|  |     18°C, sonnig -- perfekt fuer Aussaat und Pflege.              | |
+|  |                                                                   | |
+|  +-------------------------------------------------------------------+ |
+|                                                                         |
+|  +----------------+  +----------------+  +----------------+             |
+|  |    .---.       |  |    .---.       |  |    .---.       |             |
+|  |   / 12  \      |  |   / 34  \      |  |   / 73%  \     |             |
+|  |  | OFFEN |     |  |  |ERLED. |     |  |  | QUOTE |     |             |
+|  |   \ ___ /      |  |   \ ___ /      |  |   \ ___ /      |             |
+|  |                |  |                |  |                |             |
+|  |  +4 neue       |  |  +8 erledigt   |  |  +5% besser    |             |
+|  |  diese Woche   |  |  diese Woche   |  |  als letzte W. |             |
+|  +----------------+  +----------------+  +----------------+             |
+|                                                                         |
+|  +--------------------------------------+ +----------------------------+|
+|  |                                      | |                            ||
+|  |  Heutige Aufgaben              (3)   | |  Wetter-Woche              ||
+|  |                                      | |                            ||
+|  |  +----------------------------------+| |  Mo  18° .......... Sonne  ||
+|  |  |  .  Tomaten giessen              || |  Di  16° .......... Wolken ||
+|  |  |     Gewaechshaus 1   Max M.      || |  Mi  20° .......... Sonne  ||
+|  |  |     [Erledigen]                  || |  Do  22° .......... Sonne  ||
+|  |  +----------------------------------+| |  Fr  19° .......... Regen  ||
+|  |  +----------------------------------+| |  Sa  21° .......... Bewlkt ||
+|  |  |  .  Unkraut jaeten              || |  So  17° .......... Regen  ||
+|  |  |     Beet 3                       || |                            ||
+|  |  |     [Erledigen]                  || |  Garten-Tipp:              ||
+|  |  +----------------------------------+| |  Ideales Wetter fuer       ||
+|  |  +----------------------------------+| |  Aussaat am Mittwoch!      ||
+|  |  |  x  Kompost umsetzen   ERLEDIGT  || |                            ||
+|  |  |     Kompost   Lisa S.  11:30     || +----------------------------+|
+|  |  +----------------------------------+|                               |
+|  +--------------------------------------+                               |
+|                                                                         |
+|  +-------------------------------------------------------------------+ |
+|  |  Kuerzlich abgeschlossen                           [Alle anzeigen]| |
+|  |                                                                   | |
+|  |  Kompost umsetzen     Lisa S.  Heute 11:30     [Archivieren]      | |
+|  |  Hecke schneiden      Tom K.   Gestern 16:00   [Archivieren]      | |
+|  |  Rasen maehen         Max M.   Gestern 10:00   [Archivieren]      | |
+|  +-------------------------------------------------------------------+ |
+|                                                                         |
+|  ______________________________________________________________________ |
+|  Gartenplaner (c) 2026                                 [Dunkelmodus]    |
++=========================================================================+
+```
+
+#### Layout-Wireframe: Pflanzen-Bibliothek (Detail)
+
+```
++=========================================================================+
+|  Gartenplaner            [Suche]    [Benachrichtigungen]    [NM]        |
+|  [Dashboard]   [Aufgaben]   [Pflanzen]   [Statistiken]   [Logs]        |
+|  _______________________________________________________________________
+|                                                                         |
+|  Pflanzenbibliothek                                                     |
+|                                                                         |
+|  +------------------------------------------------------+              |
+|  |  Pflanze suchen...                                    |              |
+|  +------------------------------------------------------+              |
+|                                                                         |
+|  ( Alle )  ( Gemuese )  ( Obst )  ( Kraeuter )  ( Blumen )             |
+|                                                                         |
+|  +--------------------+  +--------------------+  +--------------------+ |
+|  |                    |  |                    |  |                    | |
+|  |     [Tomaten-      |  |     [Karotten-     |  |     [Basilikum-   | |
+|  |      Illustration] |  |      Illustration] |  |      Illustration]| |
+|  |                    |  |                    |  |                    | |
+|  |  Tomate            |  |  Karotte           |  |  Basilikum        | |
+|  |  Solanum lyco...   |  |  Daucus carota     |  |  Ocimum basil.   | |
+|  |                    |  |                    |  |                    | |
+|  |  (Einfach) (Sonne) |  |  (Mittel) (Sonne)  |  |  (Einfach)(Sonne)| |
+|  |                    |  |                    |  |                    | |
+|  +--------------------+  +--------------------+  +--------------------+ |
+|                                                                         |
+|  --- Pflanzdetail-Modal (ueber der Seite) ----------------------------- |
+|  |                                                                    | |
+|  |  +-------------------------------+  +---------------------------+  | |
+|  |  |                               |  |  Tomate                   |  | |
+|  |  |     [Grosse Tomaten-          |  |  Solanum lycopersicum     |  | |
+|  |  |      Illustration]            |  |                           |  | |
+|  |  |                               |  |  Schwierigkeit: Einfach   |  | |
+|  |  +-------------------------------+  |  Licht: Volle Sonne       |  | |
+|  |                                     |  Wasser: Regelmaessig     |  | |
+|  |  Beschreibung                       |  Abstand: 50-60 cm        |  | |
+|  |  Die Tomate ist eine der belieb-    |  Erntezeit: 60-90 Tage    |  | |
+|  |  testen Gartenpflanzen...           |                           |  | |
+|  |                                     +---------------------------+  | |
+|  |  Gute Nachbarn                                                     | |
+|  |  (Basilikum) (Karotte) (Petersilie)                                | |
+|  |                                                                    | |
+|  |  Schlechte Nachbarn                                                | |
+|  |  (Fenchel) (Kartoffel)                                             | |
+|  |                                                                    | |
+|  |  Pflegetipps                                                       | |
+|  |  Regelmaessig giessen, Stuetzen aufstellen...                      | |
+|  |                                                      [Schliessen]  | |
+|  +--------------------------------------------------------------------- |
++=========================================================================+
+```
+
+#### Komponenten-Design
+
+**Buttons:**
+- Primary: BG `#365E3D`, Text `#FFF`, Radius 12px, Padding 12px 28px, Font 14px/600
+- Secondary: BG `#FBF9F4`, Border 1.5px `#E7E5E4`, Text `#1C1917`, Radius 12px
+- Ghost: kein BG, Text `#365E3D`, Hover: BG `#F5F3EE`
+- Pill-Button (Tags): BG `#ECFDF5`, Text `#365E3D`, Radius 9999px, Padding 4px 12px
+
+**Cards:**
+- BG `#FFFFFF`, Border 1px `#E7E5E4`, Radius 16px, Padding 24px
+- Hover: leichter translateY(-2px), Border `#A8D5BA`
+- Kein Box-Shadow im Ruhezustand
+
+**Inputs:**
+- BG `#FFFFFF`, Border 1.5px `#E7E5E4`, Radius 12px, Padding 14px 18px, Font 15px
+- Focus: Border `#365E3D`, Ring `0 0 0 3px rgba(54, 94, 61, 0.1)`
+- Placeholder: `#A8A29E`
+
+**Tags/Pills:**
+- Radius 9999px, Padding 4px 14px, Font 12px/500
+- Difficulty Easy: BG `#ECFDF5`, Text `#166534`
+- Difficulty Medium: BG `#FEF9C3`, Text `#854D0E`
+- Difficulty Hard: BG `#FEE2E2`, Text `#991B1B`
+
+#### Besondere Features
+- **Willkommensnachricht mit Wetter-Kontext** ("Heute ist ein guter Tag zum Gaertnern")
+- **Runde Stat-Elemente** (Kreise) statt rechteckiger Karten
+- **Creme-Hintergrund** statt kaltem Weiss fuer waermeres Gefuehl
+- **Pill-shaped Buttons und Tags** fuer organisches Gefuehl
+- **Grosszuegige Radii** (12px-16px) fuer weiche Formen
+- **Pflanzen-Detail als Side-Sheet** oder grosses Modal mit Illustrationsbereich
+
+#### Inspirationsquellen
+- Planta (sanfte Farben, Pflanzenfokus)
+- Headspace (Wellness-Aesthetik, runde Formen)
+- Gardenize (Notizbuch-Charakter)
+- Botanische Illustrationen (Creme-Toene, natuerliche Waerme)
+
+#### Vorteile
+- Einladend und warm -- motiviert zum Gaertnern
+- Creme-Hintergrund ist augenschonender als reines Weiss
+- Runde Formen erzeugen ein organisches, natuerliches Gefuehl
+- Grosse Touch-Targets durch grosszuegiges Padding
+
+#### Nachteile
+- Pflaume als Akzent (#7C3AED) muss sparsam eingesetzt werden
+- Creme-Hintergrund kann in manchen Lichtverhaeltnissen "schmutzig" wirken
+- Grosszuegiges Padding reduziert Informationsdichte
+- Runde Stat-Kreise sind schwieriger responsiv umzusetzen
+
+---
+
+### Konzept 5: "GridGarden"
+
+#### Design-Philosophie
+Der Garten als Grid -- visuell und strukturell. Inspiriert von Bento-Box-Layouts und modernen Design-Tools. Jede Information bekommt ihren eigenen "Plot" im Layout-Grid. Modulare Karten, die der Nutzer perspektivisch anordnen und priorisieren kann. Klare Geometrie, starke Rasterstruktur.
+
+#### Farbpalette
+| Rolle | Farbe | Hex |
+|-------|-------|-----|
+| Primaer | Blattgruen | `#15803D` |
+| Sekundaer | Limette | `#84CC16` |
+| Akzent | Indigo | `#4F46E5` |
+| Hintergrund | Kaltweiss | `#F1F5F9` |
+| Oberflaeche | Weiss | `#FFFFFF` |
+| Text Primaer | Schwarz-Blau | `#020617` |
+| Text Sekundaer | Stahlgrau | `#475569` |
+| Border | Hellstahl | `#CBD5E1` |
+| Success | Smaragd | `#059669` |
+| Warning | Orange | `#EA580C` |
+| Error | Karmin | `#DC2626` |
+| Dark BG | Mitternacht | `#020617` |
+| Dark Surface | Tiefblau | `#0F172A` |
+| Dark Border | Nachtblau | `#1E293B` |
+| Dark Primaer | Neongruen | `#4ADE80` |
+
+#### Typografie
+- **Font-Family:** `"Space Grotesk", "Inter", system-ui, sans-serif`
+- **H1:** 28px / 700 / -0.03em
+- **H2:** 20px / 600 / -0.015em
+- **H3:** 14px / 700 / 0.05em (Uppercase, wide letter-spacing)
+- **Body:** 14px / 400 / 1.5 Line-Height
+- **Small:** 12px / 500
+- **Code/Zahlen:** `"Space Mono", monospace` -- 14px / 600
+
+#### Layout-Wireframe: Dashboard/Hauptseite (Bento-Grid)
+
+```
++==========================================================================+
+|  GARTENPLANER              [_____ Suche _____]        [+]  [Bell]  [NM] |
+|  [Dashboard] [Aufgaben] [Pflanzen] [Statistiken] [Logs]                 |
++==========================================================================+
+|                                                                          |
+|  +---------------------------+  +---------------------------+            |
+|  |                           |  |                           |            |
+|  |  OFFENE AUFGABEN          |  |  ABSCHLUSSQUOTE           |            |
+|  |                           |  |                           |            |
+|  |         12                |  |        73.9%              |            |
+|  |                           |  |                           |            |
+|  |  ████████████░░░░  26%    |  |  ████████████████████░░   |            |
+|  |                           |  |                           |            |
+|  +---------------------------+  +---------------------------+            |
+|                                                                          |
+|  +---------------------------+  +---------------------------+            |
+|  |                           |  |                           |            |
+|  |  ERLEDIGT                 |  |  MITARBEITER              |            |
+|  |                           |  |                           |            |
+|  |         34                |  |         5                 |            |
+|  |                           |  |                           |            |
+|  |  +8 vs. letzte Woche     |  |  Max M.  ████████  12     |            |
+|  |                           |  |  Lisa S. ██████    8      |            |
+|  +---------------------------+  |  Tom K.  █████     7      |            |
+|                                 |  Andere  ████      8      |            |
+|  +---------------------------+  |                           |            |
+|  |                           |  +---------------------------+            |
+|  |  WETTER HEUTE             |                                           |
+|  |                           |  +--------------------------------------+ |
+|  |  18°C  Sonnig             |  |                                      | |
+|  |                           |  |  NAECHSTE AUFGABEN                   | |
+|  |  Mo Di Mi Do Fr Sa So     |  |                                      | |
+|  |  18 16 20 22 19 21 17     |  |  +----------------------------------+| |
+|  |  .. .  .. .. .  .. .      |  |  | [ ] Tomaten giessen               || |
+|  |                           |  |  |     Gew.haus 1 - Max M. - 14:00  || |
+|  +---------------------------+  |  +----------------------------------+| |
+|                                 |  | [ ] Unkraut jaeten                || |
+|  +---------------------------+  |  |     Beet 3 - nicht zugewiesen     || |
+|  |                           |  |  +----------------------------------+| |
+|  |  STANDORT-VERTEILUNG      |  |  | [x] Kompost umsetzen   ERLEDIGT  || |
+|  |                           |  |  |     Kompost - Lisa S. - 11:30    || |
+|  |  Gew.haus 1  ████████ 8  |  |  +----------------------------------+| |
+|  |  Beet 3      ██████   6  |  |  | [ ] Erdbeeren mulchen             || |
+|  |  Kompost     ████     4  |  |  |     Beet 1 - nicht zugewiesen     || |
+|  |  Rasen       ███      3  |  |  +----------------------------------+| |
+|  |  Andere      █████    5  |  |  | [ ] Rasen maehen                  || |
+|  |                           |  |  |     Rasen - Tom K.                || |
+|  +---------------------------+  |  +----------------------------------+| |
+|                                 |                                      | |
+|                                 |  [Alle Aufgaben anzeigen ->]         | |
+|                                 +--------------------------------------+ |
+|                                                                          |
++==========================================================================+
+```
+
+#### Layout-Wireframe: Garten-Editor (Aufgabe erstellen)
+
+```
++==========================================================================+
+|  GARTENPLANER              [_____ Suche _____]        [+]  [Bell]  [NM] |
+|  [Dashboard] [Aufgaben] [Pflanzen] [Statistiken] [Logs]                 |
++==========================================================================+
+|                                                                          |
+|  NEUE AUFGABE                                                            |
+|                                                                          |
+|  +--------------------------------------+  +---------------------------+ |
+|  |                                      |  |                           | |
+|  |  GRUNDDATEN                          |  |  VORSCHAU                 | |
+|  |                                      |  |                           | |
+|  |  Aufgabe *                           |  |  +---------------------+  | |
+|  |  +----------------------------------+|  |  |                     |  | |
+|  |  | Tomaten pflanzen                 ||  |  |  Tomaten pflanzen   |  | |
+|  |  +----------------------------------+|  |  |  Gewaechshaus 1    |  | |
+|  |                                      |  |  |  Max Mustermann    |  | |
+|  |  Standort *                          |  |  |  Woechentlich      |  | |
+|  |  +----------------------------------+|  |  |                     |  | |
+|  |  | Gewaechshaus 1                  ||  |  |  3 Teilaufgaben     |  | |
+|  |  +----------------------------------+|  |  |  [ ] Boden vorb.   |  | |
+|  |                                      |  |  |  [ ] Setzlinge     |  | |
+|  |  Beschreibung                        |  |  |  [ ] Stuetzen      |  | |
+|  |  +----------------------------------+|  |  |                     |  | |
+|  |  |                                  ||  |  +---------------------+  | |
+|  |  |                                  ||  |                           | |
+|  |  +----------------------------------+|  +---------------------------+ |
+|  |                                      |                                |
+|  +--------------------------------------+                                |
+|                                                                          |
+|  +--------------------------------------+                                |
+|  |  OPTIONEN                            |                                |
+|  |                                      |                                |
+|  |  +-----------------+ +-------------+ |                                |
+|  |  | Mitarbeiter     | | Wiederholung| |                                |
+|  |  | [Max Musterm. ] | | [Woechentl.]| |                                |
+|  |  +-----------------+ +-------------+ |                                |
+|  |                                      |                                |
+|  |  TEILAUFGABEN                        |                                |
+|  |  +------------------------------+ +--+                               |
+|  |  | Neue Teilaufgabe...          | |+ |                               |
+|  |  +------------------------------+ +--+                               |
+|  |  [x] Boden vorbereiten                |                               |
+|  |  [x] Setzlinge kaufen                 |                               |
+|  |  [x] Stuetzen aufstellen              |                               |
+|  +--------------------------------------+                                |
+|                                                                          |
+|  [ Abbrechen ]                 [ AUFGABE ERSTELLEN ]                     |
+|                                                                          |
++==========================================================================+
+```
+
+#### Layout-Wireframe: Statistiken
+
+```
++==========================================================================+
+|  GARTENPLANER              [_____ Suche _____]        [+]  [Bell]  [NM] |
+|  [Dashboard] [Aufgaben] [Pflanzen] [Statistiken] [Logs]                 |
++==========================================================================+
+|                                                                          |
+|  STATISTIKEN & ANALYSEN                                                  |
+|                                                                          |
+|  +--------------------+  +--------------------+  +--------------------+  |
+|  | OFFEN              |  | ERLEDIGT           |  | QUOTE              |  |
+|  |       12           |  |       34           |  |      73.9%         |  |
+|  | ███████████░░░ 26% |  | von 46 gesamt      |  | ████████████████░  |  |
+|  +--------------------+  +--------------------+  +--------------------+  |
+|                                                                          |
+|  +-------------------------------------+  +----------------------------+ |
+|  |                                     |  |                            | |
+|  |  AUFGABEN NACH MITARBEITER          |  |  AUFGABEN NACH STANDORT   | |
+|  |                                     |  |                            | |
+|  |  Max M.   ██████████████████  12    |  |  Gew.haus 1  ████████  8  | |
+|  |  Lisa S.  ████████████       8     |  |  Beet 3      ██████   6  | |
+|  |  Tom K.   ██████████         7     |  |  Kompost     ████     4  | |
+|  |  Anna B.  ██████             4     |  |  Rasen       ███      3  | |
+|  |  Peter L. ████               3     |  |  Gew.haus 2  ██       2  | |
+|  |                                     |  |                            | |
+|  +-------------------------------------+  +----------------------------+ |
+|                                                                          |
+|  +----------------------------------------------------------------------+|
+|  |                                                                      ||
+|  |  WOECHENTLICHE AKTIVITAET (6 WOCHEN)                                 ||
+|  |                                                                      ||
+|  |  12 |          ##                                                    ||
+|  |  10 |    ##    ##                                                    ||
+|  |   8 |    ##    ##    ##                                              ||
+|  |   6 |    ## ## ## ## ##                                              ||
+|  |   4 | ## ## ## ## ## ## ##                                           ||
+|  |   2 | ## ## ## ## ## ## ##                                           ||
+|  |   0 +--+--+--+--+--+--+--                                           ||
+|  |      W1 W2 W3 W4 W5 W6 W7                                           ||
+|  |                                                                      ||
+|  +----------------------------------------------------------------------+|
+|                                                                          |
+|  +--------------------+  +--------------------+  +--------------------+  |
+|  | ARCHIVIERT         |  | STANDORTE          |  | HEUTE ERSTELLT     |  |
+|  |       6            |  |       5            |  |       3            |  |
+|  +--------------------+  +--------------------+  +--------------------+  |
+|  +--------------------+  +--------------------+  +--------------------+  |
+|  | DIESE WOCHE        |  | WOCHE ERLEDIGT     |  | DURCHSCHN. ZEIT   |  |
+|  |       8            |  |       5            |  |     2.3 Tage      |  |
+|  +--------------------+  +--------------------+  +--------------------+  |
+|                                                                          |
++==========================================================================+
+```
+
+#### Komponenten-Design
+
+**Buttons:**
+- Primary: BG `#15803D`, Text `#FFF`, Radius 8px, Padding 10px 20px, Font 14px/600
+- Secondary: BG `#F1F5F9`, Text `#020617`, Border 1px `#CBD5E1`, Radius 8px
+- Icon-FAB: 48x48px, BG `#15803D`, Radius 12px, Shadow `0 4px 12px rgba(21, 128, 61, 0.25)`
+- Danger: BG transparent, Text `#DC2626`, Border 1px `#FCA5A5`, Radius 8px
+
+**Cards (Bento-Zellen):**
+- BG `#FFFFFF`, Border 1px `#CBD5E1`, Radius 12px, Padding 20px
+- Titel: 14px / 700 / Uppercase / `#475569` / 0.05em Letter-Spacing
+- Zahl: 36px / 700 / Space Mono / `#020617`
+- Progress-Bar: 4px Hoehe, Radius 2px, BG `#E2E8F0`, Fill `#15803D`
+
+**Inputs:**
+- BG `#FFFFFF`, Border 1px `#CBD5E1`, Radius 8px, Padding 10px 14px, Font 14px
+- Focus: Border `#15803D`, Shadow `0 0 0 2px rgba(21, 128, 61, 0.15)`
+- Label: 12px / 600 / Uppercase / `#475569` / margin-bottom 6px
+
+**Badges/Tags:**
+- Radius 6px, Padding 2px 8px, Font 11px/600
+- Status Open: BG `#F0FDF4`, Text `#166534`, Border 1px `#BBF7D0`
+- Status Done: BG `#ECFDF5`, Text `#059669`, Border 1px `#A7F3D0`
+- Priority High: BG `#FEF2F2`, Text `#DC2626`, Border 1px `#FECACA`
+
+#### Besondere Features
+- **Bento-Box Dashboard** -- asymmetrisches Grid mit unterschiedlich grossen Karten
+- **Live-Vorschau** beim Erstellen einer Aufgabe (rechte Spalte zeigt Preview)
+- **Uppercase H3-Labels** als visuelle Anker in jeder Karte
+- **Monospace-Zahlen** (Space Mono) fuer Daten-Fokus
+- **Progressbars** ueberall wo Verhaeltnisse dargestellt werden
+- **Modulare Karten** die perspektivisch drag-and-drop angeordnet werden koennten
+
+#### Inspirationsquellen
+- Bento.me (Bento-Grid-Layout)
+- Vercel Dashboard (klare Datenvisualisierung)
+- Apple Weather App (kompakte Wetter-Karten)
+- GrowVeg (Gartenplanung-Kontext)
+- Raycast (monospace Zahlen, geometric layout)
+
+#### Vorteile
+- Visuell ansprechendes, modernes Layout das "anders" aussieht
+- Bento-Grid nutzt den Bildschirmplatz optimal
+- Uppercase-Labels und Monospace-Zahlen geben starke visuelle Hierarchie
+- Asymmetrie erzeugt visuelles Interesse ohne Unordnung
+- Live-Vorschau beim Erstellen reduziert Fehler
+
+#### Nachteile
+- Bento-Grid ist auf Mobilgeraeten schwer umsetzbar (muss zu Single-Column degredieren)
+- Asymmetrisches Layout kann bei wenigen Daten "leer" wirken
+- Space Grotesk als Schrift ist weniger verbreitet (erfordert Web-Font-Loading)
+- Uppercase-Labels koennen die Lesbarkeit bei laengeren Texten reduzieren
+- Live-Vorschau erhoecht die JavaScript-Komplexitaet
+
+---
+
+## Vergleichsmatrix der 5 Konzepte
+
+| Kriterium | GardenFlow | Gruen & Klar | Terra Dashboard | Botanical | GridGarden |
+|-----------|-----------|-------------|----------------|-----------|------------|
+| **Gaertner-Feeling** | Hoch | Mittel | Niedrig | Sehr Hoch | Mittel |
+| **Informationsdichte** | Mittel | Niedrig | Sehr Hoch | Niedrig | Hoch |
+| **Mobile-Eignung** | Gut (Sidebar-Overlay) | Sehr gut | Maessig (Tabellen) | Gut | Maessig (Grid) |
+| **Entwicklungsaufwand** | Mittel-Hoch | Niedrig | Hoch | Mittel | Hoch |
+| **Lernkurve Nutzer** | Niedrig | Sehr Niedrig | Mittel | Sehr Niedrig | Niedrig |
+| **Skalierbarkeit** | Gut | Mittel | Sehr gut | Mittel | Sehr gut |
+| **Barrierefreiheit** | Gut | Gut | Gut | Mittel (Kontraste) | Gut |
+| **Einzigartigkeit** | Mittel | Hoch (Serif) | Niedrig (Standard-SaaS) | Hoch (Aesthetik) | Hoch (Bento) |
+
+---
+
+## Empfehlung
+
+Fuer den GardenPlanner empfehle ich eine **Kombination aus Konzept 1 (GardenFlow) und Konzept 4 (Botanical)**:
+
+- **Sidebar-Navigation** von GardenFlow (skaliert besser als horizontale Tabs)
+- **Warme Farbpalette** von Botanical (Creme-Hintergrund, organische Radii)
+- **Tagesbasierte Aufgabengruppierung** von Gruen & Klar
+- **Stat-Cards mit Trends** von Terra Dashboard
+- **Bento-Elemente** von GridGarden fuer das Dashboard
+
+Diese Kombination wuerde ein Design ergeben, das:
+1. Sich wie eine Garten-App anfuehlt (nicht wie ein Buero-Tool)
+2. Maximale Usability auf allen Geraeteklassen bietet
+3. Genug Informationsdichte fuer Power-User hat
+4. Visuell modern und einladend wirkt
+5. Schrittweise implementierbar ist (Sidebar zuerst, dann Grid-Layout)

--- a/docs/superpowers/plans/2026-03-30-docker-registry-optimization.md
+++ b/docs/superpowers/plans/2026-03-30-docker-registry-optimization.md
@@ -1,0 +1,406 @@
+# Docker Registry Optimization & Publishing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Optimize the Dockerfile for production use and set up automated multi-platform image publishing to Docker Hub via GitHub Actions.
+
+**Architecture:** Multi-stage Dockerfile isolates build dependencies from the production image. A GitHub Actions workflow triggers on push to main, extracts the version from package.json, and builds/pushes multi-platform images with SemVer tags.
+
+**Tech Stack:** Docker (multi-stage, Buildx, QEMU), GitHub Actions, Docker Hub
+
+---
+
+### Task 1: Update .dockerignore
+
+**Files:**
+- Modify: `.dockerignore`
+
+- [ ] **Step 1: Replace .dockerignore contents**
+
+Replace the full contents of `.dockerignore` with:
+
+```dockerignore
+# Git
+.git
+.gitignore
+
+# Documentation
+docs/
+
+# Tests
+tests/
+
+# Claude Code
+.claude/
+
+# GitHub Actions
+.github/
+
+# Dependencies (rebuilt in container)
+node_modules/
+
+# Runtime data (mounted as volume)
+data/
+
+# Environment
+.env
+.env.local
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docker files
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Logs
+*.log
+logs/
+```
+
+- [ ] **Step 2: Verify build context is smaller**
+
+Run:
+```bash
+docker build --no-cache -f Dockerfile -t gardenplanner-test . 2>&1 | head -5
+```
+
+Expected: Build starts without errors. The build context should be smaller than before (no docs/, tests/, .claude/, node_modules/, data/ included).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .dockerignore
+git commit -m "chore: optimize .dockerignore for production builds"
+```
+
+---
+
+### Task 2: Rewrite Dockerfile as multi-stage build
+
+**Files:**
+- Modify: `Dockerfile`
+
+- [ ] **Step 1: Replace Dockerfile with multi-stage build**
+
+Replace the full contents of `Dockerfile` with:
+
+```dockerfile
+# =============================================================================
+# Stage 1: Install production dependencies
+# =============================================================================
+FROM node:22-alpine AS deps
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+
+RUN npm config set strict-ssl false \
+    && npm config set registry http://repo.inform-software.com/artifactory/api/npm/npmjs/ \
+    && npm ci --omit=dev
+
+# =============================================================================
+# Stage 2: Production image
+# =============================================================================
+FROM node:22-alpine AS production
+
+# OCI labels — populated by CI, with sensible defaults for local builds
+ARG BUILD_VERSION=dev
+ARG BUILD_CREATED=unknown
+ARG BUILD_REVISION=unknown
+
+LABEL org.opencontainers.image.title="gardenplanner"
+LABEL org.opencontainers.image.description="Garden task management web application"
+LABEL org.opencontainers.image.version="${BUILD_VERSION}"
+LABEL org.opencontainers.image.source="https://github.com/milkrunner/GardenPlanner"
+LABEL org.opencontainers.image.url="https://hub.docker.com/r/milkrunner/gardenplanner"
+LABEL org.opencontainers.image.created="${BUILD_CREATED}"
+LABEL org.opencontainers.image.revision="${BUILD_REVISION}"
+LABEL org.opencontainers.image.licenses="MIT"
+
+WORKDIR /app
+
+# Update Alpine packages
+RUN apk update && apk upgrade --no-cache
+
+# Copy dependencies from build stage
+COPY --from=deps /app/node_modules ./node_modules
+
+# Copy application files
+COPY package.json ./
+COPY server.js ./
+COPY public/ ./public/
+COPY src/ ./src/
+
+# Create data directories and set permissions
+RUN mkdir -p /app/data /app/data/logs && chown -R node:node /app
+
+# Non-root user
+USER node
+
+# Production environment
+ENV NODE_ENV=production
+
+# Expose port
+EXPOSE 3000
+
+# Healthcheck
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/auth/status || exit 1
+
+# Start server
+CMD ["node", "server.js"]
+```
+
+- [ ] **Step 2: Build the image locally to verify**
+
+Run:
+```bash
+docker build --no-cache -t gardenplanner-test . 2>&1
+```
+
+Expected: Build completes successfully with two stages. No errors.
+
+- [ ] **Step 3: Run the image to verify it starts**
+
+Run:
+```bash
+docker run --rm -d --name gp-test -p 3001:3000 gardenplanner-test
+sleep 3
+wget -qO- http://localhost:3001/api/auth/status || curl -s http://localhost:3001/api/auth/status
+docker stop gp-test
+```
+
+Expected: Returns JSON response from the auth status endpoint. Container starts and stops cleanly.
+
+- [ ] **Step 4: Verify OCI labels are present**
+
+Run:
+```bash
+docker inspect gardenplanner-test --format '{{json .Config.Labels}}' | python -m json.tool 2>/dev/null || docker inspect gardenplanner-test --format '{{json .Config.Labels}}'
+```
+
+Expected: Output shows all `org.opencontainers.image.*` labels with default values (`dev`, `unknown`).
+
+- [ ] **Step 5: Clean up test image**
+
+Run:
+```bash
+docker rmi gardenplanner-test
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "feat: rewrite Dockerfile as multi-stage build with OCI labels"
+```
+
+---
+
+### Task 3: Update docker-compose.yml
+
+**Files:**
+- Modify: `docker-compose.yml`
+
+- [ ] **Step 1: Replace docker-compose.yml contents**
+
+Replace the full contents of `docker-compose.yml` with:
+
+```yaml
+services:
+  gartenplaner:
+    image: milkrunner/gardenplanner:latest
+    build: .
+    container_name: gartenplaner
+    ports:
+      - "8080:3000"
+    restart: unless-stopped
+    environment:
+      - TZ=Europe/Berlin
+      - API_KEY=${API_KEY}
+      - PORT=3000
+    volumes:
+      - gartenplaner-data:/app/data
+    labels:
+      - "description=Gartenplaner Web Application"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  gartenplaner-data:
+```
+
+- [ ] **Step 2: Verify docker compose config is valid**
+
+Run:
+```bash
+docker compose config
+```
+
+Expected: Outputs the resolved compose configuration without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "chore: add image name and remove hardcoded subnet from docker-compose"
+```
+
+---
+
+### Task 4: Create GitHub Actions workflow
+
+**Files:**
+- Create: `.github/workflows/docker-publish.yml`
+
+- [ ] **Step 1: Create the workflow directory**
+
+Run:
+```bash
+mkdir -p .github/workflows
+```
+
+- [ ] **Step 2: Create the workflow file**
+
+Create `.github/workflows/docker-publish.yml` with:
+
+```yaml
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  IMAGE_NAME: milkrunner/gardenplanner
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+          echo "full=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.full }}
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.minor }}
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
+            ${{ env.IMAGE_NAME }}:latest
+          build-args: |
+            BUILD_VERSION=${{ steps.version.outputs.full }}
+            BUILD_CREATED=${{ github.event.head_commit.timestamp }}
+            BUILD_REVISION=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+- [ ] **Step 3: Validate the workflow YAML syntax**
+
+Run:
+```bash
+node -e "const fs = require('fs'); const y = require('yaml') || JSON.parse('null'); const content = fs.readFileSync('.github/workflows/docker-publish.yml', 'utf8'); console.log('YAML is valid');" 2>/dev/null || python -c "import yaml; yaml.safe_load(open('.github/workflows/docker-publish.yml')); print('YAML is valid')"
+```
+
+Expected: `YAML is valid`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/docker-publish.yml
+git commit -m "feat: add GitHub Actions workflow for Docker Hub publishing"
+```
+
+---
+
+### Task 5: Final integration test
+
+- [ ] **Step 1: Build with docker compose**
+
+Run:
+```bash
+docker compose build
+```
+
+Expected: Multi-stage build completes successfully via compose.
+
+- [ ] **Step 2: Start with docker compose**
+
+Run:
+```bash
+docker compose up -d
+sleep 5
+wget -qO- http://localhost:8080/api/auth/status || curl -s http://localhost:8080/api/auth/status
+```
+
+Expected: Application responds on port 8080.
+
+- [ ] **Step 3: Verify healthcheck**
+
+Run:
+```bash
+docker inspect gartenplaner --format '{{.State.Health.Status}}'
+```
+
+Expected: `healthy` (may need to wait 30-40 seconds after start).
+
+- [ ] **Step 4: Stop and clean up**
+
+Run:
+```bash
+docker compose down
+```
+
+- [ ] **Step 5: Commit all remaining changes (if any)**
+
+Run:
+```bash
+git status
+```
+
+If there are uncommitted changes, stage and commit them. Otherwise, this step is complete.

--- a/docs/superpowers/specs/2026-03-30-docker-registry-optimization-design.md
+++ b/docs/superpowers/specs/2026-03-30-docker-registry-optimization-design.md
@@ -1,0 +1,118 @@
+# Docker Registry Optimization & Publishing
+
+**Date:** 2026-03-30
+**Status:** Approved
+**Target:** Docker Hub (public) — `milkrunner/gardenplanner`
+
+## Goal
+
+Optimize the Dockerfile for production use and set up automated multi-platform image publishing to Docker Hub via GitHub Actions.
+
+## 1. Dockerfile — Multi-Stage Build
+
+Replace the current single-stage Dockerfile with a two-stage build:
+
+### Stage 1: `deps`
+- Base: `node:22-alpine`
+- Copy only `package.json` + `package-lock.json`
+- Configure npm registry (Artifactory: `repo.inform-software.com`) with `strict-ssl false`
+- Run `npm ci --omit=dev` for deterministic installs
+- This stage is disposable — npm config and tooling do not carry over
+
+### Stage 2: `production`
+- Base: `node:22-alpine`
+- `apk upgrade --no-cache` (without `|| true` — build must fail on errors)
+- Copy `node_modules/` from Stage 1
+- Copy application files: `server.js`, `public/`, `src/`, `README.md`
+- Create data directories: `/app/data`, `/app/data/logs`
+- Set ownership to `node:node`, switch to non-root user
+- Set `NODE_ENV=production`
+- Expose port 3000
+- Healthcheck: `wget` on `http://localhost:3000/api/auth/status`
+- Entrypoint: `node server.js`
+
+### Key changes from current Dockerfile
+- `npm audit || true` removed — audit belongs in CI, not in the image build
+- `strict-ssl false` isolated to deps stage — does not exist in final image
+- `apk upgrade || true` changed to `apk upgrade --no-cache` — errors must be visible
+- OCI labels added via build args (see section 2)
+
+## 2. OCI-Compliant Labels
+
+Labels are set via `ARG` with defaults, populated dynamically by CI:
+
+| Label | Value |
+|-------|-------|
+| `org.opencontainers.image.title` | `gardenplanner` |
+| `org.opencontainers.image.description` | `Garden task management web application` |
+| `org.opencontainers.image.version` | From `package.json` (e.g. `1.0.0`) |
+| `org.opencontainers.image.source` | `https://github.com/milkrunner/GardenPlanner` |
+| `org.opencontainers.image.url` | `https://hub.docker.com/r/milkrunner/gardenplanner` |
+| `org.opencontainers.image.created` | Build timestamp (ISO 8601) |
+| `org.opencontainers.image.licenses` | `MIT` |
+
+## 3. .dockerignore
+
+Add the following to reduce build context and prevent non-production files from entering the image:
+
+```
+docs/
+tests/
+.claude/
+.github/
+node_modules/
+data/
+```
+
+Uncomment the currently commented-out `docs/` and `tests/` entries.
+
+## 4. GitHub Actions Workflow
+
+**File:** `.github/workflows/docker-publish.yml`
+**Trigger:** Push to `main` branch
+
+### Steps
+
+1. **Checkout** repository
+2. **Extract version** from `package.json` (e.g. `1.0.0`)
+3. **Setup QEMU** for multi-platform emulation
+4. **Setup Docker Buildx** for extended build capabilities
+5. **Login to Docker Hub** via `docker/login-action`
+6. **Build and push** via `docker/build-push-action`
+
+### Configuration
+
+- **Platforms:** `linux/amd64`, `linux/arm64`
+- **Cache:** GitHub Actions cache layer for faster rebuilds
+- **Tags generated from SemVer:**
+  - `1.2.3` (exact version)
+  - `1.2` (minor)
+  - `1` (major)
+  - `latest`
+
+### Required GitHub Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `DOCKERHUB_USERNAME` | Docker Hub username (`milkrunner`) |
+| `DOCKERHUB_TOKEN` | Docker Hub access token (not password) |
+
+## 5. docker-compose.yml Changes
+
+- Add `image: milkrunner/gardenplanner:latest` so the compose file works with the registry image
+- Keep `build: .` for local builds
+- Remove the hardcoded subnet `172.28.0.0/16` — unnecessary and can cause collisions on other systems
+
+### Usage
+
+- **Local build:** `docker compose up --build`
+- **Registry image:** `docker compose pull && docker compose up`
+
+## Files Changed
+
+| File | Action |
+|------|--------|
+| `Dockerfile` | Rewrite — multi-stage build with OCI labels |
+| `.dockerignore` | Update — add exclusions for docs, tests, .claude, .github, node_modules, data |
+| `.github/workflows/docker-publish.yml` | Create — automated build & push workflow |
+| `docker-compose.yml` | Update — add image name, remove hardcoded subnet |

--- a/mockups/01-gardenflow.html
+++ b/mockups/01-gardenflow.html
@@ -1,0 +1,1653 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GardenFlow - Gartenplaner Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Source+Sans+3:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <style>
+    /* ========================================
+       CSS CUSTOM PROPERTIES
+       ======================================== */
+    :root {
+      --color-primary: #2D5F3E;
+      --color-primary-light: #3A7A50;
+      --color-secondary: #87A96B;
+      --color-accent: #C45B28;
+      --color-accent-light: #D4712F;
+      --color-bg: #FAFAF7;
+      --color-surface: #FFFFFF;
+      --color-text: #1A1A1A;
+      --color-text-secondary: #6B7280;
+      --color-border: #E5E7EB;
+      --color-sidebar-active-bg: #F0FDF4;
+      --color-sidebar-bg: #FFFFFF;
+      --color-topbar-bg: #FFFFFF;
+      --color-input-bg: #FFFFFF;
+      --color-hover-card: #F9FAFB;
+      --color-task-hover: #FAFBFC;
+      --color-timeline-line: #E5E7EB;
+      --color-weather-bg: #F7FAF5;
+      --color-checkbox-border: #D1D5DB;
+      --color-search-bg: #F3F4F6;
+      --sidebar-width: 240px;
+      --sidebar-collapsed: 72px;
+      --topbar-height: 64px;
+      --transition-speed: 0.2s;
+      --radius-sm: 8px;
+      --radius-md: 12px;
+      --radius-lg: 16px;
+    }
+
+    [data-theme="dark"] {
+      --color-primary: #4CAF72;
+      --color-primary-light: #5BC47F;
+      --color-secondary: #87A96B;
+      --color-accent: #E07040;
+      --color-accent-light: #EB8555;
+      --color-bg: #111111;
+      --color-surface: #1C1C1C;
+      --color-text: #E8E8E8;
+      --color-text-secondary: #9CA3AF;
+      --color-border: #2D2D2D;
+      --color-sidebar-active-bg: #1A2E1F;
+      --color-sidebar-bg: #1C1C1C;
+      --color-topbar-bg: #1C1C1C;
+      --color-input-bg: #252525;
+      --color-hover-card: #252525;
+      --color-task-hover: #222222;
+      --color-timeline-line: #333333;
+      --color-weather-bg: #1A2E1F;
+      --color-checkbox-border: #4B5563;
+      --color-search-bg: #252525;
+    }
+
+    /* ========================================
+       RESET & BASE
+       ======================================== */
+    *, *::before, *::after {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    html {
+      font-size: 15px;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    body {
+      font-family: 'Source Sans 3', -apple-system, sans-serif;
+      font-weight: 400;
+      color: var(--color-text);
+      background: var(--color-bg);
+      line-height: 1.6;
+      overflow-x: hidden;
+      transition: background var(--transition-speed) ease, color var(--transition-speed) ease;
+    }
+
+    h1, h2, h3, h4 {
+      font-family: 'Outfit', sans-serif;
+    }
+
+    h1 {
+      font-size: 28px;
+      font-weight: 700;
+      line-height: 1.2;
+    }
+
+    h2 {
+      font-size: 20px;
+      font-weight: 600;
+      line-height: 1.3;
+    }
+
+    h3 {
+      font-size: 16px;
+      font-weight: 600;
+    }
+
+    a {
+      text-decoration: none;
+      color: inherit;
+    }
+
+    button {
+      cursor: pointer;
+      border: none;
+      background: none;
+      font-family: inherit;
+      font-size: inherit;
+    }
+
+    /* ========================================
+       LAYOUT SHELL
+       ======================================== */
+    .app-layout {
+      display: flex;
+      min-height: 100vh;
+    }
+
+    /* ========================================
+       SIDEBAR
+       ======================================== */
+    .sidebar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      height: 100vh;
+      width: var(--sidebar-width);
+      background: var(--color-sidebar-bg);
+      border-right: 1px solid var(--color-border);
+      display: flex;
+      flex-direction: column;
+      z-index: 100;
+      transition: width var(--transition-speed) ease, transform var(--transition-speed) ease;
+      overflow: hidden;
+    }
+
+    .sidebar.collapsed {
+      width: var(--sidebar-collapsed);
+    }
+
+    .sidebar-header {
+      display: flex;
+      align-items: center;
+      padding: 20px;
+      gap: 12px;
+      min-height: 64px;
+    }
+
+    .sidebar-logo {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-shrink: 0;
+    }
+
+    .logo-icon {
+      width: 32px;
+      height: 32px;
+      background: var(--color-primary);
+      border-radius: var(--radius-sm);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .logo-icon svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    .logo-text {
+      font-family: 'Outfit', sans-serif;
+      font-size: 20px;
+      font-weight: 700;
+      color: var(--color-primary);
+      white-space: nowrap;
+      opacity: 1;
+      transition: opacity var(--transition-speed) ease;
+    }
+
+    .sidebar.collapsed .logo-text {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .sidebar-nav {
+      flex: 1;
+      padding: 8px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .nav-item {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 12px;
+      border-radius: var(--radius-sm);
+      color: var(--color-text-secondary);
+      font-weight: 500;
+      font-size: 14px;
+      transition: all var(--transition-speed) ease;
+      white-space: nowrap;
+      border-left: 3px solid transparent;
+      position: relative;
+    }
+
+    .nav-item:hover {
+      color: var(--color-text);
+      background: var(--color-hover-card);
+    }
+
+    .nav-item.active {
+      color: var(--color-primary);
+      background: var(--color-sidebar-active-bg);
+      border-left-color: var(--color-primary);
+      font-weight: 600;
+    }
+
+    .nav-item svg {
+      width: 20px;
+      height: 20px;
+      flex-shrink: 0;
+    }
+
+    .nav-item-label {
+      opacity: 1;
+      transition: opacity var(--transition-speed) ease;
+    }
+
+    .sidebar.collapsed .nav-item-label {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .sidebar.collapsed .nav-item {
+      justify-content: center;
+      padding: 10px;
+      border-left-color: transparent;
+    }
+
+    .sidebar.collapsed .nav-item.active {
+      border-left-color: transparent;
+    }
+
+    /* Tooltip on collapsed sidebar */
+    .sidebar.collapsed .nav-item::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      left: calc(100% + 8px);
+      top: 50%;
+      transform: translateY(-50%);
+      background: var(--color-text);
+      color: var(--color-bg);
+      padding: 4px 10px;
+      border-radius: 6px;
+      font-size: 12px;
+      white-space: nowrap;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.15s ease;
+      z-index: 200;
+    }
+
+    .sidebar.collapsed .nav-item:hover::after {
+      opacity: 1;
+    }
+
+    .sidebar-footer {
+      padding: 16px 12px;
+      border-top: 1px solid var(--color-border);
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .theme-toggle {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 12px;
+      border-radius: var(--radius-sm);
+      color: var(--color-text-secondary);
+      font-size: 14px;
+      font-weight: 500;
+      transition: all var(--transition-speed) ease;
+      width: 100%;
+      cursor: pointer;
+    }
+
+    .theme-toggle:hover {
+      color: var(--color-text);
+      background: var(--color-hover-card);
+    }
+
+    .theme-toggle svg {
+      width: 20px;
+      height: 20px;
+      flex-shrink: 0;
+    }
+
+    .theme-toggle-label {
+      opacity: 1;
+      transition: opacity var(--transition-speed) ease;
+      white-space: nowrap;
+    }
+
+    .sidebar.collapsed .theme-toggle-label {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .sidebar.collapsed .theme-toggle {
+      justify-content: center;
+    }
+
+    /* ========================================
+       MAIN CONTENT AREA
+       ======================================== */
+    .main-area {
+      flex: 1;
+      margin-left: var(--sidebar-width);
+      transition: margin-left var(--transition-speed) ease;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .sidebar.collapsed ~ .main-area {
+      margin-left: var(--sidebar-collapsed);
+    }
+
+    /* ========================================
+       TOPBAR
+       ======================================== */
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      height: var(--topbar-height);
+      background: var(--color-topbar-bg);
+      border-bottom: 1px solid var(--color-border);
+      display: flex;
+      align-items: center;
+      padding: 0 32px;
+      gap: 16px;
+      transition: background var(--transition-speed) ease;
+    }
+
+    .sidebar-toggle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      border-radius: var(--radius-sm);
+      color: var(--color-text-secondary);
+      transition: all var(--transition-speed) ease;
+    }
+
+    .sidebar-toggle:hover {
+      background: var(--color-hover-card);
+      color: var(--color-text);
+    }
+
+    .sidebar-toggle svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    .search-wrapper {
+      flex: 1;
+      max-width: 480px;
+      position: relative;
+    }
+
+    .search-input {
+      width: 100%;
+      height: 40px;
+      padding: 0 16px 0 42px;
+      border: 1.5px solid var(--color-border);
+      border-radius: var(--radius-sm);
+      background: var(--color-search-bg);
+      font-family: 'Source Sans 3', sans-serif;
+      font-size: 14px;
+      color: var(--color-text);
+      transition: all var(--transition-speed) ease;
+      outline: none;
+    }
+
+    .search-input::placeholder {
+      color: var(--color-text-secondary);
+    }
+
+    .search-input:focus {
+      border-color: var(--color-primary);
+      background: var(--color-input-bg);
+    }
+
+    .search-icon {
+      position: absolute;
+      left: 14px;
+      top: 50%;
+      transform: translateY(-50%);
+      color: var(--color-text-secondary);
+      pointer-events: none;
+    }
+
+    .search-icon svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .topbar-right {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-left: auto;
+    }
+
+    .notification-btn {
+      position: relative;
+      width: 36px;
+      height: 36px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--radius-sm);
+      color: var(--color-text-secondary);
+      transition: all var(--transition-speed) ease;
+    }
+
+    .notification-btn:hover {
+      background: var(--color-hover-card);
+      color: var(--color-text);
+    }
+
+    .notification-btn svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    .notification-badge {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      width: 8px;
+      height: 8px;
+      background: var(--color-accent);
+      border-radius: 50%;
+      border: 2px solid var(--color-topbar-bg);
+    }
+
+    .user-avatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #FFFFFF;
+      font-family: 'Outfit', sans-serif;
+      font-weight: 600;
+      font-size: 14px;
+      cursor: pointer;
+      transition: transform var(--transition-speed) ease;
+    }
+
+    .user-avatar:hover {
+      transform: scale(1.05);
+    }
+
+    /* ========================================
+       CONTENT
+       ======================================== */
+    .content {
+      flex: 1;
+      padding: 32px;
+      max-width: 1280px;
+    }
+
+    /* Welcome Section */
+    .welcome-section {
+      margin-bottom: 32px;
+    }
+
+    .welcome-section h1 {
+      color: var(--color-text);
+      margin-bottom: 4px;
+    }
+
+    .welcome-date {
+      color: var(--color-text-secondary);
+      font-size: 15px;
+    }
+
+    /* ========================================
+       STAT CARDS
+       ======================================== */
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 16px;
+      margin-bottom: 32px;
+    }
+
+    .stat-card {
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      padding: 20px;
+      transition: all var(--transition-speed) ease;
+      cursor: default;
+    }
+
+    .stat-card:hover {
+      transform: translateY(-1px);
+      border-color: var(--color-secondary);
+      box-shadow: 0 4px 12px rgba(0,0,0,0.04);
+    }
+
+    .stat-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .stat-card-icon {
+      width: 40px;
+      height: 40px;
+      border-radius: var(--radius-sm);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .stat-card-icon svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    .stat-card-icon.open {
+      background: #FEF3C7;
+      color: #D97706;
+    }
+
+    .stat-card-icon.done {
+      background: #D1FAE5;
+      color: #059669;
+    }
+
+    .stat-card-icon.team {
+      background: #DBEAFE;
+      color: #2563EB;
+    }
+
+    .stat-card-icon.weather {
+      background: #FEE2E2;
+      color: #DC2626;
+    }
+
+    [data-theme="dark"] .stat-card-icon.open {
+      background: #422006;
+      color: #FBBF24;
+    }
+
+    [data-theme="dark"] .stat-card-icon.done {
+      background: #064E3B;
+      color: #34D399;
+    }
+
+    [data-theme="dark"] .stat-card-icon.team {
+      background: #1E3A5F;
+      color: #60A5FA;
+    }
+
+    [data-theme="dark"] .stat-card-icon.weather {
+      background: #450A0A;
+      color: #F87171;
+    }
+
+    .stat-card-trend {
+      font-size: 12px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 20px;
+    }
+
+    .stat-card-trend.up {
+      background: #D1FAE5;
+      color: #059669;
+    }
+
+    .stat-card-trend.down {
+      background: #FEE2E2;
+      color: #DC2626;
+    }
+
+    [data-theme="dark"] .stat-card-trend.up {
+      background: #064E3B;
+      color: #34D399;
+    }
+
+    [data-theme="dark"] .stat-card-trend.down {
+      background: #450A0A;
+      color: #F87171;
+    }
+
+    .stat-card-value {
+      font-family: 'Outfit', sans-serif;
+      font-size: 32px;
+      font-weight: 700;
+      color: var(--color-text);
+      line-height: 1;
+      margin-bottom: 4px;
+    }
+
+    .stat-card-label {
+      font-size: 13px;
+      color: var(--color-text-secondary);
+      font-weight: 500;
+    }
+
+    /* ========================================
+       MAIN GRID (Tasks + Weather/Activity)
+       ======================================== */
+    .dashboard-grid {
+      display: grid;
+      grid-template-columns: 1fr 380px;
+      gap: 24px;
+    }
+
+    /* ========================================
+       TASKS SECTION
+       ======================================== */
+    .section-card {
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      padding: 24px;
+      transition: all var(--transition-speed) ease;
+    }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 20px;
+    }
+
+    .section-header h2 {
+      color: var(--color-text);
+    }
+
+    .section-count {
+      font-size: 13px;
+      color: var(--color-text-secondary);
+      background: var(--color-hover-card);
+      padding: 4px 12px;
+      border-radius: 20px;
+      font-weight: 500;
+    }
+
+    .btn-primary {
+      background: var(--color-primary);
+      color: #FFFFFF;
+      padding: 8px 16px;
+      border-radius: var(--radius-sm);
+      font-weight: 600;
+      font-size: 13px;
+      transition: all var(--transition-speed) ease;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .btn-primary:hover {
+      background: var(--color-primary-light);
+    }
+
+    .btn-secondary {
+      background: transparent;
+      color: var(--color-text-secondary);
+      padding: 8px 16px;
+      border-radius: var(--radius-sm);
+      font-weight: 600;
+      font-size: 13px;
+      border: 1.5px solid var(--color-border);
+      transition: all var(--transition-speed) ease;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .btn-secondary:hover {
+      border-color: var(--color-primary);
+      color: var(--color-primary);
+    }
+
+    /* Task List */
+    .task-list {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .task-item {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 14px 0;
+      border-bottom: 1px solid var(--color-border);
+      transition: background var(--transition-speed) ease;
+      border-radius: 4px;
+      padding-left: 8px;
+      padding-right: 8px;
+      margin: 0 -8px;
+    }
+
+    .task-item:last-child {
+      border-bottom: none;
+    }
+
+    .task-item:hover {
+      background: var(--color-task-hover);
+    }
+
+    .task-checkbox {
+      appearance: none;
+      -webkit-appearance: none;
+      width: 20px;
+      height: 20px;
+      border: 2px solid var(--color-checkbox-border);
+      border-radius: 6px;
+      cursor: pointer;
+      flex-shrink: 0;
+      transition: all var(--transition-speed) ease;
+      position: relative;
+    }
+
+    .task-checkbox:checked {
+      background: var(--color-primary);
+      border-color: var(--color-primary);
+    }
+
+    .task-checkbox:checked::after {
+      content: '';
+      position: absolute;
+      left: 5px;
+      top: 1px;
+      width: 6px;
+      height: 10px;
+      border: solid #FFFFFF;
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg);
+    }
+
+    .task-checkbox:hover {
+      border-color: var(--color-primary);
+    }
+
+    .task-content {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .task-title {
+      font-weight: 500;
+      font-size: 14px;
+      color: var(--color-text);
+      transition: all var(--transition-speed) ease;
+    }
+
+    .task-item.completed .task-title {
+      text-decoration: line-through;
+      color: var(--color-text-secondary);
+    }
+
+    .task-meta {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-top: 4px;
+      font-size: 12px;
+      color: var(--color-text-secondary);
+    }
+
+    .task-meta-item {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .task-meta-item svg {
+      width: 12px;
+      height: 12px;
+    }
+
+    .task-priority {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .task-priority.high {
+      background: #EF4444;
+    }
+
+    .task-priority.medium {
+      background: #F59E0B;
+    }
+
+    .task-priority.low {
+      background: #10B981;
+    }
+
+    .task-time {
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--color-text-secondary);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    /* ========================================
+       RIGHT COLUMN
+       ======================================== */
+    .right-column {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    /* Weather Week */
+    .weather-grid {
+      display: grid;
+      grid-template-columns: repeat(7, 1fr);
+      gap: 6px;
+    }
+
+    .weather-day {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 12px 4px;
+      border-radius: var(--radius-sm);
+      background: var(--color-weather-bg);
+      transition: all var(--transition-speed) ease;
+      cursor: default;
+    }
+
+    .weather-day:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    }
+
+    .weather-day.today {
+      background: var(--color-primary);
+      color: #FFFFFF;
+    }
+
+    .weather-day-name {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 8px;
+      color: var(--color-text-secondary);
+    }
+
+    .weather-day.today .weather-day-name {
+      color: rgba(255,255,255,0.8);
+    }
+
+    .weather-day-icon {
+      font-size: 22px;
+      margin-bottom: 6px;
+      line-height: 1;
+    }
+
+    .weather-day-temp {
+      font-family: 'Outfit', sans-serif;
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--color-text);
+    }
+
+    .weather-day.today .weather-day-temp {
+      color: #FFFFFF;
+    }
+
+    .weather-day-templow {
+      font-size: 11px;
+      color: var(--color-text-secondary);
+      margin-top: 2px;
+    }
+
+    .weather-day.today .weather-day-templow {
+      color: rgba(255,255,255,0.7);
+    }
+
+    /* Activity Timeline */
+    .timeline {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      position: relative;
+    }
+
+    .timeline-item {
+      display: flex;
+      gap: 14px;
+      padding: 12px 0;
+      position: relative;
+    }
+
+    .timeline-dot-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      flex-shrink: 0;
+      width: 20px;
+    }
+
+    .timeline-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--color-primary);
+      flex-shrink: 0;
+      position: relative;
+      z-index: 1;
+    }
+
+    .timeline-line {
+      width: 2px;
+      flex: 1;
+      background: var(--color-timeline-line);
+      margin-top: 4px;
+    }
+
+    .timeline-item:last-child .timeline-line {
+      display: none;
+    }
+
+    .timeline-dot.accent {
+      background: var(--color-accent);
+    }
+
+    .timeline-dot.secondary {
+      background: var(--color-secondary);
+    }
+
+    .timeline-content {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .timeline-text {
+      font-size: 13px;
+      color: var(--color-text);
+      line-height: 1.5;
+    }
+
+    .timeline-text strong {
+      font-weight: 600;
+    }
+
+    .timeline-time {
+      font-size: 11px;
+      color: var(--color-text-secondary);
+      margin-top: 2px;
+    }
+
+    /* ========================================
+       MOBILE OVERLAY
+       ======================================== */
+    .sidebar-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.4);
+      z-index: 90;
+      opacity: 0;
+      transition: opacity var(--transition-speed) ease;
+    }
+
+    .sidebar-overlay.visible {
+      opacity: 1;
+    }
+
+    /* ========================================
+       RESPONSIVE
+       ======================================== */
+    @media (max-width: 1024px) {
+      .dashboard-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .right-column {
+        flex-direction: row;
+        flex-wrap: wrap;
+      }
+
+      .right-column > .section-card {
+        flex: 1;
+        min-width: 280px;
+      }
+    }
+
+    @media (max-width: 768px) {
+      .sidebar {
+        transform: translateX(-100%);
+        width: var(--sidebar-width) !important;
+      }
+
+      .sidebar.mobile-open {
+        transform: translateX(0);
+      }
+
+      .sidebar-overlay {
+        display: block;
+      }
+
+      .main-area {
+        margin-left: 0 !important;
+      }
+
+      .content {
+        padding: 20px 16px;
+      }
+
+      .topbar {
+        padding: 0 16px;
+      }
+
+      .stats-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+      }
+
+      .weather-grid {
+        grid-template-columns: repeat(4, 1fr);
+      }
+
+      .right-column {
+        flex-direction: column;
+      }
+
+      .right-column > .section-card {
+        min-width: auto;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .stats-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .weather-grid {
+        grid-template-columns: repeat(3, 1fr);
+      }
+
+      .task-meta {
+        flex-wrap: wrap;
+      }
+    }
+
+    /* ========================================
+       SCROLLBAR
+       ======================================== */
+    ::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background: var(--color-border);
+      border-radius: 3px;
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background: var(--color-text-secondary);
+    }
+  </style>
+</head>
+<body>
+  <!-- Sidebar Overlay (mobile) -->
+  <div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+  <div class="app-layout">
+    <!-- ========== SIDEBAR ========== -->
+    <aside class="sidebar" id="sidebar">
+      <div class="sidebar-header">
+        <div class="sidebar-logo">
+          <div class="logo-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 22c-4-3-8-6-8-11a8 8 0 0 1 16 0c0 5-4 8-8 11z"/>
+              <path d="M12 11c0-3 2-5 4-6"/>
+              <path d="M12 11c0-3-2-5-4-6"/>
+            </svg>
+          </div>
+          <span class="logo-text">GardenFlow</span>
+        </div>
+      </div>
+
+      <nav class="sidebar-nav">
+        <a href="#" class="nav-item active" data-tooltip="Dashboard">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="7" height="7" rx="1"/>
+            <rect x="14" y="3" width="7" height="7" rx="1"/>
+            <rect x="3" y="14" width="7" height="7" rx="1"/>
+            <rect x="14" y="14" width="7" height="7" rx="1"/>
+          </svg>
+          <span class="nav-item-label">Dashboard</span>
+        </a>
+        <a href="#" class="nav-item" data-tooltip="Aufgaben">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 11l3 3L22 4"/>
+            <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+          </svg>
+          <span class="nav-item-label">Aufgaben</span>
+        </a>
+        <a href="#" class="nav-item" data-tooltip="Pflanzen">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M7 20h10"/>
+            <path d="M12 20V10"/>
+            <path d="M12 10c-2-4-6-5-9-4 3-1 6 1 9 4z"/>
+            <path d="M12 10c2-4 6-5 9-4-3-1-6 1-9 4z"/>
+            <path d="M12 10c0-4 1-7 0-10 0 3-1 6 0 10z"/>
+          </svg>
+          <span class="nav-item-label">Pflanzen</span>
+        </a>
+        <a href="#" class="nav-item" data-tooltip="Statistiken">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="20" x2="18" y2="10"/>
+            <line x1="12" y1="20" x2="12" y2="4"/>
+            <line x1="6" y1="20" x2="6" y2="14"/>
+          </svg>
+          <span class="nav-item-label">Statistiken</span>
+        </a>
+        <a href="#" class="nav-item" data-tooltip="Logs">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+            <polyline points="14 2 14 8 20 8"/>
+            <line x1="16" y1="13" x2="8" y2="13"/>
+            <line x1="16" y1="17" x2="8" y2="17"/>
+            <line x1="10" y1="9" x2="8" y2="9"/>
+          </svg>
+          <span class="nav-item-label">Logs</span>
+        </a>
+      </nav>
+
+      <div class="sidebar-footer">
+        <button class="theme-toggle" id="themeToggle" title="Theme umschalten">
+          <svg id="themeIconLight" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5"/>
+            <line x1="12" y1="1" x2="12" y2="3"/>
+            <line x1="12" y1="21" x2="12" y2="23"/>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+            <line x1="1" y1="12" x2="3" y2="12"/>
+            <line x1="21" y1="12" x2="23" y2="12"/>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+          </svg>
+          <svg id="themeIconDark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none;">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+          </svg>
+          <span class="theme-toggle-label">Dark Mode</span>
+        </button>
+      </div>
+    </aside>
+
+    <!-- ========== MAIN AREA ========== -->
+    <div class="main-area" id="mainArea">
+      <!-- Topbar -->
+      <header class="topbar">
+        <button class="sidebar-toggle" id="sidebarToggle" title="Sidebar umschalten">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="3" y1="6" x2="21" y2="6"/>
+            <line x1="3" y1="12" x2="17" y2="12"/>
+            <line x1="3" y1="18" x2="21" y2="18"/>
+          </svg>
+        </button>
+
+        <div class="search-wrapper">
+          <span class="search-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8"/>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+          </span>
+          <input type="text" class="search-input" placeholder="Pflanzen, Aufgaben oder Bereiche suchen...">
+        </div>
+
+        <div class="topbar-right">
+          <button class="notification-btn" title="Benachrichtigungen">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+              <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+            </svg>
+            <span class="notification-badge"></span>
+          </button>
+          <div class="user-avatar" title="Markus Gruen">MG</div>
+        </div>
+      </header>
+
+      <!-- Content -->
+      <main class="content">
+        <!-- Welcome -->
+        <div class="welcome-section">
+          <h1>Willkommen zurueck, Markus</h1>
+          <p class="welcome-date" id="currentDate">Montag, 30. Maerz 2026</p>
+        </div>
+
+        <!-- Stat Cards -->
+        <div class="stats-grid">
+          <div class="stat-card">
+            <div class="stat-card-header">
+              <div class="stat-card-icon open">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="10"/>
+                  <line x1="12" y1="8" x2="12" y2="12"/>
+                  <line x1="12" y1="16" x2="12.01" y2="16"/>
+                </svg>
+              </div>
+              <span class="stat-card-trend down">-3</span>
+            </div>
+            <div class="stat-card-value">12</div>
+            <div class="stat-card-label">Offene Aufgaben</div>
+          </div>
+
+          <div class="stat-card">
+            <div class="stat-card-header">
+              <div class="stat-card-icon done">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="20 6 9 17 4 12"/>
+                </svg>
+              </div>
+              <span class="stat-card-trend up">+8</span>
+            </div>
+            <div class="stat-card-value">34</div>
+            <div class="stat-card-label">Erledigt diese Woche</div>
+          </div>
+
+          <div class="stat-card">
+            <div class="stat-card-header">
+              <div class="stat-card-icon team">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+                  <circle cx="9" cy="7" r="4"/>
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+                </svg>
+              </div>
+              <span class="stat-card-trend up">+1</span>
+            </div>
+            <div class="stat-card-value">5</div>
+            <div class="stat-card-label">Mitarbeiter aktiv</div>
+          </div>
+
+          <div class="stat-card">
+            <div class="stat-card-header">
+              <div class="stat-card-icon weather">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="5"/>
+                  <line x1="12" y1="1" x2="12" y2="3"/>
+                  <line x1="12" y1="21" x2="12" y2="23"/>
+                  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+                  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+                  <line x1="1" y1="12" x2="3" y2="12"/>
+                  <line x1="21" y1="12" x2="23" y2="12"/>
+                  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+                  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+                </svg>
+              </div>
+            </div>
+            <div class="stat-card-value">18°C</div>
+            <div class="stat-card-label">Aktuelles Wetter</div>
+          </div>
+        </div>
+
+        <!-- Dashboard Grid -->
+        <div class="dashboard-grid">
+          <!-- Tasks -->
+          <div class="section-card">
+            <div class="section-header">
+              <div style="display:flex; align-items:center; gap:12px;">
+                <h2>Heutige Aufgaben</h2>
+                <span class="section-count">5 Aufgaben</span>
+              </div>
+              <button class="btn-primary">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+                  <line x1="12" y1="5" x2="12" y2="19"/>
+                  <line x1="5" y1="12" x2="19" y2="12"/>
+                </svg>
+                Neue Aufgabe
+              </button>
+            </div>
+
+            <div class="task-list">
+              <!-- Task 1 -->
+              <div class="task-item" data-task>
+                <span class="task-priority high"></span>
+                <input type="checkbox" class="task-checkbox">
+                <div class="task-content">
+                  <div class="task-title">Tomaten im Gewaechshaus giessen</div>
+                  <div class="task-meta">
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+                      Gewaechshaus A
+                    </span>
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                      Lisa M.
+                    </span>
+                  </div>
+                </div>
+                <span class="task-time">07:00</span>
+              </div>
+
+              <!-- Task 2 -->
+              <div class="task-item" data-task>
+                <span class="task-priority high"></span>
+                <input type="checkbox" class="task-checkbox">
+                <div class="task-content">
+                  <div class="task-title">Rosenbeet Rueckschnitt vorbereiten</div>
+                  <div class="task-meta">
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+                      Rosengarten
+                    </span>
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                      Thomas K.
+                    </span>
+                  </div>
+                </div>
+                <span class="task-time">08:30</span>
+              </div>
+
+              <!-- Task 3 -->
+              <div class="task-item" data-task>
+                <span class="task-priority medium"></span>
+                <input type="checkbox" class="task-checkbox">
+                <div class="task-content">
+                  <div class="task-title">Kompost umsetzen und verteilen</div>
+                  <div class="task-meta">
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+                      Kompostplatz
+                    </span>
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                      Stefan B.
+                    </span>
+                  </div>
+                </div>
+                <span class="task-time">10:00</span>
+              </div>
+
+              <!-- Task 4 -->
+              <div class="task-item" data-task>
+                <span class="task-priority low"></span>
+                <input type="checkbox" class="task-checkbox">
+                <div class="task-content">
+                  <div class="task-title">Bewaesserungsanlage Sektor 3 pruefen</div>
+                  <div class="task-meta">
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+                      Sektor 3
+                    </span>
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                      Markus G.
+                    </span>
+                  </div>
+                </div>
+                <span class="task-time">13:00</span>
+              </div>
+
+              <!-- Task 5 -->
+              <div class="task-item" data-task>
+                <span class="task-priority medium"></span>
+                <input type="checkbox" class="task-checkbox">
+                <div class="task-content">
+                  <div class="task-title">Neupflanzung Lavendel im Kraeuterbeet</div>
+                  <div class="task-meta">
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+                      Kraeutergarten
+                    </span>
+                    <span class="task-meta-item">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                      Anna R.
+                    </span>
+                  </div>
+                </div>
+                <span class="task-time">15:00</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Right Column -->
+          <div class="right-column">
+            <!-- Weather Week -->
+            <div class="section-card">
+              <div class="section-header">
+                <h2>Wetter diese Woche</h2>
+                <button class="btn-secondary" style="padding:6px 12px; font-size:12px;">Details</button>
+              </div>
+              <div class="weather-grid">
+                <div class="weather-day today">
+                  <span class="weather-day-name">Mo</span>
+                  <span class="weather-day-icon">&#9728;&#65039;</span>
+                  <span class="weather-day-temp">18°</span>
+                  <span class="weather-day-templow">8°</span>
+                </div>
+                <div class="weather-day">
+                  <span class="weather-day-name">Di</span>
+                  <span class="weather-day-icon">&#9925;</span>
+                  <span class="weather-day-temp">16°</span>
+                  <span class="weather-day-templow">7°</span>
+                </div>
+                <div class="weather-day">
+                  <span class="weather-day-name">Mi</span>
+                  <span class="weather-day-icon">&#127782;&#65039;</span>
+                  <span class="weather-day-temp">14°</span>
+                  <span class="weather-day-templow">6°</span>
+                </div>
+                <div class="weather-day">
+                  <span class="weather-day-name">Do</span>
+                  <span class="weather-day-icon">&#127783;&#65039;</span>
+                  <span class="weather-day-temp">11°</span>
+                  <span class="weather-day-templow">5°</span>
+                </div>
+                <div class="weather-day">
+                  <span class="weather-day-name">Fr</span>
+                  <span class="weather-day-icon">&#127780;&#65039;</span>
+                  <span class="weather-day-temp">15°</span>
+                  <span class="weather-day-templow">6°</span>
+                </div>
+                <div class="weather-day">
+                  <span class="weather-day-name">Sa</span>
+                  <span class="weather-day-icon">&#9728;&#65039;</span>
+                  <span class="weather-day-temp">19°</span>
+                  <span class="weather-day-templow">9°</span>
+                </div>
+                <div class="weather-day">
+                  <span class="weather-day-name">So</span>
+                  <span class="weather-day-icon">&#9728;&#65039;</span>
+                  <span class="weather-day-temp">21°</span>
+                  <span class="weather-day-templow">10°</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Activity Timeline -->
+            <div class="section-card">
+              <div class="section-header">
+                <h2>Letzte Aktivitaeten</h2>
+                <button class="btn-secondary" style="padding:6px 12px; font-size:12px;">Alle anzeigen</button>
+              </div>
+              <div class="timeline">
+                <div class="timeline-item">
+                  <div class="timeline-dot-wrapper">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-line"></div>
+                  </div>
+                  <div class="timeline-content">
+                    <div class="timeline-text"><strong>Lisa M.</strong> hat die Bewaesserung in <strong>Gewaechshaus B</strong> abgeschlossen</div>
+                    <div class="timeline-time">Vor 15 Minuten</div>
+                  </div>
+                </div>
+                <div class="timeline-item">
+                  <div class="timeline-dot-wrapper">
+                    <div class="timeline-dot accent"></div>
+                    <div class="timeline-line"></div>
+                  </div>
+                  <div class="timeline-content">
+                    <div class="timeline-text"><strong>Thomas K.</strong> hat <strong>3 neue Pflanzen</strong> im Kraeuterbeet erfasst</div>
+                    <div class="timeline-time">Vor 42 Minuten</div>
+                  </div>
+                </div>
+                <div class="timeline-item">
+                  <div class="timeline-dot-wrapper">
+                    <div class="timeline-dot secondary"></div>
+                    <div class="timeline-line"></div>
+                  </div>
+                  <div class="timeline-content">
+                    <div class="timeline-text"><strong>Stefan B.</strong> hat einen Schaedlingsbefall in <strong>Sektor 2</strong> gemeldet</div>
+                    <div class="timeline-time">Vor 1 Stunde</div>
+                  </div>
+                </div>
+                <div class="timeline-item">
+                  <div class="timeline-dot-wrapper">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-line"></div>
+                  </div>
+                  <div class="timeline-content">
+                    <div class="timeline-text"><strong>Anna R.</strong> hat den Wochenbericht fuer <strong>Kalenderwoche 13</strong> erstellt</div>
+                    <div class="timeline-time">Vor 2 Stunden</div>
+                  </div>
+                </div>
+                <div class="timeline-item">
+                  <div class="timeline-dot-wrapper">
+                    <div class="timeline-dot accent"></div>
+                    <div class="timeline-line"></div>
+                  </div>
+                  <div class="timeline-content">
+                    <div class="timeline-text"><strong>Markus G.</strong> hat die Duengeplanung fuer <strong>April</strong> freigegeben</div>
+                    <div class="timeline-time">Vor 3 Stunden</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    /* ========================================
+       SIDEBAR TOGGLE
+       ======================================== */
+    const sidebar = document.getElementById('sidebar');
+    const mainArea = document.getElementById('mainArea');
+    const sidebarToggle = document.getElementById('sidebarToggle');
+    const sidebarOverlay = document.getElementById('sidebarOverlay');
+
+    function isMobile() {
+      return window.innerWidth <= 768;
+    }
+
+    sidebarToggle.addEventListener('click', () => {
+      if (isMobile()) {
+        sidebar.classList.toggle('mobile-open');
+        sidebarOverlay.classList.toggle('visible');
+      } else {
+        sidebar.classList.toggle('collapsed');
+      }
+    });
+
+    sidebarOverlay.addEventListener('click', () => {
+      sidebar.classList.remove('mobile-open');
+      sidebarOverlay.classList.remove('visible');
+    });
+
+    // Close mobile sidebar on resize to desktop
+    window.addEventListener('resize', () => {
+      if (!isMobile()) {
+        sidebar.classList.remove('mobile-open');
+        sidebarOverlay.classList.remove('visible');
+      }
+    });
+
+    /* ========================================
+       DARK MODE TOGGLE
+       ======================================== */
+    const themeToggle = document.getElementById('themeToggle');
+    const themeIconLight = document.getElementById('themeIconLight');
+    const themeIconDark = document.getElementById('themeIconDark');
+    const toggleLabel = themeToggle.querySelector('.theme-toggle-label');
+
+    function setTheme(theme) {
+      document.documentElement.setAttribute('data-theme', theme);
+      localStorage.setItem('gardenflow-theme', theme);
+      if (theme === 'dark') {
+        themeIconLight.style.display = 'none';
+        themeIconDark.style.display = 'block';
+        toggleLabel.textContent = 'Light Mode';
+      } else {
+        themeIconLight.style.display = 'block';
+        themeIconDark.style.display = 'none';
+        toggleLabel.textContent = 'Dark Mode';
+      }
+    }
+
+    // Load saved theme
+    const savedTheme = localStorage.getItem('gardenflow-theme') || 'light';
+    setTheme(savedTheme);
+
+    themeToggle.addEventListener('click', () => {
+      const current = document.documentElement.getAttribute('data-theme');
+      setTheme(current === 'dark' ? 'light' : 'dark');
+    });
+
+    /* ========================================
+       TASK CHECKBOXES
+       ======================================== */
+    document.querySelectorAll('.task-checkbox').forEach(checkbox => {
+      checkbox.addEventListener('change', function() {
+        const taskItem = this.closest('.task-item');
+        if (this.checked) {
+          taskItem.classList.add('completed');
+        } else {
+          taskItem.classList.remove('completed');
+        }
+      });
+    });
+
+    /* ========================================
+       NAV ITEM ACTIVE STATE
+       ======================================== */
+    document.querySelectorAll('.nav-item').forEach(item => {
+      item.addEventListener('click', function(e) {
+        e.preventDefault();
+        document.querySelectorAll('.nav-item').forEach(i => i.classList.remove('active'));
+        this.classList.add('active');
+
+        // Close mobile sidebar on nav click
+        if (isMobile()) {
+          sidebar.classList.remove('mobile-open');
+          sidebarOverlay.classList.remove('visible');
+        }
+      });
+    });
+
+    /* ========================================
+       DATE DISPLAY
+       ======================================== */
+    const dateEl = document.getElementById('currentDate');
+    const now = new Date();
+    const days = ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'];
+    const months = ['Januar', 'Februar', 'Maerz', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'];
+    dateEl.textContent = `${days[now.getDay()]}, ${now.getDate()}. ${months[now.getMonth()]} ${now.getFullYear()}`;
+  </script>
+</body>
+</html>

--- a/mockups/02-gruen-und-klar.html
+++ b/mockups/02-gruen-und-klar.html
@@ -1,0 +1,1227 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GardenPlanner — Grün &amp; Klar</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Karla:wght@300;400;500;600&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        /* ===== Reset & Base ===== */
+        *, *::before, *::after {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        :root {
+            --primary: #14532D;
+            --secondary: #86EFAC;
+            --accent: #D97706;
+            --bg: #FDFDFC;
+            --text: #111827;
+            --text-secondary: #9CA3AF;
+            --border: #F3F4F6;
+            --tag-bg: #ECFDF5;
+            --input-border: #E5E7EB;
+            --font-heading: 'Playfair Display', Georgia, serif;
+            --font-body: 'Karla', -apple-system, sans-serif;
+            --font-mono: 'JetBrains Mono', monospace;
+        }
+
+        [data-theme="dark"] {
+            --bg: #0A0A0A;
+            --text: #E5E7EB;
+            --text-secondary: #6B7280;
+            --border: #1F1F1F;
+            --tag-bg: #14532D20;
+            --input-border: #2A2A2A;
+            --primary: #86EFAC;
+            --surface: #161616;
+        }
+
+        html {
+            scroll-behavior: smooth;
+        }
+
+        body {
+            font-family: var(--font-body);
+            font-size: 15px;
+            line-height: 1.7;
+            color: var(--text);
+            background-color: var(--bg);
+            transition: background-color 0.4s ease, color 0.4s ease;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        /* ===== Layout ===== */
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 24px;
+        }
+
+        /* ===== Navigation ===== */
+        nav {
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            background-color: var(--bg);
+            transition: background-color 0.4s ease;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .nav-inner {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 0 24px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            height: 56px;
+        }
+
+        .nav-brand {
+            font-family: var(--font-heading);
+            font-size: 18px;
+            font-weight: 700;
+            color: var(--text);
+            text-decoration: none;
+            letter-spacing: -0.02em;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 32px;
+            list-style: none;
+        }
+
+        .nav-links a {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text-secondary);
+            text-decoration: none;
+            padding: 16px 0;
+            position: relative;
+            transition: color 0.2s ease;
+        }
+
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background-color: var(--primary);
+            transition: width 0.25s ease;
+        }
+
+        .nav-links a:hover,
+        .nav-links a.active {
+            color: var(--text);
+        }
+
+        .nav-links a.active::after,
+        .nav-links a:hover::after {
+            width: 100%;
+        }
+
+        .nav-right {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        /* ===== Dark Mode Toggle ===== */
+        .theme-toggle {
+            background: none;
+            border: none;
+            cursor: pointer;
+            width: 36px;
+            height: 36px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 8px;
+            color: var(--text-secondary);
+            transition: color 0.2s ease;
+        }
+
+        .theme-toggle:hover {
+            color: var(--text);
+        }
+
+        .theme-toggle svg {
+            width: 18px;
+            height: 18px;
+            transition: transform 0.3s ease, opacity 0.2s ease;
+        }
+
+        .theme-toggle .icon-moon { display: none; }
+        [data-theme="dark"] .theme-toggle .icon-sun { display: none; }
+        [data-theme="dark"] .theme-toggle .icon-moon { display: block; }
+
+        /* ===== Main Content ===== */
+        main {
+            padding: 48px 0 80px;
+        }
+
+        /* ===== Greeting ===== */
+        .greeting {
+            margin-bottom: 8px;
+            opacity: 0;
+            transform: translateY(8px);
+            animation: fadeUp 0.6s ease forwards;
+        }
+
+        .greeting h1 {
+            font-family: var(--font-heading);
+            font-size: 32px;
+            font-weight: 700;
+            color: var(--text);
+            line-height: 1.3;
+            letter-spacing: -0.02em;
+        }
+
+        .greeting-sub {
+            font-size: 15px;
+            color: var(--text-secondary);
+            margin-top: 4px;
+        }
+
+        /* ===== Inline Stats ===== */
+        .stats-line {
+            font-family: var(--font-mono);
+            font-size: 14px;
+            color: var(--text-secondary);
+            margin-top: 20px;
+            padding-bottom: 32px;
+            border-bottom: 1px solid var(--border);
+            opacity: 0;
+            transform: translateY(8px);
+            animation: fadeUp 0.6s ease 0.1s forwards;
+        }
+
+        .stats-line .stat-num {
+            font-weight: 500;
+            color: var(--text);
+        }
+
+        .stats-line .stat-dot {
+            margin: 0 12px;
+            color: var(--text-secondary);
+            opacity: 0.4;
+        }
+
+        .stats-line .stat-highlight {
+            color: var(--primary);
+            font-weight: 500;
+        }
+
+        [data-theme="dark"] .stats-line .stat-num {
+            color: #E5E7EB;
+        }
+
+        /* ===== Section Headers ===== */
+        .section-header {
+            font-family: var(--font-heading);
+            font-size: 22px;
+            font-weight: 600;
+            color: var(--text);
+            margin-top: 40px;
+            margin-bottom: 24px;
+            letter-spacing: -0.01em;
+        }
+
+        .section-header-small {
+            font-family: var(--font-body);
+            font-size: 13px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--text-secondary);
+            margin-top: 36px;
+            margin-bottom: 16px;
+        }
+
+        /* ===== Task List ===== */
+        .task-list {
+            list-style: none;
+        }
+
+        .task-item {
+            padding: 14px 0;
+            border-bottom: 1px solid var(--border);
+            opacity: 0;
+            transform: translateY(6px);
+            animation: fadeUp 0.5s ease forwards;
+        }
+
+        .task-item:last-child {
+            border-bottom: none;
+        }
+
+        .task-top {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .task-checkbox {
+            appearance: none;
+            -webkit-appearance: none;
+            width: 18px;
+            height: 18px;
+            min-width: 18px;
+            border: 1.5px solid var(--input-border);
+            border-radius: 4px;
+            cursor: pointer;
+            position: relative;
+            transition: border-color 0.2s ease, background-color 0.2s ease;
+        }
+
+        .task-checkbox:hover {
+            border-color: var(--primary);
+        }
+
+        .task-checkbox:checked {
+            background-color: var(--primary);
+            border-color: var(--primary);
+        }
+
+        .task-checkbox:checked::after {
+            content: '';
+            position: absolute;
+            top: 2px;
+            left: 5px;
+            width: 5px;
+            height: 9px;
+            border: solid white;
+            border-width: 0 2px 2px 0;
+            transform: rotate(45deg);
+        }
+
+        [data-theme="dark"] .task-checkbox:checked {
+            background-color: #86EFAC;
+            border-color: #86EFAC;
+        }
+
+        [data-theme="dark"] .task-checkbox:checked::after {
+            border-color: #0A0A0A;
+        }
+
+        .task-title {
+            font-size: 15px;
+            font-weight: 500;
+            color: var(--text);
+            transition: color 0.3s ease, text-decoration 0.3s ease;
+        }
+
+        .task-item.completed .task-title {
+            text-decoration: line-through;
+            color: var(--text-secondary);
+        }
+
+        .task-priority {
+            font-family: var(--font-mono);
+            font-size: 11px;
+            font-weight: 500;
+            padding: 2px 8px;
+            border-radius: 4px;
+            margin-left: auto;
+            white-space: nowrap;
+        }
+
+        .priority-high {
+            color: #DC2626;
+            background: #FEF2F2;
+        }
+
+        .priority-medium {
+            color: var(--accent);
+            background: #FFFBEB;
+        }
+
+        .priority-low {
+            color: #059669;
+            background: var(--tag-bg);
+        }
+
+        [data-theme="dark"] .priority-high {
+            background: #DC262620;
+        }
+
+        [data-theme="dark"] .priority-medium {
+            background: #D9770620;
+        }
+
+        [data-theme="dark"] .priority-low {
+            background: #05966920;
+        }
+
+        /* Dot Leaders */
+        .task-meta {
+            display: flex;
+            align-items: center;
+            margin-top: 4px;
+            padding-left: 30px;
+            font-size: 13px;
+            color: var(--text-secondary);
+            gap: 0;
+        }
+
+        .task-meta-item {
+            white-space: nowrap;
+        }
+
+        .dot-leader {
+            flex: 1;
+            border-bottom: 1px dotted var(--text-secondary);
+            opacity: 0.3;
+            margin: 0 8px;
+            min-width: 20px;
+            position: relative;
+            top: -3px;
+        }
+
+        .task-meta-right {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            white-space: nowrap;
+        }
+
+        .meta-separator {
+            margin: 0 6px;
+            opacity: 0.4;
+        }
+
+        /* ===== Week View ===== */
+        .week-day {
+            margin-bottom: 8px;
+        }
+
+        .week-day-label {
+            font-family: var(--font-body);
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--text-secondary);
+            margin-bottom: 4px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .week-day-label .day-indicator {
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background-color: var(--secondary);
+        }
+
+        .week-day-label .today-indicator {
+            background-color: var(--accent);
+        }
+
+        .week-tasks {
+            padding-left: 14px;
+            list-style: none;
+        }
+
+        .week-tasks .task-item {
+            padding: 10px 0;
+            border-bottom: 1px solid var(--border);
+        }
+
+        /* ===== Weather ===== */
+        .weather-strip {
+            margin-top: 40px;
+            padding: 20px 0;
+            border-top: 1px solid var(--border);
+            border-bottom: 1px solid var(--border);
+            opacity: 0;
+            transform: translateY(6px);
+            animation: fadeUp 0.5s ease 0.5s forwards;
+        }
+
+        .weather-label {
+            font-size: 13px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--text-secondary);
+            margin-bottom: 12px;
+        }
+
+        .weather-days {
+            display: flex;
+            justify-content: space-between;
+            font-family: var(--font-mono);
+            font-size: 14px;
+        }
+
+        .weather-day {
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .weather-day-name {
+            font-family: var(--font-body);
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--text-secondary);
+        }
+
+        .weather-day-icon {
+            font-size: 18px;
+            line-height: 1;
+        }
+
+        .weather-day-temp {
+            font-weight: 500;
+            color: var(--text);
+        }
+
+        .weather-day-temp sup {
+            font-size: 10px;
+        }
+
+        /* ===== Buttons ===== */
+        .btn-primary {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 500;
+            background-color: #14532D;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            padding: 10px 20px;
+            cursor: pointer;
+            transition: opacity 0.2s ease;
+        }
+
+        .btn-primary:hover {
+            opacity: 0.88;
+        }
+
+        [data-theme="dark"] .btn-primary {
+            background-color: #86EFAC;
+            color: #0A0A0A;
+        }
+
+        .btn-text {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 500;
+            background: none;
+            border: none;
+            color: var(--text-secondary);
+            cursor: pointer;
+            padding: 0;
+            text-decoration: none;
+            transition: color 0.2s ease;
+        }
+
+        .btn-text:hover {
+            color: var(--text);
+            text-decoration: underline;
+        }
+
+        /* ===== Input Demo ===== */
+        .input-section {
+            margin-top: 40px;
+            padding-top: 32px;
+            border-top: 1px solid var(--border);
+            opacity: 0;
+            transform: translateY(6px);
+            animation: fadeUp 0.5s ease 0.6s forwards;
+        }
+
+        .input-group {
+            position: relative;
+            margin-bottom: 32px;
+        }
+
+        .input-field {
+            font-family: var(--font-body);
+            font-size: 15px;
+            width: 100%;
+            padding: 8px 0;
+            border: none;
+            border-bottom: 1.5px solid var(--input-border);
+            background: transparent;
+            color: var(--text);
+            outline: none;
+            transition: border-color 0.2s ease;
+        }
+
+        .input-field:focus {
+            border-bottom-color: var(--primary);
+        }
+
+        .input-field::placeholder {
+            color: transparent;
+        }
+
+        .input-label {
+            position: absolute;
+            top: 8px;
+            left: 0;
+            font-size: 15px;
+            color: var(--text-secondary);
+            pointer-events: none;
+            transition: all 0.2s ease;
+        }
+
+        .input-field:focus ~ .input-label,
+        .input-field:not(:placeholder-shown) ~ .input-label {
+            top: -14px;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: var(--primary);
+        }
+
+        /* ===== Modal ===== */
+        .modal-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.3);
+            backdrop-filter: blur(4px);
+            z-index: 200;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+
+        .modal-overlay.active {
+            opacity: 1;
+            pointer-events: all;
+        }
+
+        .modal {
+            background-color: var(--bg);
+            max-width: 480px;
+            width: 90%;
+            border-radius: 12px;
+            padding: 32px;
+            transform: translateY(20px) scale(0.97);
+            transition: transform 0.3s ease;
+        }
+
+        .modal-overlay.active .modal {
+            transform: translateY(0) scale(1);
+        }
+
+        .modal h2 {
+            font-family: var(--font-heading);
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 8px;
+        }
+
+        .modal p {
+            color: var(--text-secondary);
+            font-size: 14px;
+            margin-bottom: 24px;
+            line-height: 1.6;
+        }
+
+        .modal-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 12px;
+        }
+
+        /* ===== Tags ===== */
+        .tag {
+            display: inline-block;
+            font-size: 12px;
+            font-weight: 500;
+            padding: 3px 10px;
+            border-radius: 4px;
+            background-color: var(--tag-bg);
+            color: var(--primary);
+        }
+
+        [data-theme="dark"] .tag {
+            color: #86EFAC;
+        }
+
+        /* ===== Quick-Add Bar ===== */
+        .quick-add {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-top: 24px;
+            padding: 12px 0;
+            opacity: 0;
+            transform: translateY(6px);
+            animation: fadeUp 0.5s ease 0.35s forwards;
+        }
+
+        .quick-add-input {
+            font-family: var(--font-body);
+            font-size: 14px;
+            flex: 1;
+            padding: 8px 0;
+            border: none;
+            border-bottom: 1.5px solid var(--input-border);
+            background: transparent;
+            color: var(--text);
+            outline: none;
+            transition: border-color 0.2s ease;
+        }
+
+        .quick-add-input:focus {
+            border-bottom-color: var(--primary);
+        }
+
+        .quick-add-input::placeholder {
+            color: var(--text-secondary);
+        }
+
+        /* ===== Animations ===== */
+        @keyframes fadeUp {
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        /* Staggered animation delays for task items */
+        .task-item:nth-child(1) { animation-delay: 0.15s; }
+        .task-item:nth-child(2) { animation-delay: 0.22s; }
+        .task-item:nth-child(3) { animation-delay: 0.29s; }
+        .task-item:nth-child(4) { animation-delay: 0.36s; }
+        .task-item:nth-child(5) { animation-delay: 0.43s; }
+        .task-item:nth-child(6) { animation-delay: 0.50s; }
+
+        /* ===== Footer ===== */
+        footer {
+            padding: 32px 0;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+
+        footer a {
+            color: var(--text-secondary);
+            text-decoration: none;
+        }
+
+        footer a:hover {
+            text-decoration: underline;
+        }
+
+        /* ===== Dark Mode Surface Cards ===== */
+        [data-theme="dark"] nav {
+            background-color: var(--surface);
+        }
+
+        [data-theme="dark"] .modal {
+            background-color: var(--surface);
+        }
+
+        /* ===== Responsive ===== */
+        @media (max-width: 600px) {
+            .nav-links {
+                gap: 20px;
+            }
+
+            .greeting h1 {
+                font-size: 26px;
+            }
+
+            .stats-line {
+                font-size: 12px;
+            }
+
+            .stats-line .stat-dot {
+                margin: 0 6px;
+            }
+
+            .weather-days {
+                font-size: 12px;
+            }
+        }
+    </style>
+</head>
+<body>
+
+    <!-- Navigation -->
+    <nav>
+        <div class="nav-inner">
+            <a href="#" class="nav-brand">GardenPlanner</a>
+            <ul class="nav-links">
+                <li><a href="#" class="active">Dashboard</a></li>
+                <li><a href="#">Aufgaben</a></li>
+                <li><a href="#">Beete</a></li>
+                <li><a href="#">Kalender</a></li>
+            </ul>
+            <div class="nav-right">
+                <button class="theme-toggle" id="themeToggle" aria-label="Farbschema umschalten">
+                    <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="5"></circle>
+                        <line x1="12" y1="1" x2="12" y2="3"></line>
+                        <line x1="12" y1="21" x2="12" y2="23"></line>
+                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                        <line x1="1" y1="12" x2="3" y2="12"></line>
+                        <line x1="21" y1="12" x2="23" y2="12"></line>
+                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                    </svg>
+                    <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                    </svg>
+                </button>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main>
+        <div class="container">
+
+            <!-- Greeting -->
+            <div class="greeting">
+                <h1>Guten Morgen!</h1>
+                <p class="greeting-sub">Hier ist dein Garten-Uberblick.</p>
+            </div>
+
+            <!-- Inline Stats -->
+            <div class="stats-line">
+                <span class="stat-num">12</span> offen
+                <span class="stat-dot">&middot;</span>
+                <span class="stat-num">34</span> erledigt
+                <span class="stat-dot">&middot;</span>
+                <span class="stat-num">5</span> Mitarbeiter
+                <span class="stat-dot">&middot;</span>
+                <span class="stat-highlight">73%</span> Quote
+            </div>
+
+            <!-- Today Section -->
+            <h2 class="section-header">Heute, Montag 30. M&auml;rz</h2>
+
+            <ul class="task-list">
+                <li class="task-item" data-task>
+                    <div class="task-top">
+                        <input type="checkbox" class="task-checkbox" aria-label="Aufgabe abschliessen">
+                        <span class="task-title">Tomaten pikieren und in Einzelt&ouml;pfe umsetzen</span>
+                        <span class="task-priority priority-high">Hoch</span>
+                    </div>
+                    <div class="task-meta">
+                        <span class="task-meta-item">Gew&auml;chshaus</span>
+                        <span class="dot-leader"></span>
+                        <span class="task-meta-right">
+                            <span>Lena M.</span>
+                            <span class="meta-separator">&middot;</span>
+                            <span>09:00</span>
+                        </span>
+                    </div>
+                </li>
+                <li class="task-item" data-task>
+                    <div class="task-top">
+                        <input type="checkbox" class="task-checkbox" aria-label="Aufgabe abschliessen">
+                        <span class="task-title">Kompost umsetzen und neue Schicht anlegen</span>
+                        <span class="task-priority priority-medium">Mittel</span>
+                    </div>
+                    <div class="task-meta">
+                        <span class="task-meta-item">Kompostplatz</span>
+                        <span class="dot-leader"></span>
+                        <span class="task-meta-right">
+                            <span>Thomas K.</span>
+                            <span class="meta-separator">&middot;</span>
+                            <span>11:00</span>
+                        </span>
+                    </div>
+                </li>
+                <li class="task-item" data-task>
+                    <div class="task-top">
+                        <input type="checkbox" class="task-checkbox" aria-label="Aufgabe abschliessen">
+                        <span class="task-title">Fr&uuml;hbeet-Abdeckung kontrollieren</span>
+                        <span class="task-priority priority-low">Niedrig</span>
+                    </div>
+                    <div class="task-meta">
+                        <span class="task-meta-item">Beet A3</span>
+                        <span class="dot-leader"></span>
+                        <span class="task-meta-right">
+                            <span>Mira S.</span>
+                            <span class="meta-separator">&middot;</span>
+                            <span>14:00</span>
+                        </span>
+                    </div>
+                </li>
+            </ul>
+
+            <!-- Quick Add -->
+            <div class="quick-add">
+                <input type="text" class="quick-add-input" placeholder="Neue Aufgabe hinzufugen..." aria-label="Neue Aufgabe">
+                <button class="btn-primary" id="addTaskBtn">Hinzuf&uuml;gen</button>
+            </div>
+
+            <!-- This Week Section -->
+            <h2 class="section-header">Diese Woche</h2>
+
+            <!-- Tuesday -->
+            <div class="week-day">
+                <div class="week-day-label">
+                    <span class="day-indicator"></span>
+                    Dienstag, 31. M&auml;rz
+                </div>
+                <ul class="week-tasks task-list">
+                    <li class="task-item" data-task>
+                        <div class="task-top">
+                            <input type="checkbox" class="task-checkbox" aria-label="Aufgabe abschliessen">
+                            <span class="task-title">Erdbeeren mulchen</span>
+                            <span class="tag">Beet B1</span>
+                        </div>
+                        <div class="task-meta">
+                            <span class="task-meta-item">Beet B1</span>
+                            <span class="dot-leader"></span>
+                            <span class="task-meta-right">
+                                <span>Jonas F.</span>
+                                <span class="meta-separator">&middot;</span>
+                                <span>10:00</span>
+                            </span>
+                        </div>
+                    </li>
+                    <li class="task-item" data-task>
+                        <div class="task-top">
+                            <input type="checkbox" class="task-checkbox" aria-label="Aufgabe abschliessen">
+                            <span class="task-title">Bew&auml;sserungssystem Drucktest</span>
+                        </div>
+                        <div class="task-meta">
+                            <span class="task-meta-item">Hauptleitung</span>
+                            <span class="dot-leader"></span>
+                            <span class="task-meta-right">
+                                <span>Thomas K.</span>
+                                <span class="meta-separator">&middot;</span>
+                                <span>13:00</span>
+                            </span>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Wednesday -->
+            <div class="week-day">
+                <div class="week-day-label">
+                    <span class="day-indicator"></span>
+                    Mittwoch, 1. April
+                </div>
+                <ul class="week-tasks task-list">
+                    <li class="task-item" data-task>
+                        <div class="task-top">
+                            <input type="checkbox" class="task-checkbox" aria-label="Aufgabe abschliessen">
+                            <span class="task-title">Saatgut-Bestellung pr&uuml;fen</span>
+                        </div>
+                        <div class="task-meta">
+                            <span class="task-meta-item">B&uuml;ro</span>
+                            <span class="dot-leader"></span>
+                            <span class="task-meta-right">
+                                <span>Lena M.</span>
+                                <span class="meta-separator">&middot;</span>
+                                <span>09:30</span>
+                            </span>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Thursday -->
+            <div class="week-day">
+                <div class="week-day-label">
+                    <span class="day-indicator"></span>
+                    Donnerstag, 2. April
+                </div>
+                <ul class="week-tasks task-list">
+                    <li class="task-item" data-task>
+                        <div class="task-top">
+                            <input type="checkbox" class="task-checkbox" aria-label="Aufgabe abschliessen">
+                            <span class="task-title">Obstb&auml;ume: Erziehungsschnitt Jungb&auml;ume</span>
+                            <span class="task-priority priority-high">Hoch</span>
+                        </div>
+                        <div class="task-meta">
+                            <span class="task-meta-item">Streuobstwiese</span>
+                            <span class="dot-leader"></span>
+                            <span class="task-meta-right">
+                                <span>Mira S.</span>
+                                <span class="meta-separator">&middot;</span>
+                                <span>08:30</span>
+                            </span>
+                        </div>
+                    </li>
+                    <li class="task-item" data-task>
+                        <div class="task-top">
+                            <input type="checkbox" class="task-checkbox" aria-label="Aufgabe abschliessen">
+                            <span class="task-title">Unkraut j&auml;ten Kr&auml;uterbeet</span>
+                        </div>
+                        <div class="task-meta">
+                            <span class="task-meta-item">Beet C2</span>
+                            <span class="dot-leader"></span>
+                            <span class="task-meta-right">
+                                <span>Anna B.</span>
+                                <span class="meta-separator">&middot;</span>
+                                <span>14:00</span>
+                            </span>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Weather Strip -->
+            <div class="weather-strip">
+                <div class="weather-label">Wetter diese Woche</div>
+                <div class="weather-days">
+                    <div class="weather-day">
+                        <span class="weather-day-name">Mo</span>
+                        <span class="weather-day-icon">&#9925;</span>
+                        <span class="weather-day-temp">18<sup>&deg;</sup></span>
+                    </div>
+                    <div class="weather-day">
+                        <span class="weather-day-name">Di</span>
+                        <span class="weather-day-icon">&#9729;</span>
+                        <span class="weather-day-temp">16<sup>&deg;</sup></span>
+                    </div>
+                    <div class="weather-day">
+                        <span class="weather-day-name">Mi</span>
+                        <span class="weather-day-icon">&#9728;</span>
+                        <span class="weather-day-temp">20<sup>&deg;</sup></span>
+                    </div>
+                    <div class="weather-day">
+                        <span class="weather-day-name">Do</span>
+                        <span class="weather-day-icon">&#9728;</span>
+                        <span class="weather-day-temp">22<sup>&deg;</sup></span>
+                    </div>
+                    <div class="weather-day">
+                        <span class="weather-day-name">Fr</span>
+                        <span class="weather-day-icon">&#9925;</span>
+                        <span class="weather-day-temp">19<sup>&deg;</sup></span>
+                    </div>
+                    <div class="weather-day">
+                        <span class="weather-day-name">Sa</span>
+                        <span class="weather-day-icon">&#9728;</span>
+                        <span class="weather-day-temp">21<sup>&deg;</sup></span>
+                    </div>
+                    <div class="weather-day">
+                        <span class="weather-day-name">So</span>
+                        <span class="weather-day-icon">&#9729;</span>
+                        <span class="weather-day-temp">17<sup>&deg;</sup></span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Input Demo Section -->
+            <div class="input-section">
+                <h2 class="section-header">Neue Aufgabe</h2>
+
+                <div class="input-group">
+                    <input type="text" class="input-field" id="inputTitle" placeholder=" " aria-label="Titel">
+                    <label class="input-label" for="inputTitle">Titel</label>
+                </div>
+
+                <div class="input-group">
+                    <input type="text" class="input-field" id="inputLocation" placeholder=" " aria-label="Standort">
+                    <label class="input-label" for="inputLocation">Standort</label>
+                </div>
+
+                <div class="input-group">
+                    <input type="text" class="input-field" id="inputPerson" placeholder=" " aria-label="Zustandig">
+                    <label class="input-label" for="inputPerson">Zust&auml;ndig</label>
+                </div>
+
+                <div style="display: flex; gap: 12px; align-items: center;">
+                    <button class="btn-primary" id="openModalBtn">Erstellen</button>
+                    <button class="btn-text">Abbrechen</button>
+                </div>
+            </div>
+
+        </div>
+    </main>
+
+    <!-- Modal -->
+    <div class="modal-overlay" id="modalOverlay">
+        <div class="modal">
+            <h2>Aufgabe erstellt</h2>
+            <p>Die neue Aufgabe wurde deinem Gartenplan hinzugef&uuml;gt und ist unter &bdquo;Heute&ldquo; sichtbar.</p>
+            <div class="modal-actions">
+                <button class="btn-text" id="modalClose">Schliessen</button>
+                <button class="btn-primary" id="modalConfirm">Zum Dashboard</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            GardenPlanner &middot; Konzept &bdquo;Gr&uuml;n &amp; Klar&ldquo; &middot; <a href="#">Impressum</a>
+        </div>
+    </footer>
+
+    <script>
+        // ===== Dark Mode Toggle =====
+        const themeToggle = document.getElementById('themeToggle');
+        const root = document.documentElement;
+
+        function setTheme(theme) {
+            root.setAttribute('data-theme', theme);
+            localStorage.setItem('garden-theme', theme);
+        }
+
+        themeToggle.addEventListener('click', () => {
+            const current = root.getAttribute('data-theme');
+            setTheme(current === 'dark' ? 'light' : 'dark');
+        });
+
+        // Restore saved theme
+        const savedTheme = localStorage.getItem('garden-theme');
+        if (savedTheme) {
+            setTheme(savedTheme);
+        } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            setTheme('dark');
+        }
+
+        // ===== Task Checkbox Animation =====
+        document.querySelectorAll('.task-checkbox').forEach(checkbox => {
+            checkbox.addEventListener('change', function () {
+                const taskItem = this.closest('.task-item');
+                if (this.checked) {
+                    taskItem.classList.add('completed');
+                    taskItem.style.transition = 'opacity 0.4s ease';
+                    taskItem.style.opacity = '0.55';
+                } else {
+                    taskItem.classList.remove('completed');
+                    taskItem.style.opacity = '1';
+                }
+            });
+        });
+
+        // ===== Modal =====
+        const modalOverlay = document.getElementById('modalOverlay');
+        const openModalBtn = document.getElementById('openModalBtn');
+        const modalClose = document.getElementById('modalClose');
+        const modalConfirm = document.getElementById('modalConfirm');
+
+        function openModal() {
+            modalOverlay.classList.add('active');
+        }
+
+        function closeModal() {
+            modalOverlay.classList.remove('active');
+        }
+
+        openModalBtn.addEventListener('click', openModal);
+        modalClose.addEventListener('click', closeModal);
+        modalConfirm.addEventListener('click', closeModal);
+        modalOverlay.addEventListener('click', (e) => {
+            if (e.target === modalOverlay) closeModal();
+        });
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') closeModal();
+        });
+
+        // ===== Quick Add Task =====
+        const quickAddInput = document.querySelector('.quick-add-input');
+        const addTaskBtn = document.getElementById('addTaskBtn');
+
+        function addTask() {
+            const title = quickAddInput.value.trim();
+            if (!title) return;
+
+            const taskList = document.querySelector('.task-list');
+            const li = document.createElement('li');
+            li.className = 'task-item';
+            li.setAttribute('data-task', '');
+            li.style.opacity = '0';
+            li.style.transform = 'translateY(6px)';
+            li.innerHTML = `
+                <div class="task-top">
+                    <input type="checkbox" class="task-checkbox" aria-label="Aufgabe abschliessen">
+                    <span class="task-title">${title}</span>
+                    <span class="tag">Neu</span>
+                </div>
+                <div class="task-meta">
+                    <span class="task-meta-item">Nicht zugewiesen</span>
+                    <span class="dot-leader"></span>
+                    <span class="task-meta-right">
+                        <span>&mdash;</span>
+                        <span class="meta-separator">&middot;</span>
+                        <span>Jetzt</span>
+                    </span>
+                </div>
+            `;
+
+            // Insert before the last item or at the end
+            taskList.appendChild(li);
+
+            // Animate in
+            requestAnimationFrame(() => {
+                li.style.transition = 'opacity 0.4s ease, transform 0.4s ease';
+                li.style.opacity = '1';
+                li.style.transform = 'translateY(0)';
+            });
+
+            // Bind checkbox
+            li.querySelector('.task-checkbox').addEventListener('change', function () {
+                const taskItem = this.closest('.task-item');
+                if (this.checked) {
+                    taskItem.classList.add('completed');
+                    taskItem.style.transition = 'opacity 0.4s ease';
+                    taskItem.style.opacity = '0.55';
+                } else {
+                    taskItem.classList.remove('completed');
+                    taskItem.style.opacity = '1';
+                }
+            });
+
+            quickAddInput.value = '';
+            quickAddInput.focus();
+        }
+
+        addTaskBtn.addEventListener('click', addTask);
+        quickAddInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') addTask();
+        });
+
+        // ===== Intersection Observer for Scroll Animations =====
+        const observerOptions = {
+            threshold: 0.1,
+            rootMargin: '0px 0px -40px 0px'
+        };
+
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.style.animationPlayState = 'running';
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, observerOptions);
+
+        document.querySelectorAll('.week-day').forEach((el, i) => {
+            el.style.opacity = '0';
+            el.style.transform = 'translateY(8px)';
+            el.style.animation = `fadeUp 0.5s ease ${0.3 + i * 0.1}s forwards`;
+        });
+    </script>
+
+</body>
+</html>

--- a/mockups/03-terra-dashboard.html
+++ b/mockups/03-terra-dashboard.html
@@ -1,0 +1,1947 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Terra Dashboard — Gartenplaner</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+/* ============================================
+   RESET & BASE
+   ============================================ */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --primary: #166534;
+  --primary-hover: #14532d;
+  --secondary: #4ADE80;
+  --accent: #0EA5E9;
+  --bg: #F8FAFC;
+  --surface: #FFFFFF;
+  --text: #0F172A;
+  --text-secondary: #64748B;
+  --border: #E2E8F0;
+  --hover-row: #F1F5F9;
+  --success: #22C55E;
+  --danger: #EF4444;
+  --warning: #F59E0B;
+  --font-main: 'Manrope', system-ui, -apple-system, sans-serif;
+  --font-mono: 'IBM Plex Mono', 'Consolas', monospace;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04);
+  --shadow-lg: 0 4px 12px rgba(0,0,0,0.08);
+  --transition: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  --sidebar-width: 56px;
+  --topbar-height: 56px;
+}
+
+/* Dark Mode */
+[data-theme="dark"] {
+  --bg: #020617;
+  --surface: #0F172A;
+  --text: #F1F5F9;
+  --text-secondary: #94A3B8;
+  --border: #1E293B;
+  --hover-row: #1E293B;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 1px 3px rgba(0,0,0,0.4), 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-lg: 0 4px 12px rgba(0,0,0,0.4);
+}
+
+html {
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-main);
+  font-weight: 400;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.5;
+  display: flex;
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+
+/* ============================================
+   SIDEBAR
+   ============================================ */
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: var(--sidebar-width);
+  background: var(--primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 12px 0;
+  z-index: 100;
+  gap: 4px;
+}
+
+.sidebar-logo {
+  width: 32px;
+  height: 32px;
+  background: var(--secondary);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+  font-weight: 800;
+  font-size: 16px;
+  color: var(--primary);
+  flex-shrink: 0;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.sidebar-item {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  color: rgba(255,255,255,0.6);
+  cursor: pointer;
+  transition: all var(--transition);
+  border: none;
+  background: none;
+  font-size: 18px;
+}
+
+.sidebar-item:hover,
+.sidebar-item.active {
+  background: rgba(255,255,255,0.15);
+  color: #fff;
+}
+
+.sidebar-item.active {
+  background: rgba(255,255,255,0.2);
+}
+
+.sidebar-item .tooltip {
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--text);
+  color: #fff;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition);
+  z-index: 200;
+}
+
+.sidebar-item .tooltip::before {
+  content: '';
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 4px solid transparent;
+  border-right-color: var(--text);
+}
+
+.sidebar-item:hover .tooltip {
+  opacity: 1;
+}
+
+.sidebar-bottom {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-top: auto;
+}
+
+/* ============================================
+   MAIN LAYOUT
+   ============================================ */
+.main-wrapper {
+  margin-left: var(--sidebar-width);
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* ============================================
+   TOPBAR
+   ============================================ */
+.topbar {
+  height: var(--topbar-height);
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  gap: 16px;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+.topbar-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.topbar-title span {
+  color: var(--primary);
+}
+
+.search-box {
+  flex: 1;
+  max-width: 400px;
+  position: relative;
+  margin-left: 24px;
+}
+
+.search-box input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px 0 36px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-main);
+  font-size: 13px;
+  color: var(--text);
+  outline: none;
+  transition: all var(--transition);
+}
+
+.search-box input::placeholder {
+  color: var(--text-secondary);
+}
+
+.search-box input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(14,165,233,0.12);
+}
+
+.search-box .search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-secondary);
+  font-size: 14px;
+  pointer-events: none;
+}
+
+.search-box .search-kbd {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+  position: relative;
+  font-size: 16px;
+}
+
+.icon-btn:hover {
+  background: var(--hover-row);
+  color: var(--text);
+}
+
+.icon-btn .badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  background: var(--danger);
+  border-radius: 50%;
+  border: 2px solid var(--surface);
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.avatar:hover {
+  box-shadow: 0 0 0 2px var(--surface), 0 0 0 4px var(--primary);
+}
+
+/* ============================================
+   CONTENT AREA
+   ============================================ */
+.content {
+  padding: 24px;
+  flex: 1;
+}
+
+.content-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.content-header h1 {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.content-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn-primary {
+  height: 36px;
+  padding: 0 16px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-main);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: all var(--transition);
+}
+
+.btn-primary:hover {
+  background: var(--primary-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.btn-secondary {
+  height: 36px;
+  padding: 0 16px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-main);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: all var(--transition);
+}
+
+.btn-secondary:hover {
+  background: var(--hover-row);
+  border-color: #CBD5E1;
+}
+
+/* ============================================
+   STAT CARDS
+   ============================================ */
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 20px;
+  transition: all var(--transition);
+}
+
+.stat-card:hover {
+  box-shadow: var(--shadow-md);
+  border-color: #CBD5E1;
+}
+
+[data-theme="dark"] .stat-card:hover {
+  border-color: #334155;
+}
+
+.stat-label {
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.stat-value-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.stat-value {
+  font-family: var(--font-mono);
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+
+.stat-trend {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.stat-trend.up {
+  color: #166534;
+  background: #DCFCE7;
+}
+
+.stat-trend.down {
+  color: #991B1B;
+  background: #FEE2E2;
+}
+
+[data-theme="dark"] .stat-trend.up {
+  color: #4ADE80;
+  background: rgba(74, 222, 128, 0.12);
+}
+
+[data-theme="dark"] .stat-trend.down {
+  color: #F87171;
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.stat-sub {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 6px;
+}
+
+.stat-sub .mono {
+  font-size: 12px;
+}
+
+/* Progress bar in stat card */
+.stat-progress {
+  margin-top: 12px;
+  height: 6px;
+  background: var(--border);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.stat-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--primary), var(--secondary));
+  border-radius: 3px;
+  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 0;
+}
+
+/* ============================================
+   GRID LAYOUT: 2 COLUMNS
+   ============================================ */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.card-header {
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+}
+
+.card-title {
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text);
+}
+
+.card-body {
+  padding: 16px 20px;
+}
+
+/* ============================================
+   BAR CHART (CSS only)
+   ============================================ */
+.bar-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bar-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.bar-label {
+  width: 80px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.bar-track {
+  flex: 1;
+  height: 24px;
+  background: var(--bg);
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+}
+
+.bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 0;
+  display: flex;
+  align-items: center;
+  padding-left: 8px;
+}
+
+.bar-fill-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+}
+
+.bar-fill.green { background: var(--primary); }
+.bar-fill.lime { background: var(--secondary); }
+.bar-fill.blue { background: var(--accent); }
+.bar-fill.amber { background: var(--warning); }
+.bar-fill.red { background: var(--danger); }
+
+.bar-fill.lime .bar-fill-label { color: var(--primary); }
+
+.bar-count {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  width: 28px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* ============================================
+   TABS
+   ============================================ */
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0 20px;
+}
+
+.tab {
+  padding: 12px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border: none;
+  background: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: all var(--transition);
+  font-family: var(--font-main);
+}
+
+.tab:hover {
+  color: var(--text);
+}
+
+.tab.active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+  font-weight: 600;
+}
+
+.tab .tab-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--bg);
+  padding: 1px 6px;
+  border-radius: 10px;
+  margin-left: 6px;
+}
+
+.tab.active .tab-count {
+  background: #DCFCE7;
+  color: var(--primary);
+}
+
+[data-theme="dark"] .tab.active .tab-count {
+  background: rgba(74, 222, 128, 0.12);
+}
+
+/* ============================================
+   TABLE
+   ============================================ */
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead th {
+  background: var(--bg);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  padding: 10px 16px;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+  transition: color var(--transition);
+}
+
+thead th:hover {
+  color: var(--text);
+}
+
+thead th .sort-icon {
+  display: inline-block;
+  margin-left: 4px;
+  opacity: 0.3;
+  font-size: 10px;
+}
+
+thead th.sorted .sort-icon {
+  opacity: 1;
+  color: var(--primary);
+}
+
+tbody td {
+  padding: 12px 16px;
+  font-size: 13px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+tbody tr {
+  transition: background var(--transition);
+}
+
+tbody tr:hover {
+  background: var(--hover-row);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Priority badge */
+.prio {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.prio.p1 { background: #FEE2E2; color: #991B1B; }
+.prio.p2 { background: #FEF3C7; color: #92400E; }
+.prio.p3 { background: #DBEAFE; color: #1E40AF; }
+.prio.p4 { background: var(--bg); color: var(--text-secondary); }
+
+[data-theme="dark"] .prio.p1 { background: rgba(248,113,113,0.15); color: #F87171; }
+[data-theme="dark"] .prio.p2 { background: rgba(245,158,11,0.15); color: #FBBF24; }
+[data-theme="dark"] .prio.p3 { background: rgba(14,165,233,0.15); color: #38BDF8; }
+[data-theme="dark"] .prio.p4 { background: rgba(100,116,139,0.15); color: #94A3B8; }
+
+/* Status badge */
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.status-badge .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.status-badge.open { background: #DBEAFE; color: #1E40AF; }
+.status-badge.open .dot { background: #3B82F6; }
+.status-badge.progress { background: #FEF3C7; color: #92400E; }
+.status-badge.progress .dot { background: #F59E0B; }
+.status-badge.done { background: #DCFCE7; color: #166534; }
+.status-badge.done .dot { background: #22C55E; }
+.status-badge.review { background: #F3E8FF; color: #6B21A8; }
+.status-badge.review .dot { background: #A855F7; }
+
+[data-theme="dark"] .status-badge.open { background: rgba(59,130,246,0.15); color: #60A5FA; }
+[data-theme="dark"] .status-badge.progress { background: rgba(245,158,11,0.15); color: #FBBF24; }
+[data-theme="dark"] .status-badge.done { background: rgba(34,197,94,0.15); color: #4ADE80; }
+[data-theme="dark"] .status-badge.review { background: rgba(168,85,247,0.15); color: #C084FC; }
+
+/* Table action buttons */
+.table-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.action-btn {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  transition: all var(--transition);
+}
+
+.action-btn:hover {
+  background: var(--bg);
+  color: var(--text);
+}
+
+/* Pagination */
+.table-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+}
+
+.table-footer-info {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.table-footer-info .mono {
+  font-size: 13px;
+}
+
+.pagination {
+  display: flex;
+  gap: 4px;
+}
+
+.page-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.page-btn:hover {
+  background: var(--hover-row);
+}
+
+.page-btn.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+.page-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* ============================================
+   WEATHER COMPACT
+   ============================================ */
+.weather-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+
+.weather-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 4px;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition);
+  cursor: default;
+}
+
+.weather-day:hover {
+  background: var(--hover-row);
+}
+
+.weather-day.today {
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+
+.weather-day-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.weather-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.weather-temp {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.weather-low {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.weather-precip {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--accent);
+  font-weight: 500;
+}
+
+/* ============================================
+   LEADERBOARD
+   ============================================ */
+.leaderboard {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.leader-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.leader-item:last-child {
+  border-bottom: none;
+}
+
+.leader-rank {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  width: 24px;
+  text-align: center;
+}
+
+.leader-rank.gold { color: #F59E0B; }
+.leader-rank.silver { color: #94A3B8; }
+.leader-rank.bronze { color: #D97706; }
+
+.leader-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.leader-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.leader-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.leader-role {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.leader-stat {
+  text-align: right;
+}
+
+.leader-count {
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.leader-unit {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+/* ============================================
+   BOTTOM ROW
+   ============================================ */
+.bottom-grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 16px;
+}
+
+/* Sparkline Chart (CSS only) */
+.sparkline-area {
+  padding: 0;
+}
+
+.sparkline-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 120px;
+  padding: 0 4px;
+}
+
+.spark-bar {
+  flex: 1;
+  background: var(--primary);
+  border-radius: 2px 2px 0 0;
+  min-width: 0;
+  transition: all var(--transition);
+  opacity: 0.6;
+  position: relative;
+  cursor: crosshair;
+}
+
+.spark-bar:hover {
+  opacity: 1;
+  background: var(--secondary);
+}
+
+.spark-bar::after {
+  content: attr(data-value);
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 1px 4px;
+  border-radius: 3px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition);
+}
+
+.spark-bar:hover::after {
+  opacity: 1;
+}
+
+.sparkline-labels {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 4px 0;
+  font-size: 10px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-weight: 500;
+}
+
+/* Location distribution */
+.location-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.location-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.location-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.location-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  flex: 1;
+}
+
+.location-bar-track {
+  width: 100px;
+  height: 6px;
+  background: var(--bg);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.location-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 0;
+}
+
+.location-count {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  width: 28px;
+  text-align: right;
+}
+
+.location-pct {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+  width: 36px;
+  text-align: right;
+}
+
+/* ============================================
+   DARK MODE TOGGLE
+   ============================================ */
+.theme-toggle {
+  position: relative;
+}
+
+.theme-toggle input {
+  display: none;
+}
+
+.theme-switch {
+  width: 40px;
+  height: 22px;
+  background: var(--border);
+  border-radius: 11px;
+  cursor: pointer;
+  display: block;
+  position: relative;
+  transition: all var(--transition);
+}
+
+.theme-switch::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  background: #fff;
+  border-radius: 50%;
+  transition: all var(--transition);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.theme-toggle input:checked + .theme-switch {
+  background: var(--primary);
+}
+
+.theme-toggle input:checked + .theme-switch::after {
+  transform: translateX(18px);
+}
+
+/* ============================================
+   ANIMATIONS
+   ============================================ */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.stat-card,
+.card {
+  animation: fadeIn 0.4s ease-out backwards;
+}
+
+.stat-card:nth-child(1) { animation-delay: 0.05s; }
+.stat-card:nth-child(2) { animation-delay: 0.1s; }
+.stat-card:nth-child(3) { animation-delay: 0.15s; }
+.stat-card:nth-child(4) { animation-delay: 0.2s; }
+
+.dashboard-grid .card:nth-child(1) { animation-delay: 0.25s; }
+.dashboard-grid .card:nth-child(2) { animation-delay: 0.3s; }
+
+.bottom-grid .card:nth-child(1) { animation-delay: 0.35s; }
+.bottom-grid .card:nth-child(2) { animation-delay: 0.4s; }
+
+/* ============================================
+   RESPONSIVE
+   ============================================ */
+@media (max-width: 1100px) {
+  .dashboard-grid,
+  .bottom-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .stat-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .content {
+    padding: 16px;
+  }
+}
+</style>
+</head>
+<body>
+
+<!-- ====== SIDEBAR ====== -->
+<nav class="sidebar">
+  <div class="sidebar-logo">G</div>
+  <div class="sidebar-nav">
+    <button class="sidebar-item active">
+      <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      <span class="tooltip">Dashboard</span>
+    </button>
+    <button class="sidebar-item">
+      <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M12 22c4-4 8-7.5 8-12a8 8 0 10-16 0c0 4.5 4 8 8 12z"/><circle cx="12" cy="10" r="3"/></svg>
+      <span class="tooltip">Standorte</span>
+    </button>
+    <button class="sidebar-item">
+      <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/></svg>
+      <span class="tooltip">Aufgaben</span>
+    </button>
+    <button class="sidebar-item">
+      <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4-4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+      <span class="tooltip">Team</span>
+    </button>
+    <button class="sidebar-item">
+      <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/></svg>
+      <span class="tooltip">Pflanzen</span>
+    </button>
+    <button class="sidebar-item">
+      <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+      <span class="tooltip">Kalender</span>
+    </button>
+    <button class="sidebar-item">
+      <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+      <span class="tooltip">Berichte</span>
+    </button>
+  </div>
+  <div class="sidebar-bottom">
+    <button class="sidebar-item">
+      <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+      <span class="tooltip">Einstellungen</span>
+    </button>
+  </div>
+</nav>
+
+<!-- ====== MAIN ====== -->
+<div class="main-wrapper">
+
+  <!-- TOPBAR -->
+  <header class="topbar">
+    <div class="topbar-title"><span>Garten</span>planer</div>
+    <div class="search-box">
+      <span class="search-icon">
+        <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      </span>
+      <input type="text" placeholder="Aufgaben, Pflanzen, Standorte suchen...">
+      <span class="search-kbd">/</span>
+    </div>
+    <div class="topbar-actions">
+      <label class="theme-toggle" title="Dark Mode umschalten">
+        <input type="checkbox" id="themeToggle">
+        <span class="theme-switch"></span>
+      </label>
+      <button class="icon-btn" title="Benachrichtigungen">
+        <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 01-3.46 0"/></svg>
+        <span class="badge"></span>
+      </button>
+      <div class="avatar">NH</div>
+    </div>
+  </header>
+
+  <!-- CONTENT -->
+  <main class="content">
+
+    <div class="content-header">
+      <h1>Dashboard</h1>
+      <div class="content-header-actions">
+        <button class="btn-secondary">
+          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          Export
+        </button>
+        <button class="btn-primary">
+          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          Neue Aufgabe
+        </button>
+      </div>
+    </div>
+
+    <!-- STAT CARDS -->
+    <div class="stat-grid">
+      <div class="stat-card">
+        <div class="stat-label">Offene Aufgaben</div>
+        <div class="stat-value-row">
+          <span class="stat-value mono">12</span>
+          <span class="stat-trend up">&#8593; +4</span>
+        </div>
+        <div class="stat-sub">vs. letzte Woche</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Erledigt (Monat)</div>
+        <div class="stat-value-row">
+          <span class="stat-value mono">34</span>
+          <span class="stat-trend up">&#8593; +8</span>
+        </div>
+        <div class="stat-sub">vs. letzte Woche</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Erledigungsquote</div>
+        <div class="stat-value-row">
+          <span class="stat-value mono">73.9<span style="font-size:18px">%</span></span>
+          <span class="stat-trend up">&#8593; +2.1%</span>
+        </div>
+        <div class="stat-progress">
+          <div class="stat-progress-bar" data-width="73.9"></div>
+        </div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Aktive Mitarbeiter</div>
+        <div class="stat-value-row">
+          <span class="stat-value mono">5</span>
+          <span class="stat-trend down">&#8595; -1</span>
+        </div>
+        <div class="stat-sub"><span class="mono">6.8</span> Aufgaben / MA</div>
+      </div>
+    </div>
+
+    <!-- 2 COLUMN GRID -->
+    <div class="dashboard-grid">
+
+      <!-- LEFT COLUMN -->
+      <div style="display:flex; flex-direction:column; gap:16px;">
+
+        <!-- Bar Chart Card -->
+        <div class="card">
+          <div class="card-header">
+            <span class="card-title">Aufgaben nach Status</span>
+            <button class="icon-btn" title="Mehr">
+              <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+            </button>
+          </div>
+          <div class="card-body">
+            <div class="bar-chart">
+              <div class="bar-item">
+                <span class="bar-label">Offen</span>
+                <div class="bar-track">
+                  <div class="bar-fill blue" data-width="26"><span class="bar-fill-label">12</span></div>
+                </div>
+                <span class="bar-count mono">12</span>
+              </div>
+              <div class="bar-item">
+                <span class="bar-label">In Arbeit</span>
+                <div class="bar-track">
+                  <div class="bar-fill amber" data-width="17"><span class="bar-fill-label">8</span></div>
+                </div>
+                <span class="bar-count mono">8</span>
+              </div>
+              <div class="bar-item">
+                <span class="bar-label">Review</span>
+                <div class="bar-track">
+                  <div class="bar-fill" style="background:#A855F7" data-width="9"><span class="bar-fill-label">4</span></div>
+                </div>
+                <span class="bar-count mono">4</span>
+              </div>
+              <div class="bar-item">
+                <span class="bar-label">Erledigt</span>
+                <div class="bar-track">
+                  <div class="bar-fill green" data-width="74"><span class="bar-fill-label">34</span></div>
+                </div>
+                <span class="bar-count mono">34</span>
+              </div>
+              <div class="bar-item">
+                <span class="bar-label">Archiviert</span>
+                <div class="bar-track">
+                  <div class="bar-fill" style="background:#94A3B8" data-width="48"><span class="bar-fill-label">22</span></div>
+                </div>
+                <span class="bar-count mono">22</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Table Card -->
+        <div class="card">
+          <div class="tabs" id="taskTabs">
+            <button class="tab active" data-tab="all">Alle <span class="tab-count mono">46</span></button>
+            <button class="tab" data-tab="open">Offen <span class="tab-count mono">12</span></button>
+            <button class="tab" data-tab="done">Erledigt <span class="tab-count mono">34</span></button>
+            <button class="tab" data-tab="archived">Archiviert <span class="tab-count mono">22</span></button>
+          </div>
+          <div class="table-wrapper">
+            <table id="taskTable">
+              <thead>
+                <tr>
+                  <th data-sort="prio" class="sorted">Prio <span class="sort-icon">&#9650;</span></th>
+                  <th data-sort="task">Aufgabe <span class="sort-icon">&#9650;</span></th>
+                  <th data-sort="location">Standort <span class="sort-icon">&#9650;</span></th>
+                  <th data-sort="who">Wer <span class="sort-icon">&#9650;</span></th>
+                  <th data-sort="status">Status <span class="sort-icon">&#9650;</span></th>
+                  <th>Aktionen</th>
+                </tr>
+              </thead>
+              <tbody id="taskBody">
+                <tr data-status="open">
+                  <td><span class="prio p1">1</span></td>
+                  <td>Tomaten-Beete bewässern</td>
+                  <td>Gewächshaus A</td>
+                  <td>Lisa M.</td>
+                  <td><span class="status-badge open"><span class="dot"></span>Offen</span></td>
+                  <td><div class="table-actions"><button class="action-btn" title="Bearbeiten">&#9998;</button><button class="action-btn" title="Erledigen">&#10003;</button></div></td>
+                </tr>
+                <tr data-status="progress">
+                  <td><span class="prio p1">1</span></td>
+                  <td>Rosenschnitt Hauptbeet</td>
+                  <td>Rosengarten</td>
+                  <td>Marco K.</td>
+                  <td><span class="status-badge progress"><span class="dot"></span>In Arbeit</span></td>
+                  <td><div class="table-actions"><button class="action-btn" title="Bearbeiten">&#9998;</button><button class="action-btn" title="Erledigen">&#10003;</button></div></td>
+                </tr>
+                <tr data-status="open">
+                  <td><span class="prio p2">2</span></td>
+                  <td>Kompost umsetzen</td>
+                  <td>Kompostanlage</td>
+                  <td>Jan B.</td>
+                  <td><span class="status-badge open"><span class="dot"></span>Offen</span></td>
+                  <td><div class="table-actions"><button class="action-btn" title="Bearbeiten">&#9998;</button><button class="action-btn" title="Erledigen">&#10003;</button></div></td>
+                </tr>
+                <tr data-status="review">
+                  <td><span class="prio p2">2</span></td>
+                  <td>Kräuterbeet anlegen</td>
+                  <td>Südterrasse</td>
+                  <td>Sarah W.</td>
+                  <td><span class="status-badge review"><span class="dot"></span>Review</span></td>
+                  <td><div class="table-actions"><button class="action-btn" title="Bearbeiten">&#9998;</button><button class="action-btn" title="Erledigen">&#10003;</button></div></td>
+                </tr>
+                <tr data-status="progress">
+                  <td><span class="prio p2">2</span></td>
+                  <td>Obstbäume düngen</td>
+                  <td>Obstwiese</td>
+                  <td>Lisa M.</td>
+                  <td><span class="status-badge progress"><span class="dot"></span>In Arbeit</span></td>
+                  <td><div class="table-actions"><button class="action-btn" title="Bearbeiten">&#9998;</button><button class="action-btn" title="Erledigen">&#10003;</button></div></td>
+                </tr>
+                <tr data-status="done">
+                  <td><span class="prio p3">3</span></td>
+                  <td>Rasen mähen Nordseite</td>
+                  <td>Nordgarten</td>
+                  <td>Tom H.</td>
+                  <td><span class="status-badge done"><span class="dot"></span>Erledigt</span></td>
+                  <td><div class="table-actions"><button class="action-btn" title="Bearbeiten">&#9998;</button><button class="action-btn" title="Archivieren">&#128451;</button></div></td>
+                </tr>
+                <tr data-status="open">
+                  <td><span class="prio p3">3</span></td>
+                  <td>Bewässerungssystem prüfen</td>
+                  <td>Gewächshaus B</td>
+                  <td>Marco K.</td>
+                  <td><span class="status-badge open"><span class="dot"></span>Offen</span></td>
+                  <td><div class="table-actions"><button class="action-btn" title="Bearbeiten">&#9998;</button><button class="action-btn" title="Erledigen">&#10003;</button></div></td>
+                </tr>
+                <tr data-status="done">
+                  <td><span class="prio p4">4</span></td>
+                  <td>Werkzeugschuppen aufräumen</td>
+                  <td>Wirtschaftshof</td>
+                  <td>Jan B.</td>
+                  <td><span class="status-badge done"><span class="dot"></span>Erledigt</span></td>
+                  <td><div class="table-actions"><button class="action-btn" title="Bearbeiten">&#9998;</button><button class="action-btn" title="Archivieren">&#128451;</button></div></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="table-footer">
+            <span class="table-footer-info">Zeige <span class="mono">1-8</span> von <span class="mono">46</span></span>
+            <div class="pagination">
+              <button class="page-btn" disabled>&lsaquo;</button>
+              <button class="page-btn active">1</button>
+              <button class="page-btn">2</button>
+              <button class="page-btn">3</button>
+              <button class="page-btn">4</button>
+              <button class="page-btn">5</button>
+              <button class="page-btn">6</button>
+              <button class="page-btn">&rsaquo;</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT COLUMN -->
+      <div style="display:flex; flex-direction:column; gap:16px;">
+
+        <!-- Weather Card -->
+        <div class="card">
+          <div class="card-header">
+            <span class="card-title">Wetter 7 Tage</span>
+            <span style="font-size:12px; color:var(--text-secondary);">Standort: Berlin</span>
+          </div>
+          <div class="card-body" style="padding: 12px 16px;">
+            <div class="weather-grid">
+              <div class="weather-day today">
+                <span class="weather-day-name">Mo</span>
+                <span class="weather-icon">&#9728;&#65039;</span>
+                <span class="weather-temp mono">18&deg;</span>
+                <span class="weather-low mono">8&deg;</span>
+                <span class="weather-precip">0%</span>
+              </div>
+              <div class="weather-day">
+                <span class="weather-day-name">Di</span>
+                <span class="weather-icon">&#9925;</span>
+                <span class="weather-temp mono">15&deg;</span>
+                <span class="weather-low mono">7&deg;</span>
+                <span class="weather-precip">20%</span>
+              </div>
+              <div class="weather-day">
+                <span class="weather-day-name">Mi</span>
+                <span class="weather-icon">&#127782;&#65039;</span>
+                <span class="weather-temp mono">12&deg;</span>
+                <span class="weather-low mono">6&deg;</span>
+                <span class="weather-precip">65%</span>
+              </div>
+              <div class="weather-day">
+                <span class="weather-day-name">Do</span>
+                <span class="weather-icon">&#127783;&#65039;</span>
+                <span class="weather-temp mono">10&deg;</span>
+                <span class="weather-low mono">5&deg;</span>
+                <span class="weather-precip">80%</span>
+              </div>
+              <div class="weather-day">
+                <span class="weather-day-name">Fr</span>
+                <span class="weather-icon">&#9925;</span>
+                <span class="weather-temp mono">14&deg;</span>
+                <span class="weather-low mono">6&deg;</span>
+                <span class="weather-precip">30%</span>
+              </div>
+              <div class="weather-day">
+                <span class="weather-day-name">Sa</span>
+                <span class="weather-icon">&#9728;&#65039;</span>
+                <span class="weather-temp mono">19&deg;</span>
+                <span class="weather-low mono">9&deg;</span>
+                <span class="weather-precip">5%</span>
+              </div>
+              <div class="weather-day">
+                <span class="weather-day-name">So</span>
+                <span class="weather-icon">&#9728;&#65039;</span>
+                <span class="weather-temp mono">21&deg;</span>
+                <span class="weather-low mono">11&deg;</span>
+                <span class="weather-precip">0%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Leaderboard Card -->
+        <div class="card">
+          <div class="card-header">
+            <span class="card-title">Top Mitarbeiter</span>
+            <span style="font-size:12px; color:var(--text-secondary);">Diese Woche</span>
+          </div>
+          <div class="card-body">
+            <div class="leaderboard">
+              <div class="leader-item">
+                <span class="leader-rank gold mono">1</span>
+                <div class="leader-avatar" style="background: linear-gradient(135deg, #166534, #4ADE80);">LM</div>
+                <div class="leader-info">
+                  <div class="leader-name">Lisa Meier</div>
+                  <div class="leader-role">Gärtnerin</div>
+                </div>
+                <div class="leader-stat">
+                  <div class="leader-count mono">12</div>
+                  <div class="leader-unit">Aufgaben</div>
+                </div>
+              </div>
+              <div class="leader-item">
+                <span class="leader-rank silver mono">2</span>
+                <div class="leader-avatar" style="background: linear-gradient(135deg, #0EA5E9, #38BDF8);">MK</div>
+                <div class="leader-info">
+                  <div class="leader-name">Marco Klein</div>
+                  <div class="leader-role">Landschaftsbauer</div>
+                </div>
+                <div class="leader-stat">
+                  <div class="leader-count mono">9</div>
+                  <div class="leader-unit">Aufgaben</div>
+                </div>
+              </div>
+              <div class="leader-item">
+                <span class="leader-rank bronze mono">3</span>
+                <div class="leader-avatar" style="background: linear-gradient(135deg, #D97706, #FBBF24);">JB</div>
+                <div class="leader-info">
+                  <div class="leader-name">Jan Becker</div>
+                  <div class="leader-role">Gärtner</div>
+                </div>
+                <div class="leader-stat">
+                  <div class="leader-count mono">7</div>
+                  <div class="leader-unit">Aufgaben</div>
+                </div>
+              </div>
+              <div class="leader-item">
+                <span class="leader-rank mono">4</span>
+                <div class="leader-avatar" style="background: linear-gradient(135deg, #8B5CF6, #C084FC);">SW</div>
+                <div class="leader-info">
+                  <div class="leader-name">Sarah Weber</div>
+                  <div class="leader-role">Pflanzenexpertin</div>
+                </div>
+                <div class="leader-stat">
+                  <div class="leader-count mono">4</div>
+                  <div class="leader-unit">Aufgaben</div>
+                </div>
+              </div>
+              <div class="leader-item">
+                <span class="leader-rank mono">5</span>
+                <div class="leader-avatar" style="background: linear-gradient(135deg, #64748B, #94A3B8);">TH</div>
+                <div class="leader-info">
+                  <div class="leader-name">Tom Hoffmann</div>
+                  <div class="leader-role">Auszubildender</div>
+                </div>
+                <div class="leader-stat">
+                  <div class="leader-count mono">2</div>
+                  <div class="leader-unit">Aufgaben</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- BOTTOM ROW -->
+    <div class="bottom-grid">
+
+      <!-- Activity Sparkline -->
+      <div class="card">
+        <div class="card-header">
+          <span class="card-title">Aktivität (30 Tage)</span>
+          <div style="display:flex; align-items:center; gap:12px;">
+            <span style="font-size:12px; color:var(--text-secondary);">Gesamt: <span class="mono" style="font-size:12px; color:var(--text);">127</span></span>
+            <span class="stat-trend up" style="font-size:11px;">&#8593; +14%</span>
+          </div>
+        </div>
+        <div class="card-body sparkline-area">
+          <div class="sparkline-chart" id="sparkline">
+            <!-- bars generated by JS -->
+          </div>
+          <div class="sparkline-labels">
+            <span>01. Mär</span>
+            <span>08. Mär</span>
+            <span>15. Mär</span>
+            <span>22. Mär</span>
+            <span>30. Mär</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Location Distribution -->
+      <div class="card">
+        <div class="card-header">
+          <span class="card-title">Standort-Verteilung</span>
+          <span style="font-size:12px; color:var(--text-secondary);"><span class="mono" style="font-size:12px; color:var(--text);">6</span> Standorte</span>
+        </div>
+        <div class="card-body">
+          <div class="location-list">
+            <div class="location-item">
+              <span class="location-dot" style="background:#166534;"></span>
+              <span class="location-name">Gewächshaus A</span>
+              <div class="location-bar-track">
+                <div class="location-bar-fill" data-width="85" style="background:#166534;"></div>
+              </div>
+              <span class="location-count mono">14</span>
+              <span class="location-pct mono">30%</span>
+            </div>
+            <div class="location-item">
+              <span class="location-dot" style="background:#4ADE80;"></span>
+              <span class="location-name">Rosengarten</span>
+              <div class="location-bar-track">
+                <div class="location-bar-fill" data-width="61" style="background:#4ADE80;"></div>
+              </div>
+              <span class="location-count mono">10</span>
+              <span class="location-pct mono">22%</span>
+            </div>
+            <div class="location-item">
+              <span class="location-dot" style="background:#0EA5E9;"></span>
+              <span class="location-name">Obstwiese</span>
+              <div class="location-bar-track">
+                <div class="location-bar-fill" data-width="42" style="background:#0EA5E9;"></div>
+              </div>
+              <span class="location-count mono">7</span>
+              <span class="location-pct mono">15%</span>
+            </div>
+            <div class="location-item">
+              <span class="location-dot" style="background:#A855F7;"></span>
+              <span class="location-name">Südterrasse</span>
+              <div class="location-bar-track">
+                <div class="location-bar-fill" data-width="36" style="background:#A855F7;"></div>
+              </div>
+              <span class="location-count mono">6</span>
+              <span class="location-pct mono">13%</span>
+            </div>
+            <div class="location-item">
+              <span class="location-dot" style="background:#F59E0B;"></span>
+              <span class="location-name">Nordgarten</span>
+              <div class="location-bar-track">
+                <div class="location-bar-fill" data-width="24" style="background:#F59E0B;"></div>
+              </div>
+              <span class="location-count mono">5</span>
+              <span class="location-pct mono">11%</span>
+            </div>
+            <div class="location-item">
+              <span class="location-dot" style="background:#64748B;"></span>
+              <span class="location-name">Wirtschaftshof</span>
+              <div class="location-bar-track">
+                <div class="location-bar-fill" data-width="18" style="background:#64748B;"></div>
+              </div>
+              <span class="location-count mono">4</span>
+              <span class="location-pct mono">9%</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </main>
+</div>
+
+<script>
+// ============================================
+// DARK MODE TOGGLE
+// ============================================
+const themeToggle = document.getElementById('themeToggle');
+const html = document.documentElement;
+
+// Check for saved theme preference
+if (localStorage.getItem('terra-theme') === 'dark') {
+  html.setAttribute('data-theme', 'dark');
+  themeToggle.checked = true;
+}
+
+themeToggle.addEventListener('change', () => {
+  if (themeToggle.checked) {
+    html.setAttribute('data-theme', 'dark');
+    localStorage.setItem('terra-theme', 'dark');
+  } else {
+    html.removeAttribute('data-theme');
+    localStorage.setItem('terra-theme', 'light');
+  }
+});
+
+// ============================================
+// ANIMATED BARS & PROGRESS ON LOAD
+// ============================================
+function animateBars() {
+  // Progress bars in stat cards
+  document.querySelectorAll('.stat-progress-bar').forEach(bar => {
+    const width = bar.getAttribute('data-width');
+    setTimeout(() => { bar.style.width = width + '%'; }, 200);
+  });
+
+  // Horizontal bar fills
+  document.querySelectorAll('.bar-fill').forEach(bar => {
+    const width = bar.getAttribute('data-width');
+    setTimeout(() => { bar.style.width = width + '%'; }, 300);
+  });
+
+  // Location bar fills
+  document.querySelectorAll('.location-bar-fill').forEach(bar => {
+    const width = bar.getAttribute('data-width');
+    setTimeout(() => { bar.style.width = width + '%'; }, 400);
+  });
+}
+
+// ============================================
+// SPARKLINE CHART
+// ============================================
+function generateSparkline() {
+  const container = document.getElementById('sparkline');
+  const data = [3,5,2,7,4,6,3,8,5,4,6,9,7,5,3,6,8,4,5,7,3,6,4,8,5,7,9,4,6,5];
+  const max = Math.max(...data);
+
+  data.forEach((val, i) => {
+    const bar = document.createElement('div');
+    bar.className = 'spark-bar';
+    bar.setAttribute('data-value', val);
+    bar.style.height = '0%';
+    container.appendChild(bar);
+
+    setTimeout(() => {
+      bar.style.height = (val / max * 100) + '%';
+    }, 400 + i * 30);
+  });
+}
+
+// ============================================
+// TABLE SORTING
+// ============================================
+const sortState = { column: 'prio', direction: 'asc' };
+
+function sortTable(column) {
+  const tbody = document.getElementById('taskBody');
+  const rows = Array.from(tbody.querySelectorAll('tr'));
+  const headers = document.querySelectorAll('thead th[data-sort]');
+
+  // Toggle direction if same column
+  if (sortState.column === column) {
+    sortState.direction = sortState.direction === 'asc' ? 'desc' : 'asc';
+  } else {
+    sortState.column = column;
+    sortState.direction = 'asc';
+  }
+
+  // Update header styles
+  headers.forEach(th => {
+    th.classList.remove('sorted');
+    th.querySelector('.sort-icon').innerHTML = '&#9650;';
+  });
+  const activeHeader = document.querySelector(`th[data-sort="${column}"]`);
+  activeHeader.classList.add('sorted');
+  activeHeader.querySelector('.sort-icon').innerHTML = sortState.direction === 'asc' ? '&#9650;' : '&#9660;';
+
+  const colIndex = { prio: 0, task: 1, location: 2, who: 3, status: 4 };
+  const idx = colIndex[column];
+
+  rows.sort((a, b) => {
+    let aVal = a.cells[idx].textContent.trim();
+    let bVal = b.cells[idx].textContent.trim();
+
+    // Numeric sort for prio
+    if (column === 'prio') {
+      aVal = parseInt(aVal);
+      bVal = parseInt(bVal);
+      return sortState.direction === 'asc' ? aVal - bVal : bVal - aVal;
+    }
+
+    return sortState.direction === 'asc'
+      ? aVal.localeCompare(bVal, 'de')
+      : bVal.localeCompare(aVal, 'de');
+  });
+
+  rows.forEach(row => tbody.appendChild(row));
+}
+
+document.querySelectorAll('thead th[data-sort]').forEach(th => {
+  th.addEventListener('click', () => sortTable(th.getAttribute('data-sort')));
+});
+
+// ============================================
+// TAB SWITCHING
+// ============================================
+const tabButtons = document.querySelectorAll('#taskTabs .tab');
+const taskRows = document.querySelectorAll('#taskBody tr');
+
+const statusMap = {
+  all: null,
+  open: ['open'],
+  done: ['done'],
+  archived: [] // no archived data in our demo
+};
+
+tabButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    // Update active tab
+    tabButtons.forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+
+    const tab = btn.getAttribute('data-tab');
+    const allowedStatuses = statusMap[tab];
+
+    taskRows.forEach(row => {
+      if (allowedStatuses === null) {
+        row.style.display = '';
+      } else {
+        const rowStatus = row.getAttribute('data-status');
+        row.style.display = allowedStatuses.includes(rowStatus) ? '' : 'none';
+      }
+    });
+  });
+});
+
+// ============================================
+// PAGINATION
+// ============================================
+document.querySelectorAll('.pagination .page-btn').forEach(btn => {
+  btn.addEventListener('click', function() {
+    if (this.disabled) return;
+    document.querySelectorAll('.pagination .page-btn').forEach(b => b.classList.remove('active'));
+    this.classList.add('active');
+  });
+});
+
+// ============================================
+// SIDEBAR ACTIVE STATE
+// ============================================
+document.querySelectorAll('.sidebar-item').forEach(item => {
+  item.addEventListener('click', function() {
+    document.querySelectorAll('.sidebar-item').forEach(i => i.classList.remove('active'));
+    this.classList.add('active');
+  });
+});
+
+// ============================================
+// KEYBOARD SHORTCUT: / to focus search
+// ============================================
+document.addEventListener('keydown', (e) => {
+  if (e.key === '/' && document.activeElement.tagName !== 'INPUT') {
+    e.preventDefault();
+    document.querySelector('.search-box input').focus();
+  }
+  if (e.key === 'Escape') {
+    document.activeElement.blur();
+  }
+});
+
+// ============================================
+// INIT
+// ============================================
+window.addEventListener('DOMContentLoaded', () => {
+  generateSparkline();
+  animateBars();
+});
+</script>
+</body>
+</html>

--- a/mockups/04-botanical.html
+++ b/mockups/04-botanical.html
@@ -1,0 +1,1442 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GardenPlanner — Botanical Dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+/* ========================================
+   BOTANICAL THEME — CSS CUSTOM PROPERTIES
+   ======================================== */
+:root {
+  --primary: #365E3D;
+  --primary-light: #4a7a53;
+  --secondary: #A8D5BA;
+  --secondary-light: #c8e8d4;
+  --accent-plum: #7C3AED;
+  --accent-warm: #FBBF24;
+  --bg: #FBF9F4;
+  --surface: #FFFFFF;
+  --text: #1C1917;
+  --text-secondary: #78716C;
+  --border: #E7E5E4;
+  --border-hover: #A8D5BA;
+  --tag-bg: #ECFDF5;
+  --tag-text: #365E3D;
+  --shadow-sm: 0 1px 3px rgba(28,25,23,0.04);
+  --shadow-md: 0 4px 16px rgba(28,25,23,0.06);
+  --shadow-lg: 0 8px 32px rgba(28,25,23,0.08);
+  --radius-sm: 8px;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-pill: 9999px;
+  --font-heading: 'DM Serif Display', Georgia, serif;
+  --font-body: 'Nunito', -apple-system, sans-serif;
+  --transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Dark Mode */
+[data-theme="dark"] {
+  --bg: #0C0A09;
+  --surface: #1C1917;
+  --text: #FBF9F4;
+  --text-secondary: #A8A29E;
+  --border: #292524;
+  --border-hover: #4a7a53;
+  --tag-bg: #1a2e1f;
+  --tag-text: #A8D5BA;
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.2);
+  --shadow-md: 0 4px 16px rgba(0,0,0,0.3);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.4);
+}
+
+/* ========================================
+   RESET & BASE
+   ======================================== */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: 400;
+  line-height: 1.65;
+  color: var(--text);
+  background: var(--bg);
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  transition: background var(--transition), color var(--transition);
+}
+
+/* ========================================
+   TYPOGRAPHY
+   ======================================== */
+h1, h2, h3 {
+  font-family: var(--font-heading);
+  color: var(--text);
+  transition: color var(--transition);
+}
+
+.display {
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+h1 { font-size: 26px; font-weight: 700; line-height: 1.3; }
+h2 { font-size: 20px; font-weight: 600; line-height: 1.4; }
+h3 { font-size: 17px; font-weight: 600; line-height: 1.4; }
+
+.tag-text {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ========================================
+   LAYOUT
+   ======================================== */
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ========================================
+   DECORATIVE BACKGROUND PATTERN
+   ======================================== */
+body::before {
+  content: '';
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background-image:
+    radial-gradient(ellipse 600px 400px at 10% 20%, rgba(168,213,186,0.12) 0%, transparent 70%),
+    radial-gradient(ellipse 500px 500px at 90% 80%, rgba(168,213,186,0.08) 0%, transparent 70%),
+    radial-gradient(ellipse 300px 300px at 50% 10%, rgba(251,191,36,0.04) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+  transition: opacity var(--transition);
+}
+
+[data-theme="dark"] body::before {
+  background-image:
+    radial-gradient(ellipse 600px 400px at 10% 20%, rgba(54,94,61,0.15) 0%, transparent 70%),
+    radial-gradient(ellipse 500px 500px at 90% 80%, rgba(54,94,61,0.08) 0%, transparent 70%);
+}
+
+/* ========================================
+   NAVIGATION
+   ======================================== */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(251,249,244,0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border);
+  transition: background var(--transition), border-color var(--transition);
+}
+
+[data-theme="dark"] .nav {
+  background: rgba(12,10,9,0.85);
+}
+
+.nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 64px;
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+  color: var(--text);
+}
+
+.nav-brand svg {
+  width: 32px;
+  height: 32px;
+}
+
+.nav-brand span {
+  font-family: var(--font-heading);
+  font-size: 20px;
+  color: var(--primary);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(168,213,186,0.15);
+  border-radius: var(--radius-pill);
+  padding: 4px;
+}
+
+[data-theme="dark"] .nav-links {
+  background: rgba(54,94,61,0.2);
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  border-radius: var(--radius-pill);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: all var(--transition);
+  cursor: pointer;
+}
+
+.nav-link:hover {
+  color: var(--primary);
+  background: rgba(168,213,186,0.2);
+}
+
+.nav-link.active {
+  color: var(--surface);
+  background: var(--primary);
+}
+
+[data-theme="dark"] .nav-link.active {
+  color: #FBF9F4;
+}
+
+.nav-link svg {
+  width: 16px;
+  height: 16px;
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.nav-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--secondary), var(--primary));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+/* ========================================
+   HERO SECTION
+   ======================================== */
+.hero {
+  margin-top: 32px;
+  position: relative;
+}
+
+.hero-card {
+  background: linear-gradient(135deg, rgba(168,213,186,0.2) 0%, rgba(251,249,244,0.8) 50%, rgba(251,191,36,0.08) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 40px 48px;
+  position: relative;
+  overflow: hidden;
+  transition: background var(--transition), border-color var(--transition);
+}
+
+[data-theme="dark"] .hero-card {
+  background: linear-gradient(135deg, rgba(54,94,61,0.15) 0%, rgba(28,25,23,0.8) 50%, rgba(251,191,36,0.05) 100%);
+}
+
+.hero-card::after {
+  content: '';
+  position: absolute;
+  right: -20px;
+  top: -20px;
+  width: 260px;
+  height: 260px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' fill='none'%3E%3Cpath d='M100 20 C60 20 20 60 20 100 C20 140 60 180 100 180' stroke='%23A8D5BA' stroke-width='1' fill='none' opacity='0.3'/%3E%3Cpath d='M100 20 C100 60 80 100 100 140' stroke='%23A8D5BA' stroke-width='0.8' fill='none' opacity='0.25'/%3E%3Cpath d='M100 20 C120 50 110 80 100 140' stroke='%23A8D5BA' stroke-width='0.8' fill='none' opacity='0.2'/%3E%3Cpath d='M80 50 Q100 30 120 50 Q100 80 80 50Z' fill='%23A8D5BA' opacity='0.08'/%3E%3Cpath d='M65 80 Q90 55 105 80 Q90 110 65 80Z' fill='%23A8D5BA' opacity='0.06'/%3E%3Cpath d='M95 60 Q115 40 130 65 Q115 90 95 60Z' fill='%23A8D5BA' opacity='0.06'/%3E%3Ccircle cx='100' cy='140' r='4' fill='%23A8D5BA' opacity='0.15'/%3E%3Ccircle cx='85' cy='120' r='2.5' fill='%23A8D5BA' opacity='0.12'/%3E%3Ccircle cx='115' cy='115' r='3' fill='%23A8D5BA' opacity='0.12'/%3E%3C/svg%3E") no-repeat center;
+  background-size: contain;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.hero-greeting {
+  font-family: var(--font-heading);
+  font-size: 36px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 8px;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-greeting .wave {
+  display: inline-block;
+  animation: wave 2s ease-in-out infinite;
+  transform-origin: 70% 70%;
+}
+
+@keyframes wave {
+  0%, 100% { transform: rotate(0deg); }
+  10% { transform: rotate(14deg); }
+  20% { transform: rotate(-8deg); }
+  30% { transform: rotate(14deg); }
+  40% { transform: rotate(-4deg); }
+  50% { transform: rotate(10deg); }
+  60%, 100% { transform: rotate(0deg); }
+}
+
+.hero-context {
+  font-size: 16px;
+  color: var(--text-secondary);
+  max-width: 600px;
+  position: relative;
+  z-index: 1;
+  line-height: 1.7;
+}
+
+.hero-context .highlight {
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.hero-date {
+  margin-top: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: rgba(168,213,186,0.15);
+  padding: 6px 16px;
+  border-radius: var(--radius-pill);
+  position: relative;
+  z-index: 1;
+}
+
+.hero-date svg {
+  width: 14px;
+  height: 14px;
+  color: var(--primary);
+}
+
+/* ========================================
+   STAT CIRCLES (SVG DONUTS)
+   ======================================== */
+.stats-row {
+  display: flex;
+  justify-content: center;
+  gap: 48px;
+  margin: 40px 0;
+  flex-wrap: wrap;
+}
+
+.stat-circle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.stat-circle.visible {
+  animation: fadeUp 0.6s var(--transition) forwards;
+}
+
+.stat-svg {
+  width: 120px;
+  height: 120px;
+  position: relative;
+}
+
+.stat-svg svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.stat-svg .track {
+  fill: none;
+  stroke: var(--border);
+  stroke-width: 8;
+  transition: stroke var(--transition);
+}
+
+.stat-svg .fill {
+  fill: none;
+  stroke-width: 8;
+  stroke-linecap: round;
+  stroke-dasharray: 314;
+  stroke-dashoffset: 314;
+  transition: stroke-dashoffset 1.5s cubic-bezier(0.4, 0, 0.2, 1), stroke var(--transition);
+}
+
+.stat-svg .fill.primary { stroke: var(--primary); }
+.stat-svg .fill.warm { stroke: var(--accent-warm); }
+.stat-svg .fill.plum { stroke: var(--accent-plum); }
+
+.stat-value {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--font-heading);
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text);
+  transition: color var(--transition);
+}
+
+.stat-value .unit {
+  font-size: 16px;
+  font-weight: 400;
+}
+
+.stat-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: color var(--transition);
+}
+
+/* ========================================
+   CONTENT GRID (2 COLUMNS)
+   ======================================== */
+.content-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 24px;
+  margin-bottom: 40px;
+}
+
+@media (max-width: 800px) {
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ========================================
+   CARDS
+   ======================================== */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  transition: all var(--transition);
+  position: relative;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.card-header h2 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.card-header h2 svg {
+  width: 20px;
+  height: 20px;
+  color: var(--primary);
+}
+
+.card-badge {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--primary);
+  background: var(--tag-bg);
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
+  transition: background var(--transition), color var(--transition);
+}
+
+/* ========================================
+   TASK ITEMS
+   ======================================== */
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.task-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: all var(--transition);
+  cursor: default;
+}
+
+[data-theme="dark"] .task-item {
+  background: rgba(28,25,23,0.5);
+}
+
+.task-item:hover {
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-sm);
+}
+
+.task-item.done {
+  opacity: 0;
+  transform: translateX(30px) scale(0.95);
+  pointer-events: none;
+}
+
+.task-check {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--transition);
+  background: transparent;
+  padding: 0;
+}
+
+.task-check:hover {
+  border-color: var(--primary);
+  background: rgba(168,213,186,0.2);
+}
+
+.task-check.checked {
+  border-color: var(--primary);
+  background: var(--primary);
+}
+
+.task-check.checked svg {
+  opacity: 1;
+}
+
+.task-check svg {
+  width: 12px;
+  height: 12px;
+  color: white;
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.task-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+  transition: color var(--transition);
+}
+
+.task-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.task-tag {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  display: inline-block;
+}
+
+.tag-easy {
+  background: #ECFDF5;
+  color: #065F46;
+}
+[data-theme="dark"] .tag-easy {
+  background: #0a2618;
+  color: #6EE7B7;
+}
+
+.tag-medium {
+  background: #FEF3C7;
+  color: #92400E;
+}
+[data-theme="dark"] .tag-medium {
+  background: #2a1f05;
+  color: #FCD34D;
+}
+
+.tag-hard {
+  background: #F3E8FF;
+  color: #6B21A8;
+}
+[data-theme="dark"] .tag-hard {
+  background: #1e0a38;
+  color: #C4B5FD;
+}
+
+.task-btn {
+  padding: 6px 16px;
+  border-radius: var(--radius-pill);
+  border: 1.5px solid var(--primary);
+  background: transparent;
+  color: var(--primary);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all var(--transition);
+  font-family: var(--font-body);
+  white-space: nowrap;
+}
+
+.task-btn:hover {
+  background: var(--primary);
+  color: white;
+}
+
+/* ========================================
+   WEATHER SECTION
+   ======================================== */
+.weather-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.weather-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: all var(--transition);
+  cursor: default;
+}
+
+[data-theme="dark"] .weather-day {
+  background: rgba(28,25,23,0.5);
+}
+
+.weather-day:hover {
+  border-color: var(--border-hover);
+  transform: translateY(-2px);
+}
+
+.weather-day.today {
+  border-color: var(--primary);
+  background: rgba(168,213,186,0.1);
+}
+
+.weather-name {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.weather-icon {
+  font-size: 24px;
+  line-height: 1;
+}
+
+.weather-temp {
+  font-family: var(--font-heading);
+  font-size: 18px;
+  color: var(--text);
+}
+
+.weather-desc {
+  font-size: 10px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+/* ========================================
+   GARDEN TIP
+   ======================================== */
+.tip-box {
+  background: linear-gradient(135deg, rgba(168,213,186,0.15) 0%, rgba(251,191,36,0.08) 100%);
+  border: 1px solid rgba(168,213,186,0.3);
+  border-radius: var(--radius);
+  padding: 20px;
+  position: relative;
+  overflow: hidden;
+}
+
+[data-theme="dark"] .tip-box {
+  background: linear-gradient(135deg, rgba(54,94,61,0.15) 0%, rgba(251,191,36,0.05) 100%);
+  border-color: rgba(54,94,61,0.3);
+}
+
+.tip-box::before {
+  content: '';
+  position: absolute;
+  top: -30px;
+  right: -30px;
+  width: 100px;
+  height: 100px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath d='M50 10 Q30 30 50 60 Q70 30 50 10Z' fill='%23A8D5BA' opacity='0.15'/%3E%3Cpath d='M50 60 L50 90' stroke='%23A8D5BA' stroke-width='1.5' opacity='0.15'/%3E%3C/svg%3E") no-repeat center;
+  background-size: contain;
+  pointer-events: none;
+}
+
+.tip-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+  margin-bottom: 10px;
+}
+
+.tip-label svg {
+  width: 14px;
+  height: 14px;
+}
+
+.tip-text {
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--text);
+}
+
+.tip-text strong {
+  color: var(--primary);
+}
+
+/* ========================================
+   RECENTLY COMPLETED
+   ======================================== */
+.completed-section {
+  margin-bottom: 60px;
+}
+
+.completed-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.completed-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: all var(--transition);
+}
+
+.completed-item:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-sm);
+}
+
+.completed-check {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.completed-check svg {
+  width: 14px;
+  height: 14px;
+  color: white;
+}
+
+.completed-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.completed-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  text-decoration: line-through;
+  text-decoration-color: var(--secondary);
+  transition: color var(--transition);
+}
+
+.completed-date {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+/* ========================================
+   DARK MODE TOGGLE
+   ======================================== */
+.theme-toggle {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-md);
+  transition: all var(--transition);
+  z-index: 200;
+}
+
+.theme-toggle:hover {
+  transform: scale(1.1);
+  border-color: var(--primary);
+  box-shadow: var(--shadow-lg);
+}
+
+.theme-toggle svg {
+  width: 22px;
+  height: 22px;
+  transition: all var(--transition);
+}
+
+.theme-toggle .icon-moon { display: block; }
+.theme-toggle .icon-sun { display: none; }
+
+[data-theme="dark"] .theme-toggle .icon-moon { display: none; }
+[data-theme="dark"] .theme-toggle .icon-sun { display: block; }
+
+/* ========================================
+   FOOTER
+   ======================================== */
+.footer {
+  text-align: center;
+  padding: 32px 24px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  border-top: 1px solid var(--border);
+  transition: border-color var(--transition);
+}
+
+.footer a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
+
+/* ========================================
+   ANIMATIONS
+   ======================================== */
+@keyframes fadeUp {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.stagger-item {
+  opacity: 0;
+  transform: translateY(16px);
+}
+
+.stagger-item.visible {
+  animation: fadeUp 0.5s var(--transition) forwards;
+}
+
+/* Leaf decorative float */
+@keyframes leafFloat {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  50% { transform: translateY(-8px) rotate(3deg); }
+}
+
+.leaf-deco {
+  animation: leafFloat 4s ease-in-out infinite;
+}
+
+/* ========================================
+   SCROLLBAR
+   ======================================== */
+::-webkit-scrollbar {
+  width: 8px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg);
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-secondary);
+}
+
+/* ========================================
+   RESPONSIVE
+   ======================================== */
+@media (max-width: 640px) {
+  .hero-card { padding: 24px; }
+  .hero-greeting { font-size: 28px; }
+  .stats-row { gap: 24px; }
+  .nav-links { display: none; }
+  .weather-grid { grid-template-columns: repeat(3, 1fr); }
+}
+</style>
+</head>
+<body>
+
+<!-- =============================================
+     NAVIGATION
+     ============================================= -->
+<nav class="nav">
+  <div class="container nav-inner">
+    <a href="#" class="nav-brand">
+      <svg viewBox="0 0 32 32" fill="none">
+        <circle cx="16" cy="16" r="15" fill="#365E3D" opacity="0.1"/>
+        <path d="M16 6C12 6 8 10 8 16C8 22 12 26 16 26" stroke="#365E3D" stroke-width="2" fill="none" stroke-linecap="round"/>
+        <path d="M16 6C16 12 14 18 16 24" stroke="#365E3D" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+        <path d="M16 6C20 10 18 16 16 24" stroke="#A8D5BA" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+        <path d="M11 11Q16 8 21 12Q16 17 11 11Z" fill="#A8D5BA" opacity="0.5"/>
+        <path d="M10 17Q16 13 20 18Q14 22 10 17Z" fill="#365E3D" opacity="0.3"/>
+      </svg>
+      <span>GardenPlanner</span>
+    </a>
+
+    <div class="nav-links">
+      <a href="#" class="nav-link active">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M2 6l6-4 6 4v7a1 1 0 01-1 1H3a1 1 0 01-1-1z"/>
+          <path d="M6 14V8h4v6"/>
+        </svg>
+        Dashboard
+      </a>
+      <a href="#" class="nav-link">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="2" y="2" width="12" height="12" rx="2"/>
+          <path d="M2 6h12"/>
+          <path d="M6 2v12"/>
+        </svg>
+        Beete
+      </a>
+      <a href="#" class="nav-link">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M8 2C5 2 2 5 4 8C6 11 8 14 8 14C8 14 10 11 12 8C14 5 11 2 8 2Z"/>
+          <path d="M8 2v12"/>
+        </svg>
+        Pflanzen
+      </a>
+      <a href="#" class="nav-link">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="2" y="3" width="12" height="11" rx="1"/>
+          <path d="M5 1v4M11 1v4M2 7h12"/>
+        </svg>
+        Kalender
+      </a>
+      <a href="#" class="nav-link">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="7" cy="7" r="5"/>
+          <path d="M14 14l-3.5-3.5"/>
+        </svg>
+        Wissen
+      </a>
+    </div>
+
+    <div class="nav-actions">
+      <div class="nav-avatar">NM</div>
+    </div>
+  </div>
+</nav>
+
+<!-- =============================================
+     MAIN CONTENT
+     ============================================= -->
+<main class="container" style="position: relative; z-index: 1;">
+
+  <!-- HERO -->
+  <section class="hero stagger-item" data-delay="0">
+    <div class="hero-card">
+      <h1 class="hero-greeting">
+        Hallo, Gartner! <span class="wave">&#x1F33F;</span>
+      </h1>
+      <p class="hero-context">
+        Heute ist ein guter Tag zum Gartnern.
+        <span class="highlight">18 Grad C, sonnig</span> — perfekt fur Aussaat und Pflege.
+        Deine Tomaten freuen sich uber die Warme!
+      </p>
+      <div class="hero-date">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+          <rect x="2" y="3" width="12" height="11" rx="1"/>
+          <path d="M5 1v4M11 1v4M2 7h12"/>
+        </svg>
+        Montag, 30. Marz 2026
+      </div>
+    </div>
+  </section>
+
+  <!-- STAT CIRCLES -->
+  <section class="stats-row">
+    <div class="stat-circle" data-delay="100">
+      <div class="stat-svg">
+        <svg viewBox="0 0 120 120">
+          <circle class="track" cx="60" cy="60" r="50"/>
+          <circle class="fill primary" cx="60" cy="60" r="50" data-percent="26"/>
+        </svg>
+        <span class="stat-value">12</span>
+      </div>
+      <span class="stat-label">Offen</span>
+    </div>
+    <div class="stat-circle" data-delay="200">
+      <div class="stat-svg">
+        <svg viewBox="0 0 120 120">
+          <circle class="track" cx="60" cy="60" r="50"/>
+          <circle class="fill warm" cx="60" cy="60" r="50" data-percent="74"/>
+        </svg>
+        <span class="stat-value">34</span>
+      </div>
+      <span class="stat-label">Erledigt</span>
+    </div>
+    <div class="stat-circle" data-delay="300">
+      <div class="stat-svg">
+        <svg viewBox="0 0 120 120">
+          <circle class="track" cx="60" cy="60" r="50"/>
+          <circle class="fill plum" cx="60" cy="60" r="50" data-percent="73"/>
+        </svg>
+        <span class="stat-value">73<span class="unit">%</span></span>
+      </div>
+      <span class="stat-label">Quote</span>
+    </div>
+  </section>
+
+  <!-- CONTENT GRID -->
+  <section class="content-grid">
+
+    <!-- LEFT: Tasks -->
+    <div class="card stagger-item" data-delay="200">
+      <div class="card-header">
+        <h2>
+          <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="14" height="14" rx="2"/>
+            <path d="M7 10l2 2 4-4"/>
+          </svg>
+          Heutige Aufgaben
+        </h2>
+        <span class="card-badge">3 offen</span>
+      </div>
+
+      <div class="task-list">
+        <div class="task-item" id="task-1">
+          <button class="task-check" onclick="completeTask('task-1')" aria-label="Aufgabe erledigen">
+            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 6l3 3 5-5"/>
+            </svg>
+          </button>
+          <div class="task-content">
+            <div class="task-title">Tomaten ausgeizen</div>
+            <div class="task-meta">
+              <span class="task-tag tag-easy">Leicht</span>
+              <span>Beet Sonnenhugel</span>
+              <span>&bull;</span>
+              <span>10 Min.</span>
+            </div>
+          </div>
+          <button class="task-btn" onclick="completeTask('task-1')">Erledigen</button>
+        </div>
+
+        <div class="task-item" id="task-2">
+          <button class="task-check" onclick="completeTask('task-2')" aria-label="Aufgabe erledigen">
+            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 6l3 3 5-5"/>
+            </svg>
+          </button>
+          <div class="task-content">
+            <div class="task-title">Hochbeet gieszen — Salat & Radieschen</div>
+            <div class="task-meta">
+              <span class="task-tag tag-easy">Leicht</span>
+              <span>Hochbeet Nord</span>
+              <span>&bull;</span>
+              <span>5 Min.</span>
+            </div>
+          </div>
+          <button class="task-btn" onclick="completeTask('task-2')">Erledigen</button>
+        </div>
+
+        <div class="task-item" id="task-3">
+          <button class="task-check" onclick="completeTask('task-3')" aria-label="Aufgabe erledigen">
+            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 6l3 3 5-5"/>
+            </svg>
+          </button>
+          <div class="task-content">
+            <div class="task-title">Kartoffelkafer kontrollieren</div>
+            <div class="task-meta">
+              <span class="task-tag tag-medium">Mittel</span>
+              <span>Kartoffelfeld</span>
+              <span>&bull;</span>
+              <span>20 Min.</span>
+            </div>
+          </div>
+          <button class="task-btn" onclick="completeTask('task-3')">Erledigen</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT: Weather + Tip -->
+    <div style="display: flex; flex-direction: column; gap: 24px;">
+      <div class="card stagger-item" data-delay="300">
+        <div class="card-header">
+          <h2>
+            <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="10" cy="10" r="4"/>
+              <path d="M10 2v2M10 16v2M2 10h2M16 10h2M4.2 4.2l1.4 1.4M14.4 14.4l1.4 1.4M4.2 15.8l1.4-1.4M14.4 5.6l1.4-1.4"/>
+            </svg>
+            Wetter-Woche
+          </h2>
+        </div>
+        <div class="weather-grid">
+          <div class="weather-day today">
+            <span class="weather-name">Mo</span>
+            <span class="weather-icon">&#9728;&#65039;</span>
+            <span class="weather-temp">18&deg;</span>
+            <span class="weather-desc">Sonnig</span>
+          </div>
+          <div class="weather-day">
+            <span class="weather-name">Di</span>
+            <span class="weather-icon">&#9925;</span>
+            <span class="weather-temp">16&deg;</span>
+            <span class="weather-desc">Teils bew.</span>
+          </div>
+          <div class="weather-day">
+            <span class="weather-name">Mi</span>
+            <span class="weather-icon">&#127782;&#65039;</span>
+            <span class="weather-temp">14&deg;</span>
+            <span class="weather-desc">Wolkig</span>
+          </div>
+          <div class="weather-day">
+            <span class="weather-name">Do</span>
+            <span class="weather-icon">&#127783;&#65039;</span>
+            <span class="weather-temp">12&deg;</span>
+            <span class="weather-desc">Regen</span>
+          </div>
+          <div class="weather-day">
+            <span class="weather-name">Fr</span>
+            <span class="weather-icon">&#9728;&#65039;</span>
+            <span class="weather-temp">17&deg;</span>
+            <span class="weather-desc">Sonnig</span>
+          </div>
+        </div>
+        <p style="font-size: 13px; color: var(--text-secondary); text-align: center;">
+          Donnerstag Regen erwartet — vorher gieszen sparen!
+        </p>
+      </div>
+
+      <div class="card stagger-item" data-delay="400">
+        <div class="tip-box">
+          <div class="tip-label">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+              <path d="M8 2C5 2 3 5 4.5 7.5C6 10 8 14 8 14C8 14 10 10 11.5 7.5C13 5 11 2 8 2Z"/>
+              <path d="M8 2v12"/>
+            </svg>
+            Garten-Tipp des Tages
+          </div>
+          <p class="tip-text">
+            <strong>Mulchen gegen Trockenheit:</strong> Eine 5 cm dicke Schicht aus Rasenschnitt
+            oder Stroh halt den Boden feucht und unterdrueckt Unkraut. Ideal jetzt
+            im Fruehling, bevor die Sommerhitze kommt!
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- RECENTLY COMPLETED -->
+  <section class="completed-section stagger-item" data-delay="500">
+    <div class="card-header">
+      <h2>
+        <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="10" cy="10" r="8"/>
+          <path d="M6.5 10l2 2 4-4"/>
+        </svg>
+        Kuerzlich abgeschlossen
+      </h2>
+      <span class="card-badge">Letzte 7 Tage</span>
+    </div>
+    <div class="completed-grid">
+      <div class="completed-item">
+        <div class="completed-check">
+          <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7l3 3 5-5"/>
+          </svg>
+        </div>
+        <div class="completed-info">
+          <div class="completed-title">Erdbeeren gepflanzt</div>
+          <div class="completed-date">Vor 1 Tag &bull; Beet Suedseite</div>
+        </div>
+      </div>
+      <div class="completed-item">
+        <div class="completed-check">
+          <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7l3 3 5-5"/>
+          </svg>
+        </div>
+        <div class="completed-info">
+          <div class="completed-title">Kompost umgesetzt</div>
+          <div class="completed-date">Vor 2 Tagen &bull; Kompostbereich</div>
+        </div>
+      </div>
+      <div class="completed-item">
+        <div class="completed-check">
+          <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7l3 3 5-5"/>
+          </svg>
+        </div>
+        <div class="completed-info">
+          <div class="completed-title">Rasen gemaht</div>
+          <div class="completed-date">Vor 3 Tagen &bull; Gesamter Garten</div>
+        </div>
+      </div>
+      <div class="completed-item">
+        <div class="completed-check">
+          <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7l3 3 5-5"/>
+          </svg>
+        </div>
+        <div class="completed-info">
+          <div class="completed-title">Bohnen gesaet</div>
+          <div class="completed-date">Vor 5 Tagen &bull; Hochbeet Sued</div>
+        </div>
+      </div>
+      <div class="completed-item">
+        <div class="completed-check">
+          <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7l3 3 5-5"/>
+          </svg>
+        </div>
+        <div class="completed-info">
+          <div class="completed-title">Rosenschnitt durchgefuehrt</div>
+          <div class="completed-date">Vor 6 Tagen &bull; Rosenbeet</div>
+        </div>
+      </div>
+      <div class="completed-item">
+        <div class="completed-check">
+          <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7l3 3 5-5"/>
+          </svg>
+        </div>
+        <div class="completed-info">
+          <div class="completed-title">Bewasserungssystem geprueft</div>
+          <div class="completed-date">Vor 7 Tagen &bull; Infrastruktur</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <p>GardenPlanner &mdash; Konzept <strong>&laquo;Botanical&raquo;</strong> &bull; Warm, einladend, botanische Illustration</p>
+</footer>
+
+<!-- DARK MODE TOGGLE -->
+<button class="theme-toggle" onclick="toggleTheme()" aria-label="Dark Mode umschalten">
+  <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+  </svg>
+  <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="5"/>
+    <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+  </svg>
+</button>
+
+<!-- =============================================
+     JAVASCRIPT
+     ============================================= -->
+<script>
+(function() {
+  'use strict';
+
+  // ===== STAGGERED FADE-IN =====
+  function initStaggerAnimation() {
+    const items = document.querySelectorAll('.stagger-item');
+    const circles = document.querySelectorAll('.stat-circle');
+    const allItems = [...items, ...circles];
+
+    const observer = new IntersectionObserver(function(entries) {
+      entries.forEach(function(entry) {
+        if (entry.isIntersecting) {
+          const delay = parseInt(entry.target.getAttribute('data-delay') || '0');
+          setTimeout(function() {
+            entry.target.classList.add('visible');
+          }, delay);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.1 });
+
+    allItems.forEach(function(item) {
+      observer.observe(item);
+    });
+  }
+
+  // ===== SVG DONUT CHART ANIMATION =====
+  function initDonutCharts() {
+    const fills = document.querySelectorAll('.stat-svg .fill');
+    const circumference = 2 * Math.PI * 50; // r=50
+
+    fills.forEach(function(fill) {
+      fill.style.strokeDasharray = circumference;
+      fill.style.strokeDashoffset = circumference;
+    });
+
+    // Animate after a short delay
+    setTimeout(function() {
+      fills.forEach(function(fill) {
+        const percent = parseInt(fill.getAttribute('data-percent') || '0');
+        const offset = circumference - (circumference * percent / 100);
+        fill.style.strokeDashoffset = offset;
+      });
+    }, 600);
+  }
+
+  // ===== TASK COMPLETION =====
+  window.completeTask = function(taskId) {
+    const taskEl = document.getElementById(taskId);
+    if (!taskEl) return;
+
+    const checkBtn = taskEl.querySelector('.task-check');
+    checkBtn.classList.add('checked');
+
+    // Update badge count
+    const badge = document.querySelector('.card-badge');
+    if (badge) {
+      const current = parseInt(badge.textContent) || 0;
+      if (current > 0) {
+        badge.textContent = (current - 1) + ' offen';
+      }
+    }
+
+    setTimeout(function() {
+      taskEl.classList.add('done');
+    }, 400);
+
+    setTimeout(function() {
+      taskEl.style.height = '0';
+      taskEl.style.marginBottom = '0';
+      taskEl.style.padding = '0';
+      taskEl.style.border = 'none';
+      taskEl.style.overflow = 'hidden';
+    }, 800);
+  };
+
+  // ===== DARK MODE TOGGLE =====
+  window.toggleTheme = function() {
+    const html = document.documentElement;
+    const isDark = html.getAttribute('data-theme') === 'dark';
+
+    if (isDark) {
+      html.removeAttribute('data-theme');
+      localStorage.setItem('garden-theme', 'light');
+    } else {
+      html.setAttribute('data-theme', 'dark');
+      localStorage.setItem('garden-theme', 'dark');
+    }
+  };
+
+  // Restore saved theme
+  function restoreTheme() {
+    const saved = localStorage.getItem('garden-theme');
+    if (saved === 'dark') {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    }
+  }
+
+  // ===== NAV LINK INTERACTION =====
+  function initNavLinks() {
+    const links = document.querySelectorAll('.nav-link');
+    links.forEach(function(link) {
+      link.addEventListener('click', function(e) {
+        e.preventDefault();
+        links.forEach(function(l) { l.classList.remove('active'); });
+        link.classList.add('active');
+      });
+    });
+  }
+
+  // ===== INIT =====
+  document.addEventListener('DOMContentLoaded', function() {
+    restoreTheme();
+    initStaggerAnimation();
+    initDonutCharts();
+    initNavLinks();
+  });
+
+})();
+</script>
+</body>
+</html>

--- a/mockups/05-gridgarden.html
+++ b/mockups/05-gridgarden.html
@@ -1,0 +1,1193 @@
+<!DOCTYPE html>
+<html lang="de" data-theme="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GardenPlanner &mdash; GridGarden Dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Azeret+Mono:wght@400;600;700&family=Syne:wght@600;700;800&family=Work+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+/* ========== RESET & BASE ========== */
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --primary: #15803D;
+  --secondary: #84CC16;
+  --accent: #4F46E5;
+  --bg: #F1F5F9;
+  --surface: #FFFFFF;
+  --text: #020617;
+  --text-secondary: #475569;
+  --border: #CBD5E1;
+  --gradient-start: #15803D;
+  --gradient-end: #84CC16;
+  --glow: rgba(21, 128, 61, 0.12);
+  --font-heading: 'Syne', sans-serif;
+  --font-body: 'Work Sans', sans-serif;
+  --font-mono: 'Azeret Mono', monospace;
+  --radius-card: 12px;
+  --radius-pill: 9999px;
+  --radius-btn: 8px;
+  --transition-base: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+[data-theme="dark"] {
+  --primary: #4ADE80;
+  --secondary: #84CC16;
+  --accent: #818CF8;
+  --bg: #020617;
+  --surface: #0F172A;
+  --text: #F1F5F9;
+  --text-secondary: #94A3B8;
+  --border: #1E293B;
+  --gradient-start: #4ADE80;
+  --gradient-end: #84CC16;
+  --glow: rgba(74, 222, 128, 0.15);
+}
+
+html {
+  font-size: 14px;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+/* ========== NAVIGATION ========== */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 0 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+  transition: background var(--transition-base), border-color var(--transition-base);
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-heading);
+  font-weight: 800;
+  font-size: 18px;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.nav-brand svg {
+  width: 28px;
+  height: 28px;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  list-style: none;
+}
+
+.nav-links a {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: all var(--transition-base);
+}
+
+.nav-links a:hover {
+  color: var(--text);
+  background: var(--bg);
+}
+
+.nav-links a.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+[data-theme="dark"] .nav-links a.active {
+  background: var(--primary);
+  color: #020617;
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.btn-icon {
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-btn);
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-base);
+}
+
+.btn-icon:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+  box-shadow: 0 0 0 3px var(--glow);
+}
+
+.btn-primary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-btn);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-base);
+}
+
+[data-theme="dark"] .btn-primary {
+  color: #020617;
+}
+
+.btn-primary:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px var(--glow);
+}
+
+/* ========== MAIN CONTAINER ========== */
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.page-header {
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  font-family: var(--font-heading);
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.page-header p {
+  color: var(--text-secondary);
+  margin-top: 4px;
+  font-size: 14px;
+}
+
+/* ========== BENTO GRID ========== */
+.bento-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: auto;
+  gap: 16px;
+}
+
+/* Grid placement */
+.card-open-tasks   { grid-column: 1; grid-row: 1; }
+.card-completion   { grid-column: 2; grid-row: 1; }
+.card-weather      { grid-column: 3; grid-row: 1 / span 2; }
+.card-done         { grid-column: 1; grid-row: 2; }
+.card-staff        { grid-column: 2; grid-row: 2; }
+.card-next-tasks   { grid-column: 1 / span 2; grid-row: 3 / span 2; }
+.card-locations    { grid-column: 3; grid-row: 3; }
+.card-activity     { grid-column: 3; grid-row: 4; }
+
+/* ========== CARD BASE ========== */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  padding: 20px;
+  transition: all var(--transition-base);
+  opacity: 0;
+  transform: translateY(20px) scale(0.97);
+  position: relative;
+  overflow: hidden;
+}
+
+.card.visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.card:hover {
+  border-color: transparent;
+  box-shadow: 0 0 0 1px var(--border), 0 0 20px var(--glow);
+}
+
+.card-label {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.card-label svg {
+  width: 14px;
+  height: 14px;
+  opacity: 0.6;
+}
+
+.stat-number {
+  font-family: var(--font-mono);
+  font-size: 32px;
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 8px;
+}
+
+.stat-number.green { color: var(--primary); }
+.stat-number.accent { color: var(--accent); }
+
+/* ========== PROGRESS BAR ========== */
+.progress-bar {
+  width: 100%;
+  height: 8px;
+  background: var(--bg);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end));
+  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 0%;
+}
+
+.progress-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* ========== CIRCULAR PROGRESS ========== */
+.circle-progress-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.circle-progress {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  flex-shrink: 0;
+}
+
+.circle-progress svg {
+  transform: rotate(-90deg);
+  width: 80px;
+  height: 80px;
+}
+
+.circle-progress-bg {
+  fill: none;
+  stroke: var(--bg);
+  stroke-width: 6;
+}
+
+.circle-progress-fill {
+  fill: none;
+  stroke: url(#circleGrad);
+  stroke-width: 6;
+  stroke-linecap: round;
+  stroke-dasharray: 207.35;
+  stroke-dashoffset: 207.35;
+  transition: stroke-dashoffset 1.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.circle-progress-text {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.circle-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.circle-details span:first-child {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--primary);
+}
+
+.circle-details span:last-child {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+/* ========== WEATHER CARD ========== */
+.weather-current {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.weather-icon {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #FDE68A, #FBBF24);
+  border-radius: 16px;
+  font-size: 32px;
+  flex-shrink: 0;
+}
+
+[data-theme="dark"] .weather-icon {
+  background: linear-gradient(135deg, #78350F, #92400E);
+}
+
+.weather-temp {
+  font-family: var(--font-mono);
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.weather-desc {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.weather-details {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.weather-detail {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.weather-detail-val {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.weather-forecast-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+}
+
+.weather-forecast {
+  display: flex;
+  justify-content: space-between;
+  gap: 4px;
+}
+
+.weather-day {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.weather-day-temp {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text);
+}
+
+.weather-mini-bar {
+  width: 4px;
+  border-radius: 2px;
+  background: linear-gradient(to top, var(--gradient-start), var(--gradient-end));
+  min-height: 12px;
+}
+
+/* ========== DONE CARD ========== */
+.stat-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  font-size: 12px;
+  font-weight: 600;
+  margin-top: 4px;
+}
+
+.stat-badge.positive {
+  background: rgba(21, 128, 61, 0.1);
+  color: var(--primary);
+}
+
+[data-theme="dark"] .stat-badge.positive {
+  background: rgba(74, 222, 128, 0.12);
+}
+
+/* ========== MINI BAR CHART ========== */
+.mini-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 48px;
+  margin-top: 12px;
+}
+
+.mini-bar {
+  flex: 1;
+  border-radius: 3px 3px 0 0;
+  background: linear-gradient(to top, var(--gradient-start), var(--gradient-end));
+  opacity: 0.75;
+  transition: opacity var(--transition-base), height 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  height: 0;
+}
+
+.mini-bar:hover {
+  opacity: 1;
+}
+
+.mini-bar-labels {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.mini-bar-labels span {
+  flex: 1;
+  text-align: center;
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+/* ========== TASK LIST ========== */
+.card-next-tasks {
+  display: flex;
+  flex-direction: column;
+}
+
+.task-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.task-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  transition: background var(--transition-base);
+  cursor: pointer;
+}
+
+.task-item:hover {
+  background: var(--bg);
+}
+
+.task-checkbox {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-base);
+  background: var(--surface);
+  position: relative;
+}
+
+.task-checkbox:checked {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+.task-checkbox:checked::after {
+  content: '';
+  width: 6px;
+  height: 10px;
+  border: 2px solid #fff;
+  border-top: none;
+  border-left: none;
+  transform: rotate(45deg) translate(-1px, -1px);
+  position: absolute;
+}
+
+[data-theme="dark"] .task-checkbox:checked::after {
+  border-color: #020617;
+}
+
+.task-checkbox:hover {
+  border-color: var(--primary);
+}
+
+.task-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+  transition: all var(--transition-base);
+}
+
+.task-item.checked .task-title {
+  text-decoration: line-through;
+  opacity: 0.5;
+}
+
+.task-meta {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 1px;
+}
+
+.task-priority {
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.task-priority.high {
+  background: rgba(239, 68, 68, 0.1);
+  color: #EF4444;
+}
+
+.task-priority.medium {
+  background: rgba(245, 158, 11, 0.1);
+  color: #F59E0B;
+}
+
+.task-priority.low {
+  background: rgba(21, 128, 61, 0.1);
+  color: var(--primary);
+}
+
+/* ========== LOCATION BARS ========== */
+.location-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.location-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.location-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.location-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.location-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.location-bar {
+  width: 100%;
+  height: 6px;
+  background: var(--bg);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.location-bar-fill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 0%;
+}
+
+.location-bar-fill.c1 { background: linear-gradient(90deg, var(--gradient-start), var(--gradient-end)); }
+.location-bar-fill.c2 { background: linear-gradient(90deg, #4F46E5, #818CF8); }
+.location-bar-fill.c3 { background: linear-gradient(90deg, #F59E0B, #FBBF24); }
+.location-bar-fill.c4 { background: linear-gradient(90deg, #EC4899, #F472B6); }
+
+/* ========== SPARKLINE ========== */
+.sparkline-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 64px;
+  margin-top: 8px;
+}
+
+.sparkline-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.sparkline-bar {
+  width: 100%;
+  border-radius: 4px;
+  background: linear-gradient(to top, var(--gradient-start), var(--gradient-end));
+  transition: height 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+  height: 0;
+  min-width: 12px;
+  max-width: 28px;
+  position: relative;
+}
+
+.sparkline-bar:hover {
+  opacity: 0.85;
+}
+
+.sparkline-bar::after {
+  content: attr(data-val);
+  position: absolute;
+  top: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.sparkline-bar:hover::after {
+  opacity: 1;
+}
+
+.sparkline-label {
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+.sparkline-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.sparkline-summary span:first-child {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.sparkline-summary span:last-child {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+/* ========== DARK MODE TRANSITION ========== */
+.theme-transitioning .card {
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), background var(--transition-base), border-color var(--transition-base);
+  transform: scale(0.96);
+}
+
+.theme-transitioning .card.visible {
+  transform: scale(1);
+}
+
+/* ========== RESPONSIVE ========== */
+@media (max-width: 768px) {
+  .bento-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card-open-tasks,
+  .card-completion,
+  .card-weather,
+  .card-done,
+  .card-staff,
+  .card-next-tasks,
+  .card-locations,
+  .card-activity {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .nav-links { display: none; }
+
+  .container { padding: 16px; }
+
+  .weather-forecast { flex-wrap: wrap; justify-content: flex-start; gap: 12px; }
+}
+
+@media (max-width: 480px) {
+  .nav { padding: 0 16px; }
+  .btn-primary span { display: none; }
+}
+</style>
+</head>
+<body>
+
+<!-- SVG gradient definition for circular progress -->
+<svg width="0" height="0" style="position:absolute">
+  <defs>
+    <linearGradient id="circleGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#15803D"/>
+      <stop offset="100%" stop-color="#84CC16"/>
+    </linearGradient>
+  </defs>
+</svg>
+
+<!-- ==================== NAVIGATION ==================== -->
+<nav class="nav">
+  <a href="#" class="nav-brand">
+    <svg viewBox="0 0 28 28" fill="none">
+      <rect width="28" height="28" rx="6" fill="currentColor"/>
+      <path d="M7 20V14a7 7 0 0 1 14 0v6" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+      <path d="M14 8v6M10 14h8" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+    </svg>
+    GridGarden
+  </a>
+
+  <ul class="nav-links">
+    <li><a href="#" class="active">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Dashboard</a></li>
+    <li><a href="#">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+      Beete</a></li>
+    <li><a href="#">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+      Aufgaben</a></li>
+    <li><a href="#">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg>
+      Statistiken</a></li>
+  </ul>
+
+  <div class="nav-actions">
+    <button class="btn-icon" id="themeToggle" title="Dark Mode umschalten">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="icon-sun">
+        <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+      </svg>
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="icon-moon" style="display:none">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+      </svg>
+    </button>
+    <button class="btn-primary">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      <span>Neue Aufgabe</span>
+    </button>
+  </div>
+</nav>
+
+<!-- ==================== MAIN CONTENT ==================== -->
+<main class="container">
+  <div class="page-header">
+    <h1>Dashboard</h1>
+    <p>Montag, 30. M&auml;rz 2026 &mdash; Saison Fr&uuml;hjahr</p>
+  </div>
+
+  <div class="bento-grid">
+
+    <!-- ===== OFFENE AUFGABEN ===== -->
+    <div class="card card-open-tasks" data-delay="0">
+      <div class="card-label">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l2 2"/></svg>
+        Offene Aufgaben
+      </div>
+      <div class="stat-number green">12</div>
+      <div class="progress-label">
+        <span>4 &uuml;berf&auml;llig</span>
+        <span style="font-family:var(--font-mono);font-weight:600;">26%</span>
+      </div>
+      <div class="progress-bar">
+        <div class="progress-bar-fill" data-width="26"></div>
+      </div>
+    </div>
+
+    <!-- ===== ABSCHLUSSQUOTE ===== -->
+    <div class="card card-completion" data-delay="80">
+      <div class="card-label">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+        Abschlussquote
+      </div>
+      <div class="circle-progress-wrapper">
+        <div class="circle-progress">
+          <svg viewBox="0 0 80 80">
+            <circle class="circle-progress-bg" cx="40" cy="40" r="33"/>
+            <circle class="circle-progress-fill" cx="40" cy="40" r="33" data-pct="73.9"/>
+          </svg>
+          <div class="circle-progress-text">73.9%</div>
+        </div>
+        <div class="circle-details">
+          <span>+5.2%</span>
+          <span>vs. letzter Monat</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== WETTER ===== -->
+    <div class="card card-weather" data-delay="160">
+      <div class="card-label">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        Wetter &mdash; Aachen
+      </div>
+      <div class="weather-current">
+        <div class="weather-icon">&#9728;&#65039;</div>
+        <div>
+          <div class="weather-temp">18&deg;C</div>
+          <div class="weather-desc">Sonnig, leichter Wind</div>
+        </div>
+      </div>
+      <div class="weather-details">
+        <div class="weather-detail">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z"/></svg>
+          Feuchtigkeit <span class="weather-detail-val">62%</span>
+        </div>
+        <div class="weather-detail">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9.59 4.59A2 2 0 1 1 11 8H2m10.59 11.41A2 2 0 1 0 14 16H2m15.73-8.27A2.5 2.5 0 1 1 19.5 12H2"/></svg>
+          Wind <span class="weather-detail-val">12 km/h</span>
+        </div>
+        <div class="weather-detail">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2v20M2 12h20"/></svg>
+          UV-Index <span class="weather-detail-val">5</span>
+        </div>
+        <div class="weather-detail">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/></svg>
+          Boden <span class="weather-detail-val">14&deg;C</span>
+        </div>
+      </div>
+      <div class="weather-forecast-label">7-Tage Vorhersage</div>
+      <div class="weather-forecast">
+        <div class="weather-day"><span>Mo</span><div class="weather-mini-bar" style="height:36px"></div><span class="weather-day-temp">18&deg;</span></div>
+        <div class="weather-day"><span>Di</span><div class="weather-mini-bar" style="height:32px"></div><span class="weather-day-temp">16&deg;</span></div>
+        <div class="weather-day"><span>Mi</span><div class="weather-mini-bar" style="height:28px"></div><span class="weather-day-temp">14&deg;</span></div>
+        <div class="weather-day"><span>Do</span><div class="weather-mini-bar" style="height:26px"></div><span class="weather-day-temp">13&deg;</span></div>
+        <div class="weather-day"><span>Fr</span><div class="weather-mini-bar" style="height:34px"></div><span class="weather-day-temp">17&deg;</span></div>
+        <div class="weather-day"><span>Sa</span><div class="weather-mini-bar" style="height:40px"></div><span class="weather-day-temp">20&deg;</span></div>
+        <div class="weather-day"><span>So</span><div class="weather-mini-bar" style="height:38px"></div><span class="weather-day-temp">19&deg;</span></div>
+      </div>
+    </div>
+
+    <!-- ===== ERLEDIGT ===== -->
+    <div class="card card-done" data-delay="240">
+      <div class="card-label">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="20 6 9 17 4 12"/></svg>
+        Erledigt
+      </div>
+      <div class="stat-number" style="color:var(--text)">34</div>
+      <div class="stat-badge positive">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
+        +8 vs. letzte Woche
+      </div>
+    </div>
+
+    <!-- ===== MITARBEITER ===== -->
+    <div class="card card-staff" data-delay="320">
+      <div class="card-label">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+        Aktive Mitarbeiter
+      </div>
+      <div class="stat-number accent">5</div>
+      <div class="mini-bars">
+        <div class="mini-bar" data-height="85"></div>
+        <div class="mini-bar" data-height="60"></div>
+        <div class="mini-bar" data-height="95"></div>
+        <div class="mini-bar" data-height="45"></div>
+        <div class="mini-bar" data-height="70"></div>
+      </div>
+      <div class="mini-bar-labels">
+        <span>MK</span><span>TH</span><span>LS</span><span>JW</span><span>PB</span>
+      </div>
+    </div>
+
+    <!-- ===== NAECHSTE AUFGABEN ===== -->
+    <div class="card card-next-tasks" data-delay="400">
+      <div class="card-label">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+        N&auml;chste Aufgaben
+      </div>
+      <ul class="task-list">
+        <li class="task-item">
+          <input type="checkbox" class="task-checkbox">
+          <div class="task-content">
+            <div class="task-title">Tomaten-Beete mulchen</div>
+            <div class="task-meta">Beet A3 &middot; F&auml;llig heute</div>
+          </div>
+          <span class="task-priority high">Hoch</span>
+        </li>
+        <li class="task-item">
+          <input type="checkbox" class="task-checkbox">
+          <div class="task-content">
+            <div class="task-title">Bew&auml;sserungssystem pr&uuml;fen</div>
+            <div class="task-meta">Alle Standorte &middot; F&auml;llig morgen</div>
+          </div>
+          <span class="task-priority high">Hoch</span>
+        </li>
+        <li class="task-item">
+          <input type="checkbox" class="task-checkbox">
+          <div class="task-content">
+            <div class="task-title">Kr&auml;utergarten j&auml;ten</div>
+            <div class="task-meta">Beet K1 &middot; F&auml;llig Mi, 01.04.</div>
+          </div>
+          <span class="task-priority medium">Mittel</span>
+        </li>
+        <li class="task-item">
+          <input type="checkbox" class="task-checkbox">
+          <div class="task-content">
+            <div class="task-title">Erdbeeren d&uuml;ngen</div>
+            <div class="task-meta">Beet B2 &middot; F&auml;llig Do, 02.04.</div>
+          </div>
+          <span class="task-priority medium">Mittel</span>
+        </li>
+        <li class="task-item">
+          <input type="checkbox" class="task-checkbox">
+          <div class="task-content">
+            <div class="task-title">Kompost umsetzen</div>
+            <div class="task-meta">Kompoststation &middot; F&auml;llig Fr, 03.04.</div>
+          </div>
+          <span class="task-priority low">Niedrig</span>
+        </li>
+      </ul>
+    </div>
+
+    <!-- ===== STANDORT-VERTEILUNG ===== -->
+    <div class="card card-locations" data-delay="480">
+      <div class="card-label">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+        Standort-Verteilung
+      </div>
+      <div class="location-list">
+        <div class="location-item">
+          <div class="location-header"><span class="location-name">Gem&uuml;segarten</span><span class="location-count">18</span></div>
+          <div class="location-bar"><div class="location-bar-fill c1" data-width="80"></div></div>
+        </div>
+        <div class="location-item">
+          <div class="location-header"><span class="location-name">Kr&auml;uterbeet</span><span class="location-count">12</span></div>
+          <div class="location-bar"><div class="location-bar-fill c2" data-width="55"></div></div>
+        </div>
+        <div class="location-item">
+          <div class="location-header"><span class="location-name">Obstgarten</span><span class="location-count">8</span></div>
+          <div class="location-bar"><div class="location-bar-fill c3" data-width="36"></div></div>
+        </div>
+        <div class="location-item">
+          <div class="location-header"><span class="location-name">Gew&auml;chshaus</span><span class="location-count">6</span></div>
+          <div class="location-bar"><div class="location-bar-fill c4" data-width="27"></div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== AKTIVITAET ===== -->
+    <div class="card card-activity" data-delay="560">
+      <div class="card-label">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+        Aktivit&auml;t
+      </div>
+      <div class="sparkline-chart">
+        <div class="sparkline-col">
+          <div class="sparkline-bar" data-height="40" data-val="5"></div>
+          <span class="sparkline-label">KW21</span>
+        </div>
+        <div class="sparkline-col">
+          <div class="sparkline-bar" data-height="55" data-val="7"></div>
+          <span class="sparkline-label">KW22</span>
+        </div>
+        <div class="sparkline-col">
+          <div class="sparkline-bar" data-height="35" data-val="4"></div>
+          <span class="sparkline-label">KW23</span>
+        </div>
+        <div class="sparkline-col">
+          <div class="sparkline-bar" data-height="70" data-val="9"></div>
+          <span class="sparkline-label">KW24</span>
+        </div>
+        <div class="sparkline-col">
+          <div class="sparkline-bar" data-height="85" data-val="11"></div>
+          <span class="sparkline-label">KW25</span>
+        </div>
+        <div class="sparkline-col">
+          <div class="sparkline-bar" data-height="65" data-val="8"></div>
+          <span class="sparkline-label">KW26</span>
+        </div>
+      </div>
+      <div class="sparkline-summary">
+        <span>Gesamt</span>
+        <span>44 Aufgaben</span>
+      </div>
+    </div>
+
+  </div><!-- /bento-grid -->
+</main>
+
+<script>
+(function() {
+  'use strict';
+
+  // ==================== STAGGERED LOAD ANIMATION ====================
+  function animateCards() {
+    const cards = document.querySelectorAll('.card');
+    cards.forEach(function(card) {
+      const delay = parseInt(card.dataset.delay) || 0;
+      setTimeout(function() {
+        card.classList.add('visible');
+      }, 200 + delay);
+    });
+  }
+
+  // ==================== ANIMATE DATA-DRIVEN ELEMENTS ====================
+  function animateData() {
+    // Progress bars
+    document.querySelectorAll('.progress-bar-fill[data-width]').forEach(function(el) {
+      setTimeout(function() { el.style.width = el.dataset.width + '%'; }, 600);
+    });
+
+    // Location bars
+    document.querySelectorAll('.location-bar-fill[data-width]').forEach(function(el) {
+      setTimeout(function() { el.style.width = el.dataset.width + '%'; }, 800);
+    });
+
+    // Mini bars (staff)
+    document.querySelectorAll('.mini-bar[data-height]').forEach(function(el, i) {
+      setTimeout(function() { el.style.height = el.dataset.height + '%'; }, 700 + i * 80);
+    });
+
+    // Sparkline bars
+    document.querySelectorAll('.sparkline-bar[data-height]').forEach(function(el, i) {
+      setTimeout(function() { el.style.height = el.dataset.height + '%'; }, 900 + i * 80);
+    });
+
+    // Circular progress
+    document.querySelectorAll('.circle-progress-fill[data-pct]').forEach(function(el) {
+      var pct = parseFloat(el.dataset.pct);
+      var circumference = 2 * Math.PI * 33; // r=33
+      var offset = circumference - (pct / 100) * circumference;
+      setTimeout(function() { el.style.strokeDashoffset = offset; }, 700);
+    });
+  }
+
+  // ==================== DARK MODE TOGGLE ====================
+  var themeToggle = document.getElementById('themeToggle');
+  var html = document.documentElement;
+  var iconSun = themeToggle.querySelector('.icon-sun');
+  var iconMoon = themeToggle.querySelector('.icon-moon');
+
+  function applyThemeIcons() {
+    var isDark = html.getAttribute('data-theme') === 'dark';
+    iconSun.style.display = isDark ? 'none' : 'block';
+    iconMoon.style.display = isDark ? 'block' : 'none';
+  }
+
+  themeToggle.addEventListener('click', function() {
+    var isDark = html.getAttribute('data-theme') === 'dark';
+
+    // Spectacular transition: scale all cards briefly
+    document.body.classList.add('theme-transitioning');
+
+    setTimeout(function() {
+      html.setAttribute('data-theme', isDark ? 'light' : 'dark');
+      applyThemeIcons();
+    }, 150);
+
+    setTimeout(function() {
+      document.body.classList.remove('theme-transitioning');
+    }, 500);
+  });
+
+  applyThemeIcons();
+
+  // ==================== TASK CHECKBOXES ====================
+  document.querySelectorAll('.task-checkbox').forEach(function(cb) {
+    cb.addEventListener('change', function() {
+      var item = cb.closest('.task-item');
+      if (cb.checked) {
+        item.classList.add('checked');
+      } else {
+        item.classList.remove('checked');
+      }
+    });
+  });
+
+  // ==================== INIT ====================
+  animateCards();
+  animateData();
+
+})();
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/src/css/plants.css
+++ b/src/css/plants.css
@@ -650,3 +650,91 @@
 [data-theme="dark"] .plant-favorite-btn:hover {
   color: #F87171;
 }
+
+/* === Care Guide === */
+
+.care-guide {
+  margin-bottom: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.care-guide h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 1rem;
+}
+
+.care-guide-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+}
+
+.care-item {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0.875rem;
+  transition: border-color 0.2s;
+}
+
+.care-item:hover {
+  border-color: var(--primary-light);
+}
+
+.care-icon {
+  font-size: 1.25rem;
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.care-item strong {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.care-item p {
+  font-size: 0.85rem;
+  color: var(--text-light);
+  line-height: 1.5;
+  margin: 0;
+}
+
+@media (width <= 768px) {
+  .care-guide-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Dark Mode - Care Guide */
+[data-theme="dark"] .care-guide {
+  border-color: var(--border);
+}
+
+[data-theme="dark"] .care-guide h3 {
+  color: var(--primary);
+}
+
+[data-theme="dark"] .care-item {
+  background: var(--bg-tertiary, #262626);
+  border-color: var(--border);
+}
+
+[data-theme="dark"] .care-item:hover {
+  border-color: var(--primary);
+}
+
+[data-theme="dark"] .care-item strong {
+  color: var(--text);
+}
+
+[data-theme="dark"] .care-item p {
+  color: var(--text-light);
+}

--- a/src/js/plants.js
+++ b/src/js/plants.js
@@ -215,6 +215,36 @@
             spring: 'Frühling', summer: 'Sommer', autumn: 'Herbst', winter: 'Winter'
         }[s] || s)).join(', ');
 
+        // Build care guide HTML if careGuide data exists
+        var careGuideHtml = '';
+        if (plant.careGuide) {
+            var careItems = [
+                { key: 'watering', icon: '\ud83d\udca7', label: 'Gie\u00dfen' },
+                { key: 'fertilizing', icon: '\ud83c\udf3e', label: 'D\u00fcngen' },
+                { key: 'pruning', icon: '\u2702\ufe0f', label: 'Schnitt & Pflege' },
+                { key: 'location', icon: '\u2600\ufe0f', label: 'Standort' },
+                { key: 'soil', icon: '\ud83e\udea8', label: 'Boden' },
+                { key: 'pests', icon: '\ud83d\udc1b', label: 'Sch\u00e4dlinge & Krankheiten' },
+                { key: 'harvestTips', icon: '\ud83c\udf3d', label: 'Erntetipps' }
+            ];
+            var items = careItems
+                .filter(function (item) { return plant.careGuide[item.key]; })
+                .map(function (item) {
+                    return '<div class="care-item">' +
+                        '<span class="care-icon">' + item.icon + '</span>' +
+                        '<strong>' + item.label + '</strong>' +
+                        '<p>' + Security.escapeHtml(plant.careGuide[item.key]) + '</p>' +
+                        '</div>';
+                })
+                .join('');
+            if (items) {
+                careGuideHtml = '<div class="care-guide">' +
+                    '<h3>\ud83c\udf31 Pflegeanleitung</h3>' +
+                    '<div class="care-guide-grid">' + items + '</div>' +
+                    '</div>';
+            }
+        }
+
         content.innerHTML = `
             <button class="plant-modal-close" aria-label="Schließen">&times;</button>
             <div class="plant-detail-header">
@@ -237,6 +267,7 @@
                 <h3>Pflegetipps</h3>
                 <p>${safeTips}</p>
             </div>
+            ${careGuideHtml}
             ${plant.companions.length > 0 ? `<div class="plant-detail-section"><h3>Gute Nachbarn</h3><div class="companion-tags">${plant.companions.map(c => `<span class="companion-tag good">${Security.escapeHtml(c)}</span>`).join('')}</div></div>` : ''}
             ${plant.avoid.length > 0 ? `<div class="plant-detail-section"><h3>Schlechte Nachbarn</h3><div class="companion-tags">${plant.avoid.map(c => `<span class="companion-tag bad">${Security.escapeHtml(c)}</span>`).join('')}</div></div>` : ''}
             <div class="plant-detail-actions">

--- a/src/server/defaults/default-plants.json
+++ b/src/server/defaults/default-plants.json
@@ -2,8 +2,8 @@
   {
     "id": "tomato",
     "name": "Tomate",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83c\udf45",
+    "category": "Gemüse",
+    "icon": "🍅",
     "difficulty": "easy",
     "sun": "full",
     "water": "medium",
@@ -13,13 +13,22 @@
     "harvest": "60-85 Tage",
     "companions": ["Basilikum", "Karotte", "Petersilie"],
     "avoid": ["Fenchel", "Kartoffel"],
-    "tips": "Regelm\u00e4\u00dfig ausgeizen. Vor Regen sch\u00fctzen um Braunf\u00e4ule zu vermeiden. Tief pflanzen f\u00fcr kr\u00e4ftige Wurzeln."
+    "tips": "Regelmäßig ausgeizen. Vor Regen schützen um Braunfäule zu vermeiden. Tief pflanzen für kräftige Wurzeln.",
+    "careGuide": {
+      "watering": "Regelmäßig gießen, Staunässe vermeiden. 2-3x pro Woche, bei Hitze täglich. Immer von unten gießen, Blätter trocken halten.",
+      "fertilizing": "Alle 2 Wochen mit Tomatendünger. Ab Fruchtbildung wöchentlich. Vor dem Pflanzen Kompost einarbeiten.",
+      "pruning": "Geiztriebe regelmäßig ausbrechen. Unterste Blätter entfernen für bessere Luftzirkulation. Ab August Spitze kappen.",
+      "location": "Sonnig, windgeschützt. Mindestens 6h direkte Sonne. Ideal an einer Südwand oder im Gewächshaus.",
+      "soil": "Humusreich, locker, leicht sauer (pH 6.0-6.8). Tiefgründig und nährstoffreich.",
+      "pests": "Braunfäule, Blattläuse, Weiße Fliege. Vorbeugend: gute Luftzirkulation, Regenschutz, Basilikum als Nachbar.",
+      "harvestTips": "Reif ernten wenn gleichmäßig gefärbt. Regelmäßig pflücken fördert Nachreife. Grüne Tomaten am Fenster nachreifen lassen."
+    }
   },
   {
     "id": "carrot",
     "name": "Karotte",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83e\udd55",
+    "category": "Gemüse",
+    "icon": "🥕",
     "difficulty": "easy",
     "sun": "full",
     "water": "low",
@@ -29,13 +38,21 @@
     "harvest": "70-80 Tage",
     "companions": ["Tomate", "Zwiebel", "Lauch"],
     "avoid": ["Dill"],
-    "tips": "Boden gut lockern f\u00fcr gerade Wurzeln. Nicht frisch d\u00fcngen. Gleichm\u00e4\u00dfig feucht halten."
+    "tips": "Boden gut lockern für gerade Wurzeln. Nicht frisch düngen. Gleichmäßig feucht halten.",
+    "careGuide": {
+      "watering": "Gleichmäßig feucht halten, aber nicht nass. Bei Trockenheit splittern die Wurzeln. 1-2x pro Woche gründlich gießen.",
+      "fertilizing": "Wenig düngen — zu viel Stickstoff fördert Laubwuchs statt Wurzelbildung. Kompost vor der Aussaat einarbeiten.",
+      "location": "Sonnig bis halbschattig. Verträgt leichten Schatten am Nachmittag.",
+      "soil": "Tiefgründig gelockert, sandig-lehmig, steinfrei. pH 6.0-7.0. Keine frische organische Düngung.",
+      "pests": "Möhrenfliege ist der Hauptschädling. Vorbeugend: Kulturschutznetz, Mischkultur mit Zwiebeln.",
+      "harvestTips": "Ernten wenn die Köpfe 2-3cm aus der Erde ragen. Vorsichtig mit der Grabegabel lockern. Lagerkarotten nach dem ersten Frost ernten."
+    }
   },
   {
     "id": "basil",
     "name": "Basilikum",
-    "category": "Kr\u00e4uter",
-    "icon": "\ud83c\udf3f",
+    "category": "Kräuter",
+    "icon": "🌿",
     "difficulty": "easy",
     "sun": "full",
     "water": "medium",
@@ -45,13 +62,21 @@
     "harvest": "21-30 Tage",
     "companions": ["Tomate", "Paprika"],
     "avoid": ["Salbei"],
-    "tips": "Regelm\u00e4\u00dfig ernten f\u00f6rdert buschigen Wuchs. Bl\u00fcten abknipsen. Frostempfindlich."
+    "tips": "Regelmäßig ernten fördert buschigen Wuchs. Blüten abknipsen. Frostempfindlich.",
+    "careGuide": {
+      "watering": "Regelmäßig gießen, Erde gleichmäßig feucht halten. Morgens gießen, nie über die Blätter. Staunässe unbedingt vermeiden.",
+      "fertilizing": "Alle 3-4 Wochen leicht mit organischem Flüssigdünger. Nicht überdüngen — mindert das Aroma.",
+      "pruning": "Regelmäßig Triebspitzen ernten für buschigen Wuchs. Blütenansätze sofort abknipsen, sonst wird die Pflanze bitter.",
+      "location": "Vollsonnig, warm und windgeschützt. Mindestens 6h Sonne. Ideal auf der Fensterbank oder geschützter Terrasse.",
+      "soil": "Humusreich, durchlässig, nährstoffreich. pH 6.0-7.0. Gute Drainage ist wichtig.",
+      "harvestTips": "Immer ganze Triebspitzen ernten, nicht einzelne Blätter abzupfen. Morgens ernten für bestes Aroma."
+    }
   },
   {
     "id": "strawberry",
     "name": "Erdbeere",
     "category": "Obst",
-    "icon": "\ud83c\udf53",
+    "icon": "🍓",
     "difficulty": "easy",
     "sun": "full",
     "water": "medium",
@@ -61,13 +86,22 @@
     "harvest": "60-90 Tage",
     "companions": ["Knoblauch", "Zwiebel", "Salat"],
     "avoid": ["Kartoffel"],
-    "tips": "Stroh unterlegen gegen F\u00e4ulnis. Ausl\u00e4ufer entfernen f\u00fcr gr\u00f6\u00dfere Fr\u00fcchte. Nach 3 Jahren Standort wechseln."
+    "tips": "Stroh unterlegen gegen Fäulnis. Ausläufer entfernen für größere Früchte. Nach 3 Jahren Standort wechseln.",
+    "careGuide": {
+      "watering": "Regelmäßig gießen, besonders während Blüte und Fruchtbildung. Tropfbewässerung ideal. Früchte nicht nass machen.",
+      "fertilizing": "Im Frühjahr mit Beerendünger versorgen. Nach der Ernte nochmals düngen für die Blütenanlage im nächsten Jahr.",
+      "pruning": "Ausläufer regelmäßig entfernen, außer zur Vermehrung. Nach der Ernte altes Laub abschneiden.",
+      "location": "Sonnig, windgeschützt. Mindestens 6h direkte Sonne für süße Früchte.",
+      "soil": "Humusreich, leicht sauer (pH 5.5-6.5). Gut durchlässig. Keine Staunässe.",
+      "pests": "Grauschimmel, Erdbeermilbe, Schnecken. Vorbeugend: Stroh unterlegen, gute Luftzirkulation, Schneckenschutz.",
+      "harvestTips": "Vollreif ernten wenn gleichmäßig rot. Morgens pflücken für längere Haltbarkeit. Mit Kelch ernten."
+    }
   },
   {
     "id": "lettuce",
     "name": "Salat",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83e\udd6c",
+    "category": "Gemüse",
+    "icon": "🥬",
     "difficulty": "easy",
     "sun": "partial",
     "water": "medium",
@@ -77,13 +111,21 @@
     "harvest": "45-60 Tage",
     "companions": ["Karotte", "Radieschen", "Erdbeere"],
     "avoid": [],
-    "tips": "Staffelweise auss\u00e4en f\u00fcr durchgehende Ernte. Bei Hitze schie\u00dft er schnell. Morgens gie\u00dfen."
+    "tips": "Staffelweise aussäen für durchgehende Ernte. Bei Hitze schießt er schnell. Morgens gießen.",
+    "careGuide": {
+      "watering": "Gleichmäßig feucht halten, aber nicht nass. Bei Hitze morgens und abends leicht gießen. Tropfbewässerung ideal.",
+      "fertilizing": "Schwachzehrer — wenig Dünger nötig. Etwas Kompost vor der Pflanzung reicht. Bei Bedarf verdünnten Brennnesselsud.",
+      "location": "Halbschattig bis sonnig. Im Sommer Schatten am Nachmittag bevorzugt, sonst schießt er schnell.",
+      "soil": "Humusreich, locker, gleichmäßig feucht. pH 6.0-7.0. Gute Wasserspeicherfähigkeit.",
+      "pests": "Schnecken sind der Hauptfeind. Vorbeugend: Schneckenkragen, Bierfallen, abends nicht gießen.",
+      "harvestTips": "Morgens ernten für maximale Frische. Pflücksalate blattweise ernten, Kopfsalat komplett. Vor der Blüte ernten."
+    }
   },
   {
     "id": "potato",
     "name": "Kartoffel",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83e\udd54",
+    "category": "Gemüse",
+    "icon": "🥔",
     "difficulty": "easy",
     "sun": "full",
     "water": "medium",
@@ -93,13 +135,22 @@
     "harvest": "90-120 Tage",
     "companions": ["Bohne", "Mais", "Spinat"],
     "avoid": ["Tomate", "Sonnenblume"],
-    "tips": "Regelm\u00e4\u00dfig anh\u00e4ufeln. Ernte wenn Kraut welkt. Nicht neben Tomaten pflanzen (Krautf\u00e4ule)."
+    "tips": "Regelmäßig anhäufeln. Ernte wenn Kraut welkt. Nicht neben Tomaten pflanzen (Krautfäule).",
+    "careGuide": {
+      "watering": "Mäßig gießen, besonders während der Blüte. Zu viel Wasser fördert Fäulnis. Bei Trockenheit 1-2x pro Woche.",
+      "fertilizing": "Mittelzehrer — Kompost oder Hornspäne vor dem Pflanzen einarbeiten. Während der Wachstumsphase nicht nachdüngen.",
+      "pruning": "Regelmäßig anhäufeln sobald das Kraut 15-20cm hoch ist. Fördert die Knollenbildung und verhindert Ergrünung.",
+      "location": "Sonnig, offene Lage. Nicht am gleichen Standort wie im Vorjahr pflanzen (Fruchtfolge beachten).",
+      "soil": "Locker, sandig-lehmig, humusreich. pH 5.5-6.5. Staunässe unbedingt vermeiden.",
+      "pests": "Kartoffelkäfer, Krautfäule, Drahtwurm. Vorbeugend: Fruchtfolge einhalten, nicht neben Tomaten pflanzen.",
+      "harvestTips": "Frühkartoffeln ab Juni, Lagerkartoffeln nach Absterben des Krauts. 2 Wochen vor Ernte nicht mehr gießen. Bei trockenem Wetter ernten."
+    }
   },
   {
     "id": "zucchini",
     "name": "Zucchini",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83e\udd52",
+    "category": "Gemüse",
+    "icon": "🥒",
     "difficulty": "easy",
     "sun": "full",
     "water": "high",
@@ -109,13 +160,21 @@
     "harvest": "50-60 Tage",
     "companions": ["Mais", "Bohne", "Kapuzinerkresse"],
     "avoid": ["Kartoffel"],
-    "tips": "Braucht viel Platz. Jung ernten f\u00fcr besten Geschmack. Morgens best\u00e4uben bei schlechtem Wetter."
+    "tips": "Braucht viel Platz. Jung ernten für besten Geschmack. Morgens bestäuben bei schlechtem Wetter.",
+    "careGuide": {
+      "watering": "Reichlich gießen, besonders bei Fruchtbildung. 3-4x pro Woche gründlich wässern. Blätter trocken halten.",
+      "fertilizing": "Starkzehrer — alle 2 Wochen mit organischem Dünger oder Brennnesseljauche. Kompost großzügig einarbeiten.",
+      "location": "Vollsonnig, warm, windgeschützt. Braucht viel Platz — mindestens 1m² pro Pflanze.",
+      "soil": "Nährstoffreich, humusreich, feucht aber durchlässig. pH 6.0-7.0. Ideal auf dem Komposthaufen.",
+      "pests": "Mehltau, Blattläuse. Vorbeugend: gute Luftzirkulation, nicht über Blätter gießen, Milch-Wasser-Spray gegen Mehltau.",
+      "harvestTips": "Jung ernten bei 15-20cm Länge für besten Geschmack. Regelmäßig kontrollieren — Zucchini wachsen extrem schnell. Überreife Früchte werden holzig."
+    }
   },
   {
     "id": "sunflower",
     "name": "Sonnenblume",
     "category": "Blumen",
-    "icon": "\ud83c\udf3b",
+    "icon": "🌻",
     "difficulty": "easy",
     "sun": "full",
     "water": "low",
@@ -125,13 +184,20 @@
     "harvest": "80-100 Tage",
     "companions": ["Gurke", "Mais"],
     "avoid": ["Kartoffel"],
-    "tips": "St\u00fctze bei gro\u00dfen Sorten. Lockt Bienen und N\u00fctzlinge an. Kerne im Herbst ernten."
+    "tips": "Stütze bei großen Sorten. Lockt Bienen und Nützlinge an. Kerne im Herbst ernten.",
+    "careGuide": {
+      "watering": "Junge Pflanzen regelmäßig gießen. Etablierte Pflanzen sind recht trockenheitstolerant. Bei großer Hitze 1-2x pro Woche.",
+      "fertilizing": "Wenig Dünger nötig. Etwas Kompost bei der Pflanzung genügt. Zu viel Stickstoff macht die Stängel weich.",
+      "location": "Vollsonnig — namensgebend! Windgeschützt oder mit Stützstab bei hohen Sorten. Süd- oder Westseite ideal.",
+      "soil": "Anspruchslos, tiefgründig, durchlässig. Verträgt die meisten Böden. pH 6.0-7.5.",
+      "pests": "Blattläuse, Schnecken (bei Jungpflanzen), Vögel (bei reifenden Kernen). Vorbeugend: Vlies über Keimlinge, Netz über reife Köpfe."
+    }
   },
   {
     "id": "pepper",
     "name": "Paprika",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83c\udf36\ufe0f",
+    "category": "Gemüse",
+    "icon": "🌶️",
     "difficulty": "medium",
     "sun": "full",
     "water": "medium",
@@ -141,13 +207,22 @@
     "harvest": "70-90 Tage",
     "companions": ["Basilikum", "Tomate", "Karotte"],
     "avoid": ["Fenchel"],
-    "tips": "Erste Bl\u00fcte (K\u00f6nigsbl\u00fcte) ausbrechen f\u00fcr mehr Ertrag. Warm halten, min. 15\u00b0C."
+    "tips": "Erste Blüte (Königsblüte) ausbrechen für mehr Ertrag. Warm halten, min. 15°C.",
+    "careGuide": {
+      "watering": "Regelmäßig und gleichmäßig gießen. Keine Staunässe, aber auch nicht austrocknen lassen. Lauwarmes Wasser bevorzugt.",
+      "fertilizing": "Mittelzehrer — alle 2-3 Wochen mit Gemüsedünger. Ab Fruchtbildung kaliumbetonten Dünger verwenden.",
+      "pruning": "Königsblüte (erste Blüte in der Verzweigung) ausbrechen für mehr Ertrag. Seitentriebe bis zur ersten Verzweigung entfernen.",
+      "location": "Vollsonnig, sehr warm, windgeschützt. Mindesttemperatur 15°C. Ideal im Gewächshaus oder an Südwand.",
+      "soil": "Nährstoffreich, humusreich, warm, durchlässig. pH 6.0-6.8. Mulchen hält den Boden warm.",
+      "pests": "Blattläuse, Spinnmilben, Schnecken. Vorbeugend: regelmäßig kontrollieren, Nützlinge fördern.",
+      "harvestTips": "Grün ernten oder ausreifen lassen für mehr Süße und Vitamine. Mit Stiel abschneiden, nicht abreißen."
+    }
   },
   {
     "id": "radish",
     "name": "Radieschen",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83d\udd34",
+    "category": "Gemüse",
+    "icon": "🔴",
     "difficulty": "easy",
     "sun": "partial",
     "water": "medium",
@@ -157,61 +232,91 @@
     "harvest": "25-35 Tage",
     "companions": ["Karotte", "Salat", "Spinat"],
     "avoid": [],
-    "tips": "Schnellstes Gem\u00fcse im Garten. Ideal als L\u00fcckenf\u00fcller. Bei Hitze werden sie scharf und holzig."
+    "tips": "Schnellstes Gemüse im Garten. Ideal als Lückenfüller. Bei Hitze werden sie scharf und holzig.",
+    "careGuide": {
+      "watering": "Gleichmäßig feucht halten — Schwankungen führen zu Rissen und Pelzigkeit. Täglich leicht gießen bei Trockenheit.",
+      "fertilizing": "Schwachzehrer — keine zusätzliche Düngung nötig. Normaler Gartenboden reicht aus.",
+      "location": "Halbschattig bis sonnig. Im Sommer eher halbschattig, sonst werden sie scharf und schießen.",
+      "soil": "Locker, humusreich, steinfrei. pH 6.0-7.0. Schwere Böden mit Sand verbessern.",
+      "harvestTips": "Rechtzeitig ernten — überreife Radieschen werden holzig und pelzig. Bei 2-3cm Durchmesser ernten. Nicht zu dicht stehen lassen."
+    }
   },
   {
     "id": "lavender",
     "name": "Lavendel",
-    "category": "Kr\u00e4uter",
-    "icon": "\ud83d\udc9c",
+    "category": "Kräuter",
+    "icon": "💜",
     "difficulty": "easy",
     "sun": "full",
     "water": "low",
     "season": ["spring"],
     "spacing": "40cm",
     "germination": "14-28 Tage",
-    "harvest": "mehrj\u00e4hrig",
+    "harvest": "mehrjährig",
     "companions": ["Rose", "Thymian"],
     "avoid": [],
-    "tips": "Liebt trockene, kalkhaltige B\u00f6den. Nach Bl\u00fcte zur\u00fcckschneiden. Vertreibt Blattl\u00e4use."
+    "tips": "Liebt trockene, kalkhaltige Böden. Nach Blüte zurückschneiden. Vertreibt Blattläuse.",
+    "careGuide": {
+      "watering": "Sehr sparsam gießen — Lavendel verträgt Trockenheit besser als Nässe. Etablierte Pflanzen nur bei extremer Hitze gießen.",
+      "fertilizing": "Kaum Dünger nötig. Etwas Kalk im Frühjahr genügt. Zu viel Dünger mindert Duft und Winterhärte.",
+      "pruning": "Nach der Blüte um ein Drittel zurückschneiden. Im Frühjahr leichter Formschnitt. Nie ins alte Holz schneiden!",
+      "location": "Vollsonnig, heiß, trocken. Ideal an Südmauern, Steingärten oder erhöhten Beeten. Gute Luftzirkulation wichtig.",
+      "soil": "Kalkhaltig, mager, sehr durchlässig. pH 7.0-8.0. Schwere Böden mit Kies und Sand verbessern."
+    }
   },
   {
     "id": "rose",
     "name": "Rose",
     "category": "Blumen",
-    "icon": "\ud83c\udf39",
+    "icon": "🌹",
     "difficulty": "medium",
     "sun": "full",
     "water": "medium",
     "season": ["spring", "autumn"],
     "spacing": "50cm",
     "germination": "-",
-    "harvest": "mehrj\u00e4hrig",
+    "harvest": "mehrjährig",
     "companions": ["Lavendel", "Knoblauch"],
     "avoid": [],
-    "tips": "Im Fr\u00fchjahr schneiden. Auf Sternru\u00dftau und Blattl\u00e4use achten. Gut mulchen."
+    "tips": "Im Frühjahr schneiden. Auf Sternrußtau und Blattläuse achten. Gut mulchen.",
+    "careGuide": {
+      "watering": "Regelmäßig gießen, besonders im ersten Jahr. Morgens am Wurzelbereich, nie über Blätter. 2-3x pro Woche gründlich.",
+      "fertilizing": "Im Frühjahr mit Rosendünger versorgen. Zweite Gabe nach der ersten Blüte im Juni. Ab August nicht mehr düngen.",
+      "pruning": "Hauptschnitt im Frühjahr (März/April). Verblühtes regelmäßig ausschneiden. Im Herbst nur leicht einkürzen.",
+      "location": "Sonnig, luftig, nicht zu windexponiert. Mindestens 5h direkte Sonne. Nicht unter Bäume pflanzen.",
+      "soil": "Lehmig-humusreich, tiefgründig, nährstoffreich. pH 6.0-7.0. Gute Drainage wichtig.",
+      "pests": "Sternrußtau, Mehltau, Blattläuse, Rosenrost. Vorbeugend: resistente Sorten, gute Luftzirkulation, Knoblauch als Nachbar."
+    }
   },
   {
     "id": "mint",
     "name": "Minze",
-    "category": "Kr\u00e4uter",
-    "icon": "\ud83c\udf3f",
+    "category": "Kräuter",
+    "icon": "🌿",
     "difficulty": "easy",
     "sun": "partial",
     "water": "high",
     "season": ["spring"],
     "spacing": "30cm",
     "germination": "10-15 Tage",
-    "harvest": "mehrj\u00e4hrig",
+    "harvest": "mehrjährig",
     "companions": ["Tomate", "Kohl"],
     "avoid": [],
-    "tips": "Wuchert stark \u2014 am besten im Topf halten! Regelm\u00e4\u00dfig ernten. Vermehrung \u00fcber Ausl\u00e4ufer."
+    "tips": "Wuchert stark — am besten im Topf halten! Regelmäßig ernten. Vermehrung über Ausläufer.",
+    "careGuide": {
+      "watering": "Feucht halten, verträgt keine Trockenheit. Im Sommer täglich gießen. Mulchschicht hilft gegen Austrocknung.",
+      "fertilizing": "Wenig Dünger nötig. Etwas Kompost im Frühjahr genügt. Zu viel Dünger mindert das Aroma.",
+      "pruning": "Regelmäßig zurückschneiden fördert frischen Austrieb. Blüten abschneiden für besseren Blattgeschmack. Im Herbst bodennah abschneiden.",
+      "location": "Halbschattig bis schattig. Verträgt auch Sonne bei ausreichend Feuchtigkeit. Am besten im Topf wegen Ausbreitungsdrang.",
+      "soil": "Humusreich, feucht, nährstoffreich. pH 6.0-7.0. Verträgt auch schwerere Böden.",
+      "harvestTips": "Vor der Blüte ernten für bestes Aroma. Ganze Triebe schneiden, nicht einzelne Blätter. Morgens ernten."
+    }
   },
   {
     "id": "pumpkin",
-    "name": "K\u00fcrbis",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83c\udf83",
+    "name": "Kürbis",
+    "category": "Gemüse",
+    "icon": "🎃",
     "difficulty": "easy",
     "sun": "full",
     "water": "high",
@@ -221,13 +326,22 @@
     "harvest": "90-120 Tage",
     "companions": ["Mais", "Bohne"],
     "avoid": ["Kartoffel"],
-    "tips": "Braucht sehr viel Platz. Auf Stroh lagern gegen F\u00e4ulnis. Ernte wenn Stiel verholzt."
+    "tips": "Braucht sehr viel Platz. Auf Stroh lagern gegen Fäulnis. Ernte wenn Stiel verholzt.",
+    "careGuide": {
+      "watering": "Reichlich gießen, besonders bei Fruchtbildung. 3-5x pro Woche gründlich wässern. Morgens gießen, Blätter trocken halten.",
+      "fertilizing": "Starkzehrer — großzügig mit Kompost und organischem Dünger versorgen. Alle 2 Wochen mit Brennnesseljauche nachdüngen.",
+      "pruning": "Nach dem 5. Blatt Haupttrieb entspitzen für Seitentriebe. Pro Pflanze nur 2-3 Früchte belassen für gute Größe.",
+      "location": "Vollsonnig, warm, windgeschützt. Braucht sehr viel Platz — 2-3m² pro Pflanze. Ideal am Komposthaufen.",
+      "soil": "Sehr nährstoffreich, humusreich, tiefgründig, feucht. pH 6.0-7.0. Kompost direkt ins Pflanzloch geben.",
+      "pests": "Mehltau, Schnecken (Jungpflanzen). Vorbeugend: Mulch, Schneckenschutz, gute Luftzirkulation.",
+      "harvestTips": "Reif wenn Stiel verholzt und die Schale sich nicht mehr einritzen lässt. Vor dem ersten Frost ernten. Stiel 5-10cm stehen lassen."
+    }
   },
   {
     "id": "garlic",
     "name": "Knoblauch",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83e\uddc4",
+    "category": "Gemüse",
+    "icon": "🧄",
     "difficulty": "easy",
     "sun": "full",
     "water": "low",
@@ -237,13 +351,21 @@
     "harvest": "90-150 Tage",
     "companions": ["Erdbeere", "Rose", "Tomate"],
     "avoid": ["Bohne", "Erbse"],
-    "tips": "Im Herbst stecken f\u00fcr gr\u00f6\u00dfere Knollen. Ernte wenn untere Bl\u00e4tter gelb werden. Gut trocknen lassen."
+    "tips": "Im Herbst stecken für größere Knollen. Ernte wenn untere Blätter gelb werden. Gut trocknen lassen.",
+    "careGuide": {
+      "watering": "Sparsam gießen — Knoblauch mag es eher trocken. Ab Juni Bewässerung reduzieren für gute Ausreifung.",
+      "fertilizing": "Schwachzehrer — Kompost bei der Pflanzung genügt. Im Frühjahr etwas Kaliumdünger für Knollenbildung.",
+      "location": "Vollsonnig, offen. Gute Luftzirkulation verhindert Pilzkrankheiten. Herbstpflanzung ergibt größere Knollen.",
+      "soil": "Locker, durchlässig, humusreich. pH 6.0-7.0. Staunässe führt zu Fäulnis.",
+      "pests": "Lauchmotte, Knoblauchfliege. Vorbeugend: Kulturschutznetz, Fruchtfolge beachten, nicht neben anderen Lauchgewächsen.",
+      "harvestTips": "Ernten wenn untere Blätter vergilben und umknicken. 2-3 Wochen an luftigem Ort trocknen. Zöpfe flechten zur Lagerung."
+    }
   },
   {
     "id": "bean",
     "name": "Bohne",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83e\uded8",
+    "category": "Gemüse",
+    "icon": "🫘",
     "difficulty": "easy",
     "sun": "full",
     "water": "medium",
@@ -251,15 +373,23 @@
     "spacing": "10cm",
     "germination": "7-14 Tage",
     "harvest": "50-70 Tage",
-    "companions": ["Mais", "K\u00fcrbis", "Kartoffel"],
+    "companions": ["Mais", "Kürbis", "Kartoffel"],
     "avoid": ["Knoblauch", "Zwiebel"],
-    "tips": "Stangenbohnen brauchen Rankhilfe. Nie roh essen! Regelm\u00e4\u00dfig ernten f\u00f6rdert Nachbl\u00fcte."
+    "tips": "Stangenbohnen brauchen Rankhilfe. Nie roh essen! Regelmäßig ernten fördert Nachblüte.",
+    "careGuide": {
+      "watering": "Regelmäßig gießen, besonders während Blüte und Hülsenbildung. Nicht über die Blätter gießen. 2-3x pro Woche.",
+      "fertilizing": "Schwachzehrer — Bohnen binden Stickstoff aus der Luft! Keine Stickstoffdüngung nötig. Etwas Kalium fördert den Ertrag.",
+      "location": "Sonnig, warm, windgeschützt. Stangenbohnen brauchen stabile Rankhilfen (2-3m hoch). Buschbohnen auch in Kübeln.",
+      "soil": "Locker, humusreich, nicht zu schwer. pH 6.0-7.0. Leicht erwärmbar für schnelle Keimung.",
+      "pests": "Bohnenfliege, Blattläuse, Bohnenrost. Vorbeugend: Saatgut nicht zu früh legen, Mischkultur, Fruchtfolge.",
+      "harvestTips": "Regelmäßig pflücken fördert Nachblüte. Hülsen knackig-jung ernten. Nie roh essen — Bohnen enthalten Phasin!"
+    }
   },
   {
     "id": "cucumber",
     "name": "Gurke",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83e\udd52",
+    "category": "Gemüse",
+    "icon": "🥒",
     "difficulty": "medium",
     "sun": "full",
     "water": "high",
@@ -269,29 +399,46 @@
     "harvest": "50-70 Tage",
     "companions": ["Bohne", "Erbse", "Sonnenblume"],
     "avoid": ["Tomate", "Kartoffel"],
-    "tips": "W\u00e4rmeliebend, min. 15\u00b0C. Rankhilfe nutzen f\u00fcr Platzersparnis. Regelm\u00e4\u00dfig ernten."
+    "tips": "Wärmeliebend, min. 15°C. Rankhilfe nutzen für Platzersparnis. Regelmäßig ernten.",
+    "careGuide": {
+      "watering": "Reichlich gießen mit lauwarmem Wasser. Kaltes Wasser verursacht Bitterkeit. Täglich bei Hitze, Blätter trocken halten.",
+      "fertilizing": "Starkzehrer — alle 2 Wochen mit organischem Flüssigdünger. Kompost großzügig einarbeiten. Brennnesseljauche ideal.",
+      "pruning": "Seitentriebe nach dem 2. Blatt entspitzen. Rankgitter nutzen für bessere Luftzirkulation und gerade Früchte.",
+      "location": "Vollsonnig, sehr warm, windgeschützt. Mindesttemperatur 15°C, ideal 20-25°C. Gewächshaus oder geschütztes Freiland.",
+      "soil": "Sehr nährstoffreich, humusreich, warm, feucht aber durchlässig. pH 6.0-7.0.",
+      "pests": "Mehltau, Spinnmilben, Gurkenmosaikvirus. Vorbeugend: resistente Sorten, gute Belüftung, nicht über Blätter gießen.",
+      "harvestTips": "Regelmäßig ernten fördert Neubildung. Salatgurken bei 20-25cm, Einlegegurken bei 5-8cm ernten. Nicht zu groß werden lassen."
+    }
   },
   {
     "id": "thyme",
     "name": "Thymian",
-    "category": "Kr\u00e4uter",
-    "icon": "\ud83c\udf31",
+    "category": "Kräuter",
+    "icon": "🌱",
     "difficulty": "easy",
     "sun": "full",
     "water": "low",
     "season": ["spring"],
     "spacing": "20cm",
     "germination": "14-21 Tage",
-    "harvest": "mehrj\u00e4hrig",
+    "harvest": "mehrjährig",
     "companions": ["Lavendel", "Rose", "Kohl"],
     "avoid": [],
-    "tips": "Liebt magere, durchl\u00e4ssige B\u00f6den. Winterhart. Vor der Bl\u00fcte ernten f\u00fcr bestes Aroma."
+    "tips": "Liebt magere, durchlässige Böden. Winterhart. Vor der Blüte ernten für bestes Aroma.",
+    "careGuide": {
+      "watering": "Sehr sparsam gießen — Thymian ist trockenheitsliebend. Nur bei lang anhaltender Trockenheit etwas wässern.",
+      "fertilizing": "Kein Dünger nötig. Zu nährstoffreicher Boden mindert das Aroma. Etwas Kalk im Frühjahr ist hilfreich.",
+      "pruning": "Im Frühjahr leicht zurückschneiden für buschigen Wuchs. Nach der Blüte nochmals schneiden. Nie ins alte Holz.",
+      "location": "Vollsonnig, heiß, trocken. Ideal in Steingärten, Kräuterspiralen oder am Beetrand. Guter Bodendecker.",
+      "soil": "Mager, kalkhaltig, sehr durchlässig. pH 7.0-8.0. Sand oder Kies untermischen bei schweren Böden.",
+      "harvestTips": "Kurz vor der Blüte ernten für bestes Aroma. Ganze Triebe schneiden. Trocknet sehr gut — Aroma bleibt erhalten."
+    }
   },
   {
     "id": "onion",
     "name": "Zwiebel",
-    "category": "Gem\u00fcse",
-    "icon": "\ud83e\uddc5",
+    "category": "Gemüse",
+    "icon": "🧅",
     "difficulty": "easy",
     "sun": "full",
     "water": "low",
@@ -301,22 +448,39 @@
     "harvest": "90-120 Tage",
     "companions": ["Karotte", "Erdbeere", "Salat"],
     "avoid": ["Bohne", "Erbse"],
-    "tips": "Steckzwiebeln sind einfacher als Aussaat. Ernte wenn Laub umknickt. Gut trocknen lassen."
+    "tips": "Steckzwiebeln sind einfacher als Aussaat. Ernte wenn Laub umknickt. Gut trocknen lassen.",
+    "careGuide": {
+      "watering": "Sparsam gießen — Zwiebeln mögen es eher trocken. Ab Juli Bewässerung komplett einstellen für gute Ausreifung.",
+      "fertilizing": "Schwachzehrer — Kompost bei der Beetvorbereitung genügt. Kein frischer Mist, fördert Zwiebelfliege.",
+      "location": "Vollsonnig, offen, luftig. Gute Luftzirkulation verhindert Pilzkrankheiten.",
+      "soil": "Locker, sandig-lehmig, humusreich. pH 6.0-7.0. Gute Drainage wichtig, keine Staunässe.",
+      "pests": "Zwiebelfliege, Falscher Mehltau. Vorbeugend: Kulturschutznetz, Mischkultur mit Karotten, Fruchtfolge.",
+      "harvestTips": "Ernten wenn 2/3 des Laubes umgeknickt sind. Bei trockenem Wetter ernten. 2-3 Wochen trocknen lassen vor der Einlagerung."
+    }
   },
   {
     "id": "apple",
     "name": "Apfelbaum",
     "category": "Obst",
-    "icon": "\ud83c\udf4e",
+    "icon": "🍎",
     "difficulty": "medium",
     "sun": "full",
     "water": "medium",
     "season": ["autumn", "spring"],
     "spacing": "300cm",
     "germination": "-",
-    "harvest": "mehrj\u00e4hrig (ab Jahr 3)",
+    "harvest": "mehrjährig (ab Jahr 3)",
     "companions": ["Kapuzinerkresse", "Knoblauch"],
     "avoid": [],
-    "tips": "Winterschnitt im Februar. Auf Befruchtersorte achten. Fallobst entfernen gegen Sch\u00e4dlinge."
+    "tips": "Winterschnitt im Februar. Auf Befruchtersorte achten. Fallobst entfernen gegen Schädlinge.",
+    "careGuide": {
+      "watering": "Jungbäume regelmäßig gießen (1-2x pro Woche). Etablierte Bäume nur bei lang anhaltender Trockenheit wässern.",
+      "fertilizing": "Im Frühjahr mit Obstbaumdünger oder Kompost versorgen. Mulchschicht im Wurzelbereich hält Feuchtigkeit und liefert Nährstoffe.",
+      "pruning": "Winterschnitt im Februar bei frostfreiem Wetter. Lichtungschnitt für gute Fruchtqualität. Wasserschosse im Sommer entfernen.",
+      "location": "Sonnig, freistehend, luftig. Auf Befruchtersorte in der Nähe achten. Windgeschützt für besseren Fruchtansatz.",
+      "soil": "Tiefgründig, nährstoffreich, lehmig-humusreich. pH 6.0-7.0. Gute Drainage im Wurzelbereich.",
+      "pests": "Apfelschorf, Mehltau, Apfelwickler, Blattläuse. Vorbeugend: Schnitt für Luftzirkulation, Fallobst aufsammeln, Leimringe anbringen.",
+      "harvestTips": "Reif wenn sich der Apfel leicht vom Baum löst. Regelmäßig durchpflücken. Lageräpfel kühl und dunkel aufbewahren."
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- Care guides added to all 20 plants in `default-plants.json`
- Fields: watering, fertilizing, pruning, location, soil, pests, harvest tips
- New care guide section in plant detail modal with icon grid
- 2-column responsive grid, dark mode support

Closes #51

## Test plan
- [ ] Open any plant — care guide section visible with icons
- [ ] All 20 plants have care data
- [ ] Mobile: grid collapses to 1 column
- [ ] Dark mode looks correct