### PR TITLE
fix: Accessibility — Skip-Links, ARIA-Modal, aria-live

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/public/admin.html
+++ b/public/admin.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="../src/css/styles.css" />
   </head>
   <body>
+    <a href="#main" class="skip-to-main">Zum Inhalt springen</a>
     <script nonce="__CSP_NONCE__">
       fetch('/api/v1/auth/status', { credentials: 'same-origin' })
         .then(function(r) { return r.json(); })
@@ -50,7 +51,7 @@
         <a href="/index" class="btn btn-primary nav-action-btn">Neue Aufgabe</a>
       </div>
 
-      <main role="main">
+      <main id="main" role="main">
         <!-- New User Form -->
         <section class="admin-section">
           <div class="admin-form-header">

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="../src/css/styles.css" />
   </head>
   <body>
+    <a href="#main" class="skip-to-main">Zum Inhalt springen</a>
     <script src="../src/js/auth-check.js"></script>
     <div class="container">
       <header role="banner">
@@ -38,20 +39,20 @@
         >
       </div>
 
-      <main role="main">
+      <main id="main" role="main">
         <!-- Statistiken Schnellübersicht -->
         <section class="stats-section">
           <div class="stat-card">
             <h3>Offene Aufgaben</h3>
-            <p class="stat-number" id="statPending">0</p>
+            <p class="stat-number" id="statPending" aria-live="polite">0</p>
           </div>
           <div class="stat-card">
             <h3>Erledigte Aufgaben</h3>
-            <p class="stat-number" id="statCompleted">0</p>
+            <p class="stat-number" id="statCompleted" aria-live="polite">0</p>
           </div>
           <div class="stat-card">
             <h3>Aktive Mitarbeiter</h3>
-            <p class="stat-number" id="statEmployees">0</p>
+            <p class="stat-number" id="statEmployees" aria-live="polite">0</p>
           </div>
         </section>
 

--- a/public/garden.html
+++ b/public/garden.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="../src/css/garden.css" />
   </head>
   <body>
+    <a href="#main" class="skip-to-main">Zum Inhalt springen</a>
     <script nonce="__CSP_NONCE__">
         fetch('/api/v1/auth/status', { credentials: 'same-origin' })
             .then(r => r.json())
@@ -91,7 +92,7 @@
       </div>
 
       <!-- Main content: sidebar + grid -->
-      <div class="garden-main">
+      <div class="garden-main" id="main">
         <!-- Palette sidebar -->
         <aside class="garden-palette" id="gardenPalette" aria-label="Elemente-Palette">
           <!-- Filled dynamically by JS -->

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="../src/css/styles.css" />
   </head>
   <body>
+    <a href="#main" class="skip-to-main">Zum Inhalt springen</a>
     <script nonce="__CSP_NONCE__">
         fetch('/api/v1/auth/status', { credentials: 'same-origin' })
             .then(r => r.json())
@@ -65,7 +66,7 @@
         <a href="/index" class="btn btn-primary nav-action-btn active" aria-current="page">➕ Neue Aufgabe</a>
       </div>
 
-      <main role="main">
+      <main id="main" role="main">
         <!-- Aufgabe hinzufügen -->
         <section class="add-task-section" aria-labelledby="add-task-heading">
           <h2 id="add-task-heading">Neue Aufgabe erstellen</h2>

--- a/public/login.html
+++ b/public/login.html
@@ -15,7 +15,8 @@
     <link rel="stylesheet" href="../src/css/styles.css" />
   </head>
   <body>
-    <div class="login-container">
+    <a href="#main" class="skip-to-main">Zum Inhalt springen</a>
+    <div class="login-container" id="main">
       <div class="login-card">
         <div class="login-header">
           <h1>Gartenplaner</h1>

--- a/public/logs.html
+++ b/public/logs.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="../src/css/styles.css" />
   </head>
   <body>
+    <a href="#main" class="skip-to-main">Zum Inhalt springen</a>
     <script nonce="__CSP_NONCE__">
         fetch('/api/v1/auth/status', { credentials: 'same-origin' })
             .then(r => r.json())
@@ -60,7 +61,7 @@
         </div>
       </header>
 
-      <main>
+      <main id="main">
         <!-- Statistiken -->
         <section class="log-stats" id="logStats" aria-label="Log-Statistiken">
           <div class="stat-item">

--- a/public/plants.html
+++ b/public/plants.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="../src/css/plants.css">
 </head>
 <body>
+    <a href="#main" class="skip-to-main">Zum Inhalt springen</a>
     <script nonce="__CSP_NONCE__">
         fetch('/api/v1/auth/status', { credentials: 'same-origin' })
             .then(r => r.json())
@@ -59,7 +60,7 @@
             <a href="/index" class="btn btn-primary nav-action-btn">➕ Neue Aufgabe</a>
         </div>
 
-        <main>
+        <main id="main">
             <section class="plant-controls">
                 <div class="search-box">
                     <input type="text" id="plantSearch" placeholder="Pflanze suchen..." aria-label="Pflanzen durchsuchen">
@@ -95,7 +96,7 @@
             </section>
 
             <!-- Plant Detail Modal (injected by JS when opened) -->
-            <div class="plant-modal" id="plantModal" hidden>
+            <div class="plant-modal" id="plantModal" hidden role="dialog" aria-modal="true" aria-label="Pflanzendetails">
                 <div class="plant-modal-content" id="plantModalContent"></div>
             </div>
         </main>

--- a/public/statistics.html
+++ b/public/statistics.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="../src/css/styles.css" />
   </head>
   <body>
+    <a href="#main" class="skip-to-main">Zum Inhalt springen</a>
     <script nonce="__CSP_NONCE__">
         fetch('/api/v1/auth/status', { credentials: 'same-origin' })
             .then(r => r.json())
@@ -63,7 +64,7 @@
         >
       </div>
 
-      <main>
+      <main id="main">
         <!-- Time Range Selector & Export -->
         <section class="stats-toolbar">
           <div class="time-range-selector" role="group" aria-label="Zeitraum auswählen">

--- a/src/js/plants.js
+++ b/src/js/plants.js
@@ -282,8 +282,8 @@
         modal.removeAttribute('hidden');
         modal.classList.add('active');
 
-        content.querySelector('.plant-modal-close').addEventListener('click', () => { modal.classList.remove('active'); });
-        modal.addEventListener('click', (e) => { if (e.target === modal) modal.classList.remove('active'); });
+        content.querySelector('.plant-modal-close').addEventListener('click', () => { modal.classList.remove('active'); modal.setAttribute('hidden', ''); });
+        modal.addEventListener('click', (e) => { if (e.target === modal) { modal.classList.remove('active'); modal.setAttribute('hidden', ''); } });
 
         const createBtn = content.querySelector('.plant-create-task-btn');
         if (createBtn) {
@@ -339,7 +339,7 @@
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
                 const modal = document.getElementById('plantModal');
-                if (modal) modal.classList.remove('active');
+                if (modal) { modal.classList.remove('active'); modal.setAttribute('hidden', ''); }
             }
         });
     }


### PR DESCRIPTION
## Summary
- Skip-to-Main-Link in allen 8 HTML-Seiten hinzugefügt (`id="main"` auf Hauptcontainer)
- Plant-Modal: `role="dialog" aria-modal="true" aria-label` ergänzt + hidden-Fix beim Schließen
- Dashboard Stat-Cards: `aria-live="polite"` für Screen-Reader-Updates

Closes #199, closes #201, closes #210

## Test plan
- [x] 160 Tests bestanden
- [ ] Tab-Navigation: Skip-Link erscheint beim ersten Tab-Drücken
- [ ] Plant-Modal: Screen-Reader erkennt Dialog