### PR TITLE
fix: vereinheitliche Auth-Check und API-Pfade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/public/garden.html
+++ b/public/garden.html
@@ -19,36 +19,7 @@
     <link rel="stylesheet" href="../src/css/garden.css" />
   </head>
   <body>
-    <script nonce="__CSP_NONCE__">
-        fetch('/api/v1/auth/status', { credentials: 'same-origin' })
-            .then(r => r.json())
-            .then(data => {
-                if (data.authRequired && !data.user) window.location.href = '/login';
-                if (data.user) {
-                    window.__user = data.user;
-                    const nav = document.querySelector('nav ul') || document.querySelector('.main-nav');
-                    if (nav && data.user.role === 'admin') {
-                        const adminLink = document.createElement('a');
-                        adminLink.href = '/admin';
-                        adminLink.className = 'nav-link';
-                        adminLink.textContent = 'Admin';
-                        nav.appendChild(adminLink);
-                    }
-                    if (nav) {
-                        const logoutLink = document.createElement('a');
-                        logoutLink.href = '#';
-                        logoutLink.className = 'nav-link';
-                        logoutLink.textContent = 'Logout';
-                        logoutLink.addEventListener('click', function(e) {
-                            e.preventDefault();
-                            if (window.TaskAPI) TaskAPI.logout();
-                            else fetch('/api/v1/auth/logout', { method: 'POST', credentials: 'same-origin' }).then(function() { window.location.href = '/login'; });
-                        });
-                        nav.appendChild(logoutLink);
-                    }
-                }
-            });
-    </script>
+    <script src="../src/js/auth-check.js"></script>
     <div class="garden-container">
       <header role="banner">
         <h1>🌻 Gartenplaner</h1>

--- a/public/index.html
+++ b/public/index.html
@@ -18,36 +18,7 @@
     <link rel="stylesheet" href="../src/css/styles.css" />
   </head>
   <body>
-    <script nonce="__CSP_NONCE__">
-        fetch('/api/v1/auth/status', { credentials: 'same-origin' })
-            .then(r => r.json())
-            .then(data => {
-                if (data.authRequired && !data.user) window.location.href = '/login';
-                if (data.user) {
-                    window.__user = data.user;
-                    const nav = document.querySelector('nav ul') || document.querySelector('.main-nav');
-                    if (nav && data.user.role === 'admin') {
-                        const adminLink = document.createElement('a');
-                        adminLink.href = '/admin';
-                        adminLink.className = 'nav-link';
-                        adminLink.textContent = 'Admin';
-                        nav.appendChild(adminLink);
-                    }
-                    if (nav) {
-                        const logoutLink = document.createElement('a');
-                        logoutLink.href = '#';
-                        logoutLink.className = 'nav-link';
-                        logoutLink.textContent = 'Logout';
-                        logoutLink.addEventListener('click', function(e) {
-                            e.preventDefault();
-                            if (window.TaskAPI) TaskAPI.logout();
-                            else fetch('/api/v1/auth/logout', { method: 'POST', credentials: 'same-origin' }).then(function() { window.location.href = '/login'; });
-                        });
-                        nav.appendChild(logoutLink);
-                    }
-                }
-            });
-    </script>
+    <script src="../src/js/auth-check.js"></script>
     <div class="container">
       <header role="banner">
         <h1>🌱 Gartenplaner</h1>

--- a/public/logs.html
+++ b/public/logs.html
@@ -10,36 +10,7 @@
     <link rel="stylesheet" href="../src/css/styles.css" />
   </head>
   <body>
-    <script nonce="__CSP_NONCE__">
-        fetch('/api/v1/auth/status', { credentials: 'same-origin' })
-            .then(r => r.json())
-            .then(data => {
-                if (data.authRequired && !data.user) window.location.href = '/login';
-                if (data.user) {
-                    window.__user = data.user;
-                    const nav = document.querySelector('nav ul') || document.querySelector('.main-nav');
-                    if (nav && data.user.role === 'admin') {
-                        const adminLink = document.createElement('a');
-                        adminLink.href = '/admin';
-                        adminLink.className = 'nav-link';
-                        adminLink.textContent = 'Admin';
-                        nav.appendChild(adminLink);
-                    }
-                    if (nav) {
-                        const logoutLink = document.createElement('a');
-                        logoutLink.href = '#';
-                        logoutLink.className = 'nav-link';
-                        logoutLink.textContent = 'Logout';
-                        logoutLink.addEventListener('click', function(e) {
-                            e.preventDefault();
-                            if (window.TaskAPI) TaskAPI.logout();
-                            else fetch('/api/v1/auth/logout', { method: 'POST', credentials: 'same-origin' }).then(function() { window.location.href = '/login'; });
-                        });
-                        nav.appendChild(logoutLink);
-                    }
-                }
-            });
-    </script>
+    <script src="../src/js/auth-check.js"></script>
     <div class="log-viewer-container">
       <header>
         <h1>📊 System Logs</h1>

--- a/public/plants.html
+++ b/public/plants.html
@@ -12,36 +12,7 @@
     <link rel="stylesheet" href="../src/css/plants.css">
 </head>
 <body>
-    <script nonce="__CSP_NONCE__">
-        fetch('/api/v1/auth/status', { credentials: 'same-origin' })
-            .then(r => r.json())
-            .then(data => {
-                if (data.authRequired && !data.user) window.location.href = '/login';
-                if (data.user) {
-                    window.__user = data.user;
-                    const nav = document.querySelector('nav ul') || document.querySelector('.main-nav');
-                    if (nav && data.user.role === 'admin') {
-                        const adminLink = document.createElement('a');
-                        adminLink.href = '/admin';
-                        adminLink.className = 'nav-link';
-                        adminLink.textContent = 'Admin';
-                        nav.appendChild(adminLink);
-                    }
-                    if (nav) {
-                        const logoutLink = document.createElement('a');
-                        logoutLink.href = '#';
-                        logoutLink.className = 'nav-link';
-                        logoutLink.textContent = 'Logout';
-                        logoutLink.addEventListener('click', function(e) {
-                            e.preventDefault();
-                            if (window.TaskAPI) TaskAPI.logout();
-                            else fetch('/api/v1/auth/logout', { method: 'POST', credentials: 'same-origin' }).then(function() { window.location.href = '/login'; });
-                        });
-                        nav.appendChild(logoutLink);
-                    }
-                }
-            });
-    </script>
+    <script src="../src/js/auth-check.js"></script>
     <div class="container">
         <header role="banner">
             <h1>🌱 Pflanzenbibliothek</h1>

--- a/public/statistics.html
+++ b/public/statistics.html
@@ -14,36 +14,7 @@
     <link rel="stylesheet" href="../src/css/styles.css" />
   </head>
   <body>
-    <script nonce="__CSP_NONCE__">
-        fetch('/api/v1/auth/status', { credentials: 'same-origin' })
-            .then(r => r.json())
-            .then(data => {
-                if (data.authRequired && !data.user) window.location.href = '/login';
-                if (data.user) {
-                    window.__user = data.user;
-                    const nav = document.querySelector('nav ul') || document.querySelector('.main-nav');
-                    if (nav && data.user.role === 'admin') {
-                        const adminLink = document.createElement('a');
-                        adminLink.href = '/admin';
-                        adminLink.className = 'nav-link';
-                        adminLink.textContent = 'Admin';
-                        nav.appendChild(adminLink);
-                    }
-                    if (nav) {
-                        const logoutLink = document.createElement('a');
-                        logoutLink.href = '#';
-                        logoutLink.className = 'nav-link';
-                        logoutLink.textContent = 'Logout';
-                        logoutLink.addEventListener('click', function(e) {
-                            e.preventDefault();
-                            if (window.TaskAPI) TaskAPI.logout();
-                            else fetch('/api/v1/auth/logout', { method: 'POST', credentials: 'same-origin' }).then(function() { window.location.href = '/login'; });
-                        });
-                        nav.appendChild(logoutLink);
-                    }
-                }
-            });
-    </script>
+    <script src="../src/js/auth-check.js"></script>
     <div class="container">
       <header role="banner">
         <h1>📊 Statistiken &amp; Analysen</h1>

--- a/src/js/auth-check.js
+++ b/src/js/auth-check.js
@@ -24,6 +24,7 @@
                 logoutLink.addEventListener('click', function(e) {
                     e.preventDefault();
                     if (window.TaskAPI) TaskAPI.logout();
+                    else fetch('/api/v1/auth/logout', { method: 'POST', credentials: 'same-origin' }).then(function() { window.location.href = '/login'; });
                 });
                 if (nav) nav.appendChild(logoutLink);
             }

--- a/src/js/plants.js
+++ b/src/js/plants.js
@@ -1,6 +1,6 @@
 // Plant Library Module
 (function () {
-    const API_BASE = '/api';
+    const API_BASE = '/api/v1';
     let allPlants = [];
     let currentCategory = '';
     let currentSort = 'name-asc';


### PR DESCRIPTION
## Summary
- Inline Auth-Scripts in 5 HTML-Dateien durch externes `auth-check.js` ersetzt
- `auth-check.js` um Logout-Fallback ergänzt (fetch `/api/v1/auth/logout`)
- `plants.js` API-Pfad von `/api` auf `/api/v1` korrigiert

Closes #197

## Test plan
- [x] 160 Tests bestanden
- [ ] Alle Seiten prüfen: Auth-Check funktioniert, Admin/Login behalten eigene Logik