### PR TITLE
fix: CSP style-src — unsafe-inline statt nonce für dynamische Styles

### DIFF
--- a/src/server/middleware/security.js
+++ b/src/server/middleware/security.js
@@ -22,7 +22,7 @@ function securityHeaders(req, res, next) {
     res.setHeader('Content-Security-Policy', [
         "default-src 'self'",
         `script-src 'self' 'nonce-${nonce}' https://cdnjs.cloudflare.com`,
-        `style-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com`,
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
         "img-src 'self' data:",
         "font-src 'self' https://fonts.gstatic.com",
         "connect-src 'self' https://api.open-meteo.com https://geocoding-api.open-meteo.com",


### PR DESCRIPTION
## Summary
- `task-renderer.js` setzt dynamische inline-Styles via innerHTML (Chart-Balken, Timeline-Bars, SVG-Icons)
- CSP `style-src` hatte einen Nonce der nichts schützte (keine `<style>` Elemente im HTML)
- Nonce durch `'unsafe-inline'` ersetzt — branchenüblich und risikoarm für Styles

## Test plan
- [x] 160 Tests bestanden
- [ ] Dashboard laden — keine CSP-Violations mehr für inline Styles