### PR TITLE
fix: entferne doppeltes logger.js in logs.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/public/logs.html
+++ b/public/logs.html
@@ -223,7 +223,6 @@
     <script src="../src/js/security.js"></script>
     <script src="../src/js/encryption.js"></script>
     <script src="../src/js/rate-limiter.js"></script>
-    <script src="../src/js/logger.js"></script>
     <script src="../src/js/error-handler.js"></script>
     <script src="../src/js/api.js"></script>
     <script src="../src/js/app.js"></script>


### PR DESCRIPTION
## Summary
- `logger.js` wurde in `logs.html` doppelt geladen (Zeile 191 und 226)
- Duplikat entfernt, erstes Vorkommen beibehalten

Closes #200

## Test plan
- [x] 160 Tests bestanden
- [ ] Logs-Seite funktioniert normal, keine doppelte Initialisierung