### PR TITLE
fix: prevent credential leak via GET and fix auth status loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/public/login.html
+++ b/public/login.html
@@ -21,7 +21,7 @@
           <h1>Gartenplaner</h1>
           <p class="subtitle">Bitte melden Sie sich an</p>
         </div>
-        <form id="loginForm" class="login-form" novalidate>
+        <form id="loginForm" class="login-form" method="POST" action="/api/v1/auth/login" novalidate>
           <div class="form-group">
             <label for="username">Benutzername</label>
             <input
@@ -83,6 +83,13 @@
     <script src="../src/js/app.js"></script>
     <script nonce="__CSP_NONCE__">
       (function() {
+        // Show error message if redirected back from failed non-JS form login
+        if (new URLSearchParams(window.location.search).has('error')) {
+          var errEl = document.getElementById('loginError');
+          errEl.textContent = 'Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.';
+          errEl.hidden = false;
+        }
+
         // Check if already logged in
         fetch('/api/v1/auth/status', { credentials: 'same-origin' })
           .then(function(r) { return r.json(); })

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -28,6 +28,7 @@ const PROJECT_ROOT = path.join(__dirname, '..', '..');
 
 app.use(compression());
 app.use(express.json({ limit: '100kb' }));
+app.use(express.urlencoded({ extended: false, limit: '100kb' }));
 
 // Security headers
 app.use(securityHeaders);
@@ -53,13 +54,13 @@ app.use((req, res, next) => {
 // Request logging
 app.use(requestLogger);
 
-// Auth status endpoint (always accessible, before auth middleware)
-app.use('/api/auth', authRouter);
-app.use('/api/v1/auth', authRouter);
-
-// JWT authentication for /api/* routes
+// JWT authentication for /api/* routes (populates req.user; public auth paths pass through)
 app.use('/api', jwtAuth);
 app.use('/api/v1', jwtAuth);
+
+// Auth routes (after jwtAuth so req.user is populated on /status)
+app.use('/api/auth', authRouter);
+app.use('/api/v1/auth', authRouter);
 
 // Rate limiting — tiered
 app.use('/api/auth', authLimiter);

--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -15,26 +15,30 @@ function parseCookies(cookieHeader) {
 }
 
 function jwtAuth(req, res, next) {
-    if (req.path === '/auth/status' || req.path === '/auth/login') {
-        return next();
-    }
     if (!JWT_SECRET) {
         return next();
     }
+
+    const isPublicAuth = req.path === '/auth/status' || req.path === '/auth/login' || req.path === '/auth/logout';
     const cookies = parseCookies(req.headers.cookie);
     const token = cookies.token;
-    if (!token) {
+
+    if (token) {
+        try {
+            const payload = jwt.verify(token, JWT_SECRET);
+            req.user = { id: payload.sub, username: payload.username, role: payload.role };
+        } catch (err) {
+            if (!isPublicAuth) {
+                audit('auth_failure', { ip: req.ip, path: req.originalUrl, reason: err.message });
+                return res.status(401).json({ error: true, status: 401, message: 'Invalid or expired token' });
+            }
+        }
+    } else if (!isPublicAuth) {
         audit('auth_failure', { ip: req.ip, path: req.originalUrl, reason: 'no token' });
         return res.status(401).json({ error: true, status: 401, message: 'Authentication required' });
     }
-    try {
-        const payload = jwt.verify(token, JWT_SECRET);
-        req.user = { id: payload.sub, username: payload.username, role: payload.role };
-        next();
-    } catch (err) {
-        audit('auth_failure', { ip: req.ip, path: req.originalUrl, reason: err.message });
-        return res.status(401).json({ error: true, status: 401, message: 'Invalid or expired token' });
-    }
+
+    next();
 }
 
 function signToken(user) {

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -12,18 +12,22 @@ router.get('/status', (req, res) => {
 });
 
 router.post('/login', async (req, res) => {
+    const isFormPost = (req.get('content-type') || '').includes('application/x-www-form-urlencoded');
     const { username, password } = req.body || {};
     if (!username || !password) {
+        if (isFormPost) return res.redirect('/login?error=1');
         return res.status(400).json({ error: true, status: 400, message: 'Username and password required' });
     }
     const user = await findByUsername(username);
     if (!user || !(await verifyPassword(user, password))) {
         audit('login_failure', { ip: req.ip, username });
+        if (isFormPost) return res.redirect('/login?error=1');
         return res.status(401).json({ error: true, status: 401, message: 'Invalid credentials' });
     }
     const token = signToken(user);
     setTokenCookie(res, token);
     audit('login_success', { ip: req.ip, username, userId: user.id });
+    if (isFormPost) return res.redirect('/dashboard');
     res.json({ user: { id: user.id, username: user.username, role: user.role } });
 });
 


### PR DESCRIPTION
## Summary
- Login-Formular hatte kein `method="POST"` — bei blockiertem JS landeten Credentials als GET-Parameter in der URL
- Auth-Status-Endpoint gab immer `user: null` zurück weil `jwtAuth` vor den Auth-Routes nicht lief → Endlos-Redirect-Loop nach Login
- `jwtAuth` parst jetzt den Token auch auf öffentlichen Auth-Pfaden (ohne zu blocken), Middleware-Reihenfolge korrigiert

## Test plan
- [x] Alle 160 Tests bestanden
- [ ] Login testen — nach Anmeldung auf Dashboard bleiben, kein Redirect-Loop
- [ ] Browser-DevTools: Cookie `token` wird gesetzt, `/api/v1/auth/status` gibt `user`-Objekt zurück
- [ ] JS deaktivieren → Formular sendet POST, keine Credentials in URL