### PR TITLE
fix: Warnung wenn JWT_SECRET in Produktion nicht gesetzt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -6,6 +6,10 @@ const PORT = process.env.PORT || 3000;
 const JWT_SECRET = process.env.JWT_SECRET || '';
 
 if (require.main === module) {
+    if (process.env.NODE_ENV === 'production' && !JWT_SECRET) {
+        process.stderr.write('\u26a0\ufe0f  WARNUNG: JWT_SECRET ist nicht gesetzt \u2014 Authentifizierung ist deaktiviert!\n');
+    }
+
     migrate().then(() => {
         const server = app.listen(PORT, () => {
             logger.info({ port: PORT, auth: !!JWT_SECRET }, 'Gartenplaner API started');


### PR DESCRIPTION
## Summary
- Startup-Warnung auf stderr wenn `NODE_ENV=production` und `JWT_SECRET` leer ist
- Server crasht nicht, warnt nur deutlich sichtbar
- Version bump 3.0.5 → 3.0.6

Closes #198

## Test plan
- [x] 160 Tests bestanden
- [ ] Server ohne JWT_SECRET starten → Warnung in Konsole sichtbar