### PR TITLE
fix: Secure cookie flag nur mit explizitem COOKIE_SECURE=true

### DIFF
--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -50,9 +50,9 @@ function signToken(user) {
 }
 
 function setTokenCookie(res, token) {
-    const isProduction = process.env.NODE_ENV === 'production';
+    const secure = process.env.COOKIE_SECURE === 'true';
     res.setHeader('Set-Cookie',
-        `token=${token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=86400${isProduction ? '; Secure' : ''}`
+        `token=${token}; HttpOnly; SameSite=Strict; Path=/; Max-Age=86400${secure ? '; Secure' : ''}`
     );
 }
 


### PR DESCRIPTION
## Summary
- `NODE_ENV=production` hat automatisch `Secure` auf den Auth-Cookie gesetzt
- Docker-Compose Setup läuft über HTTP → Browser verwirft Secure-Cookies über HTTP
- Cookie wird nie gespeichert → sofortiger Logout nach Login
- Fix: `Secure`-Flag nur noch mit explizitem `COOKIE_SECURE=true` Env-Var

## Test plan
- [x] 160 Tests bestanden
- [ ] Login über HTTP → Cookie wird gesetzt, Session bleibt bestehen
- [ ] Bei HTTPS-Setup: `COOKIE_SECURE=true` in docker-compose setzen