### PR TITLE
fix: auth status 401 — path matching for /api mount prefix

### DIFF
--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -19,7 +19,7 @@ function jwtAuth(req, res, next) {
         return next();
     }
 
-    const isPublicAuth = req.path === '/auth/status' || req.path === '/auth/login' || req.path === '/auth/logout';
+    const isPublicAuth = /^(\/v1)?\/auth\/(status|login|logout)$/.test(req.path);
     const cookies = parseCookies(req.headers.cookie);
     const token = cookies.token;
 


### PR DESCRIPTION
## Summary
- `jwtAuth` gemountet auf `/api` sieht `req.path` als `/v1/auth/status`, nicht `/auth/status`
- Der `isPublicAuth`-Check hat deshalb nicht gematcht → 401 auf `/api/v1/auth/status`
- Fix: Regex `/^(\/v1)?\/auth\/(status|login|logout)$/` matcht beide Mount-Pfade

## Test plan
- [x] 160 Tests bestanden
- [ ] `/api/v1/auth/status` gibt 200 zurück (nicht 401)
- [ ] Login → Dashboard ohne Redirect-Loop