### PR TITLE
feat: interactive garden layout planner (#48)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/public/admin.html
+++ b/public/admin.html
@@ -43,6 +43,7 @@
           <a href="/dashboard" class="nav-link">Dashboard</a>
           <a href="/statistics" class="nav-link">Statistiken</a>
           <a href="/plants" class="nav-link">Pflanzen</a>
+          <a href="/garden" class="nav-link">Garten</a>
           <a href="/logs" class="nav-link">Logs</a>
           <a href="/admin" class="nav-link active" aria-current="page">Admin</a>
         </nav>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -59,6 +59,7 @@
           <a href="/dashboard" class="nav-link active" aria-current="page">📋 Dashboard</a>
           <a href="/statistics" class="nav-link">📊 Statistiken</a>
           <a href="/plants" class="nav-link">🌱 Pflanzen</a>
+          <a href="/garden" class="nav-link">🌻 Garten</a>
           <a href="/logs" class="nav-link">📜 Logs</a>
         </nav>
         <a href="/index" class="btn btn-primary nav-action-btn"

--- a/public/garden.html
+++ b/public/garden.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gartenplaner - Garten gestalten</title>
+    <meta
+      name="description"
+      content="Interaktiver Gartenplaner zum Gestalten von Gartenanlagen"
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌱</text></svg>"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../src/css/styles.css" />
+    <link rel="stylesheet" href="../src/css/garden.css" />
+  </head>
+  <body>
+    <script>
+        fetch('/api/v1/auth/status', { credentials: 'same-origin' })
+            .then(r => r.json())
+            .then(data => {
+                if (data.authRequired && !data.user) window.location.href = '/login';
+                if (data.user) {
+                    window.__user = data.user;
+                    const nav = document.querySelector('nav ul') || document.querySelector('.main-nav');
+                    if (nav && data.user.role === 'admin') {
+                        const adminLink = document.createElement('a');
+                        adminLink.href = '/admin';
+                        adminLink.className = 'nav-link';
+                        adminLink.textContent = 'Admin';
+                        nav.appendChild(adminLink);
+                    }
+                    if (nav) {
+                        const logoutLink = document.createElement('a');
+                        logoutLink.href = '#';
+                        logoutLink.className = 'nav-link';
+                        logoutLink.textContent = 'Logout';
+                        logoutLink.addEventListener('click', function(e) {
+                            e.preventDefault();
+                            if (window.TaskAPI) TaskAPI.logout();
+                            else fetch('/api/v1/auth/logout', { method: 'POST', credentials: 'same-origin' }).then(function() { window.location.href = '/login'; });
+                        });
+                        nav.appendChild(logoutLink);
+                    }
+                }
+            });
+    </script>
+    <div class="garden-container">
+      <header role="banner">
+        <h1>🌻 Gartenplaner</h1>
+        <p class="subtitle">Gestalte deinen Garten interaktiv</p>
+      </header>
+
+      <div class="nav-container">
+        <nav class="main-nav" role="navigation" aria-label="Hauptnavigation">
+          <a href="/dashboard" class="nav-link">📋 Dashboard</a>
+          <a href="/statistics" class="nav-link">📊 Statistiken</a>
+          <a href="/plants" class="nav-link">🌱 Pflanzen</a>
+          <a href="/garden" class="nav-link active" aria-current="page">🌻 Garten</a>
+          <a href="/logs" class="nav-link">📜 Logs</a>
+        </nav>
+        <a href="/index" class="btn btn-primary nav-action-btn">➕ Neue Aufgabe</a>
+      </div>
+
+      <!-- Toolbar -->
+      <div class="garden-toolbar">
+        <div class="toolbar-group">
+          <label for="gridSizeSelect">Raster:</label>
+          <select id="gridSizeSelect"></select>
+        </div>
+
+        <div class="toolbar-separator"></div>
+
+        <div class="toolbar-group">
+          <button type="button" class="toolbar-btn toolbar-btn--primary" id="gardenSaveBtn">💾 Speichern</button>
+          <button type="button" class="toolbar-btn" id="gardenLoadBtn">📂 Laden</button>
+          <button type="button" class="toolbar-btn toolbar-btn--danger" id="gardenClearBtn">🗑️ Leeren</button>
+        </div>
+
+        <div class="toolbar-separator"></div>
+
+        <div class="toolbar-group zoom-controls">
+          <button type="button" class="zoom-btn" id="zoomOut" title="Verkleinern">−</button>
+          <span class="zoom-level" id="zoomLevel">100%</span>
+          <button type="button" class="zoom-btn" id="zoomIn" title="Vergrößern">+</button>
+        </div>
+      </div>
+
+      <!-- Main content: sidebar + grid -->
+      <div class="garden-main">
+        <!-- Palette sidebar -->
+        <aside class="garden-palette" id="gardenPalette" aria-label="Elemente-Palette">
+          <!-- Filled dynamically by JS -->
+        </aside>
+
+        <!-- Grid area -->
+        <div class="garden-grid-area">
+          <div class="garden-grid-wrapper" id="gardenGridWrapper">
+            <div class="garden-grid" id="gardenGrid">
+              <!-- Cells rendered by JS -->
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Info bar -->
+      <div class="garden-info">
+        <span class="garden-info-text" id="gardenInfoText">
+          <strong>Wähle ein Element aus der Seitenleiste und klicke auf das Raster zum Platzieren.</strong>
+        </span>
+      </div>
+    </div>
+
+    <!-- Save Dialog -->
+    <div class="garden-save-dialog" id="gardenSaveDialog" hidden>
+      <div class="garden-save-content">
+        <h3>Garten speichern</h3>
+        <input type="text" id="gardenNameInput" placeholder="Name des Gartens" maxlength="100" />
+        <div class="garden-save-actions">
+          <button type="button" class="toolbar-btn" id="gardenSaveCancel">Abbrechen</button>
+          <button type="button" class="toolbar-btn toolbar-btn--primary" id="gardenSaveConfirm">Speichern</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Load Dialog -->
+    <div class="garden-save-dialog" id="gardenLoadDialog" hidden>
+      <div class="garden-save-content">
+        <h3>Garten laden</h3>
+        <div class="garden-load-list" id="gardenLoadList">
+          <!-- Filled dynamically -->
+        </div>
+        <div class="garden-save-actions">
+          <button type="button" class="toolbar-btn" id="gardenLoadClose">Schließen</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Dark Mode Toggle -->
+    <div class="theme-toggle">
+      <button
+        id="themeToggle"
+        class="theme-toggle-btn"
+        aria-label="Theme umschalten"
+        title="Dark Mode umschalten"
+      >
+        <svg
+          id="themeIcon"
+          class="theme-icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+    </div>
+
+    <script src="../src/js/garden-planner.js"></script>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -59,6 +59,7 @@
         <a href="/dashboard" class="nav-link">📋 Dashboard</a>
         <a href="/statistics" class="nav-link">📊 Statistiken</a>
         <a href="/plants" class="nav-link">🌱 Pflanzen</a>
+        <a href="/garden" class="nav-link">🌻 Garten</a>
         <a href="/logs" class="nav-link">📜 Logs</a>
       </nav>
 

--- a/public/logs.html
+++ b/public/logs.html
@@ -49,6 +49,7 @@
             <a href="/dashboard" class="nav-link">📋 Dashboard</a>
             <a href="/statistics" class="nav-link">📊 Statistiken</a>
             <a href="/plants" class="nav-link">🌱 Pflanzen</a>
+            <a href="/garden" class="nav-link">🌻 Garten</a>
             <a href="/logs" class="nav-link active" aria-current="page"
               >📜 Logs</a
             >

--- a/public/plants.html
+++ b/public/plants.html
@@ -53,6 +53,7 @@
             <a href="/dashboard" class="nav-link">📋 Dashboard</a>
             <a href="/statistics" class="nav-link">📊 Statistiken</a>
             <a href="/plants" class="nav-link active">🌱 Pflanzen</a>
+            <a href="/garden" class="nav-link">🌻 Garten</a>
             <a href="/logs" class="nav-link">📊 Logs</a>
         </nav>
 

--- a/public/statistics.html
+++ b/public/statistics.html
@@ -55,6 +55,7 @@
           <a href="/dashboard" class="nav-link">📋 Dashboard</a>
           <a href="/statistics" class="nav-link active" aria-current="page">📊 Statistiken</a>
           <a href="/plants" class="nav-link">🌱 Pflanzen</a>
+          <a href="/garden" class="nav-link">🌻 Garten</a>
           <a href="/logs" class="nav-link">📜 Logs</a>
         </nav>
         <a href="/index" class="btn btn-primary nav-action-btn"

--- a/src/css/garden.css
+++ b/src/css/garden.css
@@ -1,0 +1,528 @@
+/* Garden Planner Styles */
+
+/* Main Layout */
+.garden-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.garden-container header {
+  padding: 1.5rem 2rem 0;
+}
+
+.garden-container .nav-container {
+  padding: 0 2rem;
+}
+
+/* Toolbar */
+.garden-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: var(--bg-secondary);
+  border-bottom: 1.5px solid var(--border);
+}
+
+.garden-toolbar label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-light);
+  margin-right: 0.25rem;
+}
+
+.garden-toolbar select {
+  padding: 8px 12px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.garden-toolbar select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.toolbar-separator {
+  width: 1px;
+  height: 28px;
+  background: var(--border);
+  margin: 0 0.25rem;
+}
+
+.toolbar-btn {
+  padding: 8px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--text-sm);
+  font-family: var(--font-body);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.toolbar-btn:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--primary);
+}
+
+.toolbar-btn--primary {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.toolbar-btn--primary:hover {
+  background: var(--primary-dark);
+  border-color: var(--primary-dark);
+}
+
+.toolbar-btn--danger {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+
+.toolbar-btn--danger:hover {
+  background: var(--error-light);
+}
+
+/* Main content area */
+.garden-main {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* Sidebar palette */
+.garden-palette {
+  width: 260px;
+  min-width: 260px;
+  background: var(--bg-secondary);
+  border-right: 1.5px solid var(--border);
+  overflow-y: auto;
+  padding: 1rem 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.palette-section {
+  padding: 0 1rem;
+  margin-bottom: 1rem;
+}
+
+.palette-section-title {
+  font-family: var(--font-heading);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.palette-items {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.palette-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1.5px solid transparent;
+  font-size: var(--text-sm);
+  user-select: none;
+}
+
+.palette-item:hover {
+  background: var(--bg-tertiary);
+}
+
+.palette-item--selected {
+  background: var(--bg-tertiary);
+  border-color: var(--primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.palette-item-icon {
+  font-size: 1.2rem;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.palette-item-name {
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Plants loading indicator */
+.palette-loading {
+  padding: 8px 10px;
+  color: var(--text-light);
+  font-size: var(--text-sm);
+  font-style: italic;
+}
+
+/* Grid area */
+.garden-grid-area {
+  flex: 1;
+  overflow: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--bg);
+}
+
+.garden-grid-wrapper {
+  transform-origin: top center;
+  transition: transform 0.2s ease;
+}
+
+.garden-grid {
+  display: grid;
+  gap: 1px;
+  background: var(--border);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+}
+
+.garden-cell {
+  width: 48px;
+  height: 48px;
+  background: var(--bg-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.1s, box-shadow 0.1s;
+  position: relative;
+  user-select: none;
+}
+
+.garden-cell:hover {
+  background: var(--bg-tertiary);
+  box-shadow: inset 0 0 0 2px var(--primary-light);
+}
+
+.garden-cell--occupied {
+  cursor: pointer;
+}
+
+.garden-cell--occupied .cell-icon {
+  font-size: 1.3rem;
+  line-height: 1;
+  z-index: 1;
+}
+
+.garden-cell--selected {
+  box-shadow: inset 0 0 0 2px var(--primary) !important;
+}
+
+/* Cell tooltip */
+.garden-cell[title] {
+  position: relative;
+}
+
+/* Info panel */
+.garden-info {
+  padding: 1rem 2rem;
+  background: var(--bg-secondary);
+  border-top: 1.5px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  min-height: 50px;
+  font-size: var(--text-sm);
+}
+
+.garden-info-text {
+  color: var(--text-light);
+}
+
+.garden-info-text strong {
+  color: var(--text);
+}
+
+/* Zoom controls */
+.zoom-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: auto;
+}
+
+.zoom-btn {
+  width: 32px;
+  height: 32px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--text-lg);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+
+.zoom-btn:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--primary);
+}
+
+.zoom-level {
+  font-size: var(--text-sm);
+  color: var(--text-light);
+  min-width: 40px;
+  text-align: center;
+}
+
+/* Garden name input in save dialog */
+.garden-save-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.garden-save-dialog[hidden] {
+  display: none;
+}
+
+.garden-save-content {
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  width: 100%;
+  max-width: 400px;
+  box-shadow: var(--shadow-xl);
+}
+
+.garden-save-content h3 {
+  font-family: var(--font-heading);
+  margin-bottom: 1rem;
+}
+
+.garden-save-content input {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--text);
+  margin-bottom: 0.75rem;
+}
+
+.garden-save-content input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.garden-save-content select {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--text);
+  margin-bottom: 1rem;
+}
+
+.garden-save-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+/* Saved gardens list */
+.garden-load-list {
+  max-height: 300px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+}
+
+.garden-load-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border: 1.5px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.garden-load-item:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--primary);
+}
+
+.garden-load-item-name {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.garden-load-item-meta {
+  font-size: var(--text-xs);
+  color: var(--text-light);
+}
+
+.garden-load-item-delete {
+  background: none;
+  border: none;
+  color: var(--danger);
+  cursor: pointer;
+  padding: 4px;
+  font-size: var(--text-lg);
+  line-height: 1;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+
+.garden-load-item-delete:hover {
+  opacity: 1;
+}
+
+.garden-load-empty {
+  color: var(--text-light);
+  font-style: italic;
+  text-align: center;
+  padding: 2rem;
+}
+
+/* Dark mode adjustments */
+[data-theme="dark"] .garden-grid {
+  border-color: var(--border);
+}
+
+[data-theme="dark"] .garden-cell:hover {
+  background: var(--bg-tertiary);
+}
+
+[data-theme="dark"] .garden-save-dialog {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .garden-main {
+    flex-direction: column;
+  }
+
+  .garden-palette {
+    width: 100%;
+    min-width: 0;
+    max-height: 180px;
+    border-right: none;
+    border-bottom: 1.5px solid var(--border);
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 0.75rem;
+    gap: 0.75rem;
+  }
+
+  .palette-section {
+    min-width: 200px;
+    margin-bottom: 0;
+    padding: 0;
+  }
+
+  .palette-items {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .garden-toolbar {
+    padding: 0.75rem 1rem;
+    gap: 0.5rem;
+  }
+
+  .toolbar-separator {
+    display: none;
+  }
+
+  .garden-grid-area {
+    padding: 1rem;
+  }
+
+  .garden-cell {
+    width: 36px;
+    height: 36px;
+  }
+
+  .garden-cell--occupied .cell-icon {
+    font-size: 1rem;
+  }
+
+  .garden-info {
+    padding: 0.75rem 1rem;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 480px) {
+  .garden-toolbar {
+    padding: 0.5rem;
+  }
+
+  .garden-cell {
+    width: 30px;
+    height: 30px;
+  }
+
+  .garden-cell--occupied .cell-icon {
+    font-size: 0.9rem;
+  }
+}

--- a/src/js/garden-planner.js
+++ b/src/js/garden-planner.js
@@ -1,0 +1,716 @@
+/**
+ * Garden Planner - Interactive grid-based garden layout editor
+ * MVP: localStorage-based save/load, vanilla JS
+ */
+
+(function () {
+  'use strict';
+
+  // =====================================================
+  // Element Definitions
+  // =====================================================
+  const GARDEN_ELEMENTS = {
+    beds: [
+      { id: 'raised-bed', name: 'Hochbeet', icon: '\u{1F331}', color: '#8B7355' },
+      { id: 'ground-bed', name: 'Bodenbeet', icon: '\u{1F33F}', color: '#6B8E23' },
+      { id: 'herb-spiral', name: 'Kr\u00E4uterspirale', icon: '\u{1F300}', color: '#9ACD32' }
+    ],
+    paths: [
+      { id: 'stone-path', name: 'Steinweg', icon: '\u{1FAA8}', color: '#A9A9A9' },
+      { id: 'grass-path', name: 'Rasenweg', icon: '\u{1F7E9}', color: '#7CFC00' },
+      { id: 'gravel', name: 'Kies', icon: '\u26AA', color: '#D3D3D3' }
+    ],
+    structures: [
+      { id: 'greenhouse', name: 'Gew\u00E4chshaus', icon: '\u{1F3E0}', color: '#B0C4DE' },
+      { id: 'compost', name: 'Kompost', icon: '\u267B\uFE0F', color: '#8B4513' },
+      { id: 'water', name: 'Wasseranschluss', icon: '\u{1F6B0}', color: '#4169E1' },
+      { id: 'fence', name: 'Zaun', icon: '\u{1F3D7}\uFE0F', color: '#DEB887' },
+      { id: 'bench', name: 'Sitzbank', icon: '\u{1FA91}', color: '#D2691E' }
+    ]
+  };
+
+  const CATEGORY_LABELS = {
+    beds: 'Beete',
+    paths: 'Wege',
+    structures: 'Strukturen',
+    plants: 'Pflanzen'
+  };
+
+  const GRID_SIZES = [
+    { label: '8 x 8', rows: 8, cols: 8 },
+    { label: '10 x 10', rows: 10, cols: 10 },
+    { label: '12 x 12', rows: 12, cols: 12 },
+    { label: '16 x 16', rows: 16, cols: 16 },
+    { label: '20 x 20', rows: 20, cols: 20 }
+  ];
+
+  const STORAGE_KEY = 'gardenplanner_gardens';
+
+  // =====================================================
+  // State
+  // =====================================================
+  let gridSize = { rows: 12, cols: 12 };
+  let gridState = []; // 2D array: null or { type, name, icon, color, id }
+  let selectedElement = null;
+  let isPainting = false;
+  let zoomLevel = 1;
+  let currentGardenId = null;
+  let plantElements = [];
+
+  // =====================================================
+  // DOM References
+  // =====================================================
+  const dom = {};
+
+  function cacheDom() {
+    dom.gridSizeSelect = document.getElementById('gridSizeSelect');
+    dom.gridContainer = document.getElementById('gardenGrid');
+    dom.gridWrapper = document.getElementById('gardenGridWrapper');
+    dom.palette = document.getElementById('gardenPalette');
+    dom.infoText = document.getElementById('gardenInfoText');
+    dom.zoomIn = document.getElementById('zoomIn');
+    dom.zoomOut = document.getElementById('zoomOut');
+    dom.zoomLevel = document.getElementById('zoomLevel');
+    dom.saveBtn = document.getElementById('gardenSaveBtn');
+    dom.loadBtn = document.getElementById('gardenLoadBtn');
+    dom.clearBtn = document.getElementById('gardenClearBtn');
+    dom.saveDialog = document.getElementById('gardenSaveDialog');
+    dom.loadDialog = document.getElementById('gardenLoadDialog');
+  }
+
+  // =====================================================
+  // Grid Management
+  // =====================================================
+  function initGrid() {
+    gridState = [];
+    for (let r = 0; r < gridSize.rows; r++) {
+      gridState[r] = [];
+      for (let c = 0; c < gridSize.cols; c++) {
+        gridState[r][c] = null;
+      }
+    }
+  }
+
+  function renderGrid() {
+    dom.gridContainer.innerHTML = '';
+    dom.gridContainer.style.gridTemplateColumns = 'repeat(' + gridSize.cols + ', 1fr)';
+    dom.gridContainer.style.gridTemplateRows = 'repeat(' + gridSize.rows + ', 1fr)';
+
+    for (let r = 0; r < gridSize.rows; r++) {
+      for (let c = 0; c < gridSize.cols; c++) {
+        var cell = document.createElement('div');
+        cell.className = 'garden-cell';
+        cell.dataset.row = r;
+        cell.dataset.col = c;
+
+        var data = gridState[r][c];
+        if (data) {
+          cell.classList.add('garden-cell--occupied');
+          cell.style.backgroundColor = data.color + '33'; // with alpha
+          cell.title = data.name;
+          var icon = document.createElement('span');
+          icon.className = 'cell-icon';
+          icon.textContent = data.icon;
+          cell.appendChild(icon);
+        }
+
+        cell.addEventListener('mousedown', onCellMouseDown);
+        cell.addEventListener('mouseenter', onCellMouseEnter);
+        cell.addEventListener('touchstart', onCellTouchStart, { passive: false });
+        cell.addEventListener('touchmove', onCellTouchMove, { passive: false });
+
+        dom.gridContainer.appendChild(cell);
+      }
+    }
+  }
+
+  // =====================================================
+  // Cell Interaction
+  // =====================================================
+  function onCellMouseDown(e) {
+    e.preventDefault();
+    isPainting = true;
+    handleCellAction(this);
+  }
+
+  function onCellMouseEnter(e) {
+    if (!isPainting) return;
+    handleCellAction(this);
+  }
+
+  function onCellTouchStart(e) {
+    e.preventDefault();
+    isPainting = true;
+    handleCellAction(this);
+  }
+
+  function onCellTouchMove(e) {
+    e.preventDefault();
+    var touch = e.touches[0];
+    var el = document.elementFromPoint(touch.clientX, touch.clientY);
+    if (el && el.classList.contains('garden-cell')) {
+      handleCellAction(el);
+    }
+  }
+
+  function handleCellAction(cellEl) {
+    var r = parseInt(cellEl.dataset.row);
+    var c = parseInt(cellEl.dataset.col);
+    var current = gridState[r][c];
+
+    if (selectedElement) {
+      // Place element
+      gridState[r][c] = {
+        type: selectedElement.type,
+        id: selectedElement.id,
+        name: selectedElement.name,
+        icon: selectedElement.icon,
+        color: selectedElement.color
+      };
+      updateCell(cellEl, gridState[r][c]);
+      updateInfo('Platziert: ' + selectedElement.name + ' (' + r + ', ' + c + ')');
+    } else if (current) {
+      // Remove element
+      gridState[r][c] = null;
+      clearCell(cellEl);
+      updateInfo('Entfernt: ' + current.name + ' (' + r + ', ' + c + ')');
+    }
+  }
+
+  function updateCell(cellEl, data) {
+    cellEl.className = 'garden-cell garden-cell--occupied';
+    cellEl.style.backgroundColor = data.color + '33';
+    cellEl.title = data.name;
+    cellEl.innerHTML = '';
+    var icon = document.createElement('span');
+    icon.className = 'cell-icon';
+    icon.textContent = data.icon;
+    cellEl.appendChild(icon);
+  }
+
+  function clearCell(cellEl) {
+    cellEl.className = 'garden-cell';
+    cellEl.style.backgroundColor = '';
+    cellEl.title = '';
+    cellEl.innerHTML = '';
+  }
+
+  document.addEventListener('mouseup', function () {
+    isPainting = false;
+  });
+  document.addEventListener('touchend', function () {
+    isPainting = false;
+  });
+
+  // =====================================================
+  // Palette
+  // =====================================================
+  function renderPalette() {
+    dom.palette.innerHTML = '';
+
+    // Static categories
+    Object.keys(GARDEN_ELEMENTS).forEach(function (cat) {
+      var section = createPaletteSection(CATEGORY_LABELS[cat], GARDEN_ELEMENTS[cat], cat);
+      dom.palette.appendChild(section);
+    });
+
+    // Plants section (loaded from API)
+    var plantSection = document.createElement('div');
+    plantSection.className = 'palette-section';
+    plantSection.id = 'palettePlants';
+
+    var title = document.createElement('h4');
+    title.className = 'palette-section-title';
+    title.textContent = CATEGORY_LABELS.plants;
+    plantSection.appendChild(title);
+
+    var items = document.createElement('div');
+    items.className = 'palette-items';
+    items.id = 'palettePlantItems';
+
+    var loading = document.createElement('div');
+    loading.className = 'palette-loading';
+    loading.textContent = 'Pflanzen laden...';
+    loading.id = 'plantsLoading';
+    items.appendChild(loading);
+
+    plantSection.appendChild(items);
+    dom.palette.appendChild(plantSection);
+
+    loadPlants();
+  }
+
+  function createPaletteSection(label, items, category) {
+    var section = document.createElement('div');
+    section.className = 'palette-section';
+
+    var title = document.createElement('h4');
+    title.className = 'palette-section-title';
+    title.textContent = label;
+    section.appendChild(title);
+
+    var container = document.createElement('div');
+    container.className = 'palette-items';
+
+    items.forEach(function (item) {
+      var el = createPaletteItem(item, category);
+      container.appendChild(el);
+    });
+
+    section.appendChild(container);
+    return section;
+  }
+
+  function createPaletteItem(item, category) {
+    var el = document.createElement('div');
+    el.className = 'palette-item';
+    el.dataset.id = item.id;
+    el.dataset.type = category;
+
+    var iconEl = document.createElement('span');
+    iconEl.className = 'palette-item-icon';
+    iconEl.style.backgroundColor = item.color + '33';
+    iconEl.textContent = item.icon;
+    el.appendChild(iconEl);
+
+    var nameEl = document.createElement('span');
+    nameEl.className = 'palette-item-name';
+    nameEl.textContent = item.name;
+    el.appendChild(nameEl);
+
+    el.addEventListener('click', function () {
+      selectPaletteItem(el, {
+        type: category,
+        id: item.id,
+        name: item.name,
+        icon: item.icon,
+        color: item.color
+      });
+    });
+
+    return el;
+  }
+
+  function selectPaletteItem(el, data) {
+    // Deselect if clicking same item
+    if (selectedElement && selectedElement.id === data.id && selectedElement.type === data.type) {
+      selectedElement = null;
+      el.classList.remove('palette-item--selected');
+      updateInfo('Kein Element ausgew\u00E4hlt. Klicke auf eine Zelle, um ein Element zu entfernen.');
+      return;
+    }
+
+    // Deselect all
+    var allItems = dom.palette.querySelectorAll('.palette-item--selected');
+    allItems.forEach(function (item) { item.classList.remove('palette-item--selected'); });
+
+    selectedElement = data;
+    el.classList.add('palette-item--selected');
+    updateInfo('Ausgew\u00E4hlt: ' + data.icon + ' ' + data.name + ' \u2014 Klicke oder ziehe \u00FCber das Raster zum Platzieren.');
+  }
+
+  // =====================================================
+  // Load Plants from API
+  // =====================================================
+  function loadPlants() {
+    fetch('/api/v1/plants')
+      .then(function (res) {
+        if (!res.ok) throw new Error('Failed to load plants');
+        return res.json();
+      })
+      .then(function (data) {
+        var plants = Array.isArray(data) ? data : (data.plants || []);
+        var container = document.getElementById('palettePlantItems');
+        var loading = document.getElementById('plantsLoading');
+        if (loading) loading.remove();
+
+        // Map API plants to palette items
+        plantElements = plants.map(function (p) {
+          return {
+            id: 'plant-' + (p.id || p.name.toLowerCase().replace(/\s+/g, '-')),
+            name: p.name,
+            icon: p.icon || '\u{1F33F}',
+            color: '#E8D5B7'
+          };
+        });
+
+        if (plantElements.length === 0) {
+          var empty = document.createElement('div');
+          empty.className = 'palette-loading';
+          empty.textContent = 'Keine Pflanzen vorhanden';
+          container.appendChild(empty);
+          return;
+        }
+
+        plantElements.forEach(function (item) {
+          var el = createPaletteItem(item, 'plant');
+          container.appendChild(el);
+        });
+      })
+      .catch(function () {
+        var loading = document.getElementById('plantsLoading');
+        if (loading) {
+          loading.textContent = 'Pflanzen konnten nicht geladen werden';
+        }
+      });
+  }
+
+  // =====================================================
+  // Grid Size
+  // =====================================================
+  function onGridSizeChange() {
+    var val = dom.gridSizeSelect.value;
+    var parts = val.split('x');
+    var newSize = { rows: parseInt(parts[0]), cols: parseInt(parts[1]) };
+
+    // Check if grid has content
+    var hasContent = gridState.some(function (row) {
+      return row.some(function (cell) { return cell !== null; });
+    });
+
+    if (hasContent) {
+      if (!confirm('Rastergr\u00F6\u00DFe \u00E4ndern? Inhalte au\u00DFerhalb des neuen Rasters gehen verloren.')) {
+        dom.gridSizeSelect.value = gridSize.rows + 'x' + gridSize.cols;
+        return;
+      }
+    }
+
+    // Preserve existing cells that fit
+    var oldState = gridState;
+    gridSize = newSize;
+    initGrid();
+
+    for (var r = 0; r < Math.min(oldState.length, gridSize.rows); r++) {
+      for (var c = 0; c < Math.min(oldState[r].length, gridSize.cols); c++) {
+        gridState[r][c] = oldState[r][c];
+      }
+    }
+
+    renderGrid();
+    updateInfo('Rastergr\u00F6\u00DFe ge\u00E4ndert: ' + gridSize.rows + ' x ' + gridSize.cols);
+  }
+
+  // =====================================================
+  // Zoom
+  // =====================================================
+  function setZoom(level) {
+    zoomLevel = Math.max(0.5, Math.min(2, level));
+    dom.gridWrapper.style.transform = 'scale(' + zoomLevel + ')';
+    dom.zoomLevel.textContent = Math.round(zoomLevel * 100) + '%';
+  }
+
+  // =====================================================
+  // Save / Load (localStorage)
+  // =====================================================
+  function getAllGardens() {
+    try {
+      var data = localStorage.getItem(STORAGE_KEY);
+      return data ? JSON.parse(data) : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveGardens(gardens) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(gardens));
+  }
+
+  function serializeGrid() {
+    var cells = [];
+    for (var r = 0; r < gridSize.rows; r++) {
+      for (var c = 0; c < gridSize.cols; c++) {
+        if (gridState[r][c]) {
+          cells.push({
+            row: r,
+            col: c,
+            type: gridState[r][c].type,
+            id: gridState[r][c].id,
+            name: gridState[r][c].name,
+            icon: gridState[r][c].icon,
+            color: gridState[r][c].color
+          });
+        }
+      }
+    }
+    return cells;
+  }
+
+  function deserializeGrid(gardenData) {
+    gridSize = gardenData.gridSize;
+    dom.gridSizeSelect.value = gridSize.rows + 'x' + gridSize.cols;
+    initGrid();
+
+    gardenData.cells.forEach(function (cell) {
+      if (cell.row < gridSize.rows && cell.col < gridSize.cols) {
+        gridState[cell.row][cell.col] = {
+          type: cell.type,
+          id: cell.id,
+          name: cell.name,
+          icon: cell.icon,
+          color: cell.color
+        };
+      }
+    });
+
+    renderGrid();
+  }
+
+  function showSaveDialog() {
+    dom.saveDialog.hidden = false;
+    var nameInput = dom.saveDialog.querySelector('#gardenNameInput');
+    var gardens = getAllGardens();
+
+    // If editing existing garden, pre-fill name
+    if (currentGardenId) {
+      var existing = gardens.find(function (g) { return g.id === currentGardenId; });
+      if (existing) {
+        nameInput.value = existing.name;
+      }
+    } else {
+      nameInput.value = '';
+    }
+    nameInput.focus();
+  }
+
+  function hideSaveDialog() {
+    dom.saveDialog.hidden = true;
+  }
+
+  function doSave() {
+    var nameInput = dom.saveDialog.querySelector('#gardenNameInput');
+    var name = nameInput.value.trim();
+    if (!name) {
+      nameInput.focus();
+      return;
+    }
+
+    var gardens = getAllGardens();
+    var now = new Date().toISOString();
+    var cells = serializeGrid();
+
+    if (currentGardenId) {
+      // Update existing
+      var idx = gardens.findIndex(function (g) { return g.id === currentGardenId; });
+      if (idx >= 0) {
+        gardens[idx].name = name;
+        gardens[idx].gridSize = { rows: gridSize.rows, cols: gridSize.cols };
+        gardens[idx].cells = cells;
+        gardens[idx].updatedAt = now;
+      }
+    } else {
+      // New garden
+      var garden = {
+        id: 'garden_' + Date.now(),
+        name: name,
+        gridSize: { rows: gridSize.rows, cols: gridSize.cols },
+        cells: cells,
+        createdAt: now,
+        updatedAt: now
+      };
+      currentGardenId = garden.id;
+      gardens.push(garden);
+    }
+
+    saveGardens(gardens);
+    hideSaveDialog();
+    updateInfo('Garten "' + name + '" gespeichert.');
+  }
+
+  function showLoadDialog() {
+    dom.loadDialog.hidden = false;
+    renderLoadList();
+  }
+
+  function hideLoadDialog() {
+    dom.loadDialog.hidden = true;
+  }
+
+  function renderLoadList() {
+    var list = dom.loadDialog.querySelector('#gardenLoadList');
+    list.innerHTML = '';
+    var gardens = getAllGardens();
+
+    if (gardens.length === 0) {
+      var empty = document.createElement('div');
+      empty.className = 'garden-load-empty';
+      empty.textContent = 'Keine gespeicherten G\u00E4rten vorhanden.';
+      list.appendChild(empty);
+      return;
+    }
+
+    gardens.forEach(function (garden) {
+      var item = document.createElement('div');
+      item.className = 'garden-load-item';
+
+      var info = document.createElement('div');
+      var nameLine = document.createElement('div');
+      nameLine.className = 'garden-load-item-name';
+      nameLine.textContent = garden.name;
+      info.appendChild(nameLine);
+
+      var meta = document.createElement('div');
+      meta.className = 'garden-load-item-meta';
+      meta.textContent = garden.gridSize.rows + 'x' + garden.gridSize.cols +
+        ' | ' + garden.cells.length + ' Elemente' +
+        ' | ' + new Date(garden.updatedAt).toLocaleDateString('de-DE');
+      info.appendChild(meta);
+
+      item.appendChild(info);
+
+      var deleteBtn = document.createElement('button');
+      deleteBtn.className = 'garden-load-item-delete';
+      deleteBtn.innerHTML = '&times;';
+      deleteBtn.title = 'L\u00F6schen';
+      deleteBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (confirm('Garten "' + garden.name + '" wirklich l\u00F6schen?')) {
+          var gardens = getAllGardens().filter(function (g) { return g.id !== garden.id; });
+          saveGardens(gardens);
+          if (currentGardenId === garden.id) currentGardenId = null;
+          renderLoadList();
+        }
+      });
+      item.appendChild(deleteBtn);
+
+      item.addEventListener('click', function () {
+        currentGardenId = garden.id;
+        deserializeGrid(garden);
+        hideLoadDialog();
+        updateInfo('Garten "' + garden.name + '" geladen.');
+      });
+
+      list.appendChild(item);
+    });
+  }
+
+  // =====================================================
+  // Clear
+  // =====================================================
+  function clearGrid() {
+    if (!confirm('Gesamtes Raster l\u00F6schen? Alle platzierten Elemente werden entfernt.')) {
+      return;
+    }
+    initGrid();
+    renderGrid();
+    currentGardenId = null;
+    updateInfo('Raster gel\u00F6scht.');
+  }
+
+  // =====================================================
+  // Info bar
+  // =====================================================
+  function updateInfo(text) {
+    dom.infoText.innerHTML = '';
+    var strong = document.createElement('strong');
+    strong.textContent = text;
+    dom.infoText.appendChild(strong);
+  }
+
+  // =====================================================
+  // Theme toggle (reuse existing logic)
+  // =====================================================
+  function initTheme() {
+    var themeToggle = document.getElementById('themeToggle');
+    if (!themeToggle) return;
+
+    var savedTheme = localStorage.getItem('theme');
+    if (savedTheme === 'dark') {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    }
+
+    themeToggle.addEventListener('click', function () {
+      var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+      if (isDark) {
+        document.documentElement.removeAttribute('data-theme');
+        localStorage.setItem('theme', 'light');
+      } else {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        localStorage.setItem('theme', 'dark');
+      }
+    });
+  }
+
+  // =====================================================
+  // Keyboard shortcuts
+  // =====================================================
+  function initKeyboard() {
+    document.addEventListener('keydown', function (e) {
+      // Escape: deselect element or close dialogs
+      if (e.key === 'Escape') {
+        if (!dom.saveDialog.hidden) { hideSaveDialog(); return; }
+        if (!dom.loadDialog.hidden) { hideLoadDialog(); return; }
+        if (selectedElement) {
+          selectedElement = null;
+          var allItems = dom.palette.querySelectorAll('.palette-item--selected');
+          allItems.forEach(function (item) { item.classList.remove('palette-item--selected'); });
+          updateInfo('Auswahl aufgehoben.');
+        }
+      }
+      // Ctrl+S: save
+      if (e.ctrlKey && e.key === 's') {
+        e.preventDefault();
+        showSaveDialog();
+      }
+    });
+  }
+
+  // =====================================================
+  // Init
+  // =====================================================
+  function init() {
+    cacheDom();
+    initTheme();
+    initKeyboard();
+
+    // Grid size select
+    GRID_SIZES.forEach(function (size) {
+      var opt = document.createElement('option');
+      opt.value = size.rows + 'x' + size.cols;
+      opt.textContent = size.label;
+      if (size.rows === gridSize.rows && size.cols === gridSize.cols) {
+        opt.selected = true;
+      }
+      dom.gridSizeSelect.appendChild(opt);
+    });
+    dom.gridSizeSelect.addEventListener('change', onGridSizeChange);
+
+    // Buttons
+    dom.saveBtn.addEventListener('click', showSaveDialog);
+    dom.loadBtn.addEventListener('click', showLoadDialog);
+    dom.clearBtn.addEventListener('click', clearGrid);
+    dom.zoomIn.addEventListener('click', function () { setZoom(zoomLevel + 0.1); });
+    dom.zoomOut.addEventListener('click', function () { setZoom(zoomLevel - 0.1); });
+
+    // Save dialog buttons
+    dom.saveDialog.querySelector('#gardenSaveConfirm').addEventListener('click', doSave);
+    dom.saveDialog.querySelector('#gardenSaveCancel').addEventListener('click', hideSaveDialog);
+    dom.saveDialog.querySelector('#gardenNameInput').addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') { e.preventDefault(); doSave(); }
+    });
+
+    // Load dialog buttons
+    dom.loadDialog.querySelector('#gardenLoadClose').addEventListener('click', hideLoadDialog);
+
+    // Backdrop clicks close dialogs
+    dom.saveDialog.addEventListener('click', function (e) {
+      if (e.target === dom.saveDialog) hideSaveDialog();
+    });
+    dom.loadDialog.addEventListener('click', function (e) {
+      if (e.target === dom.loadDialog) hideLoadDialog();
+    });
+
+    // Build grid and palette
+    initGrid();
+    renderGrid();
+    renderPalette();
+
+    updateInfo('W\u00E4hle ein Element aus der Seitenleiste und klicke auf das Raster zum Platzieren.');
+  }
+
+  // Start when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -81,7 +81,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // HTML page routes (with and without .html extension)
-const pages = ['index', 'dashboard', 'statistics', 'logs', 'plants', 'login', 'admin'];
+const pages = ['index', 'dashboard', 'statistics', 'logs', 'plants', 'garden', 'login', 'admin'];
 pages.forEach(page => {
     app.get(`/${page}`, (req, res) => {
         res.sendFile(path.join(PROJECT_ROOT, 'public', `${page}.html`));


### PR DESCRIPTION
## Summary
THE core feature — interactive grid-based garden planner.

- **Grid editor**: Configurable size (8x8 to 16x16), click to place, drag to paint
- **Element palette**: Beds (3), Paths (3), Structures (5), Plants (from API)
- **Save/Load**: localStorage with named gardens
- **Controls**: Zoom (0.5x-2x), clear with confirmation, keyboard shortcuts (Esc, Ctrl+S)
- **716 lines JS**, **528 lines CSS**, full dark mode + responsive
- Navigation updated on all pages with "Garten" link

Closes #48

## Test plan
- [ ] Open /garden — grid and palette render
- [ ] Click palette item, click grid cell — element placed
- [ ] Drag across cells — paints multiple
- [ ] Save garden, reload page, load garden — persisted
- [ ] Grid size change preserves existing content
- [ ] Dark mode works
- [ ] Mobile: palette scrolls horizontally