### PR TITLE
fix: Log-Seite Farbschema an App-Theme anpassen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/src/css/logs.css
+++ b/src/css/logs.css
@@ -50,7 +50,7 @@
 }
 
 .log-stats {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
   color: white;
   padding: 20px;
   border-radius: var(--radius-lg);
@@ -120,34 +120,34 @@
 }
 
 .log-level.debug {
-  background: #e9ecef;
-  color: #6c757d;
+  background: var(--bg-tertiary);
+  color: var(--text-light);
 }
 
 .log-level.info {
-  background: #d1ecf1;
-  color: #0c5460;
+  background: var(--info-light);
+  color: var(--info);
 }
 
 .log-level.warn {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--warning-light);
+  color: var(--warning);
 }
 
 .log-level.error {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--error-light);
+  color: var(--error);
 }
 
 .log-level.critical {
-  background: #dc3545;
+  background: var(--danger);
   color: white;
 }
 
 .log-category {
   padding: 3px 8px;
-  background: #e7f3ff;
-  color: #06c;
+  background: var(--primary-light);
+  color: var(--primary);
   border-radius: var(--radius-sm);
   font-size: 0.85em;
 }
@@ -251,18 +251,18 @@
 }
 
 .health-healthy {
-  background: #d4edda;
-  color: #155724;
+  background: var(--success-light);
+  color: var(--success);
 }
 
 .health-warning {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--warning-light);
+  color: var(--warning);
 }
 
 .health-critical {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--error-light);
+  color: var(--error);
 }
 
 @media (width <= 768px) {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -4966,7 +4966,7 @@ footer {
 }
 
 .log-stats {
-  background: var(--primary);
+  background: linear-gradient(135deg, var(--primary), var(--primary-dark));
   color: white;
   padding: 20px;
   border-radius: var(--radius-lg);
@@ -5036,34 +5036,34 @@ footer {
 }
 
 .log-level.debug {
-  background: #e9ecef;
-  color: #6c757d;
+  background: var(--bg-tertiary);
+  color: var(--text-light);
 }
 
 .log-level.info {
-  background: #d1ecf1;
-  color: #0c5460;
+  background: var(--info-light);
+  color: var(--info);
 }
 
 .log-level.warn {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--warning-light);
+  color: var(--warning);
 }
 
 .log-level.error {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--error-light);
+  color: var(--error);
 }
 
 .log-level.critical {
-  background: #dc3545;
+  background: var(--danger);
   color: white;
 }
 
 .log-category {
   padding: 4px 14px;
-  background: #ECFDF5;
-  color: #365E3D;
+  background: var(--primary-light);
+  color: var(--primary);
   border-radius: 9999px;
   font-size: 12px;
   font-weight: 500;
@@ -5175,18 +5175,18 @@ footer {
 }
 
 .health-healthy {
-  background: #ECFDF5;
-  color: #166534;
+  background: var(--success-light);
+  color: var(--success);
 }
 
 .health-warning {
-  background: #FEF9C3;
-  color: #854D0E;
+  background: var(--warning-light);
+  color: var(--warning);
 }
 
 .health-critical {
-  background: #FEE2E2;
-  color: #991B1B;
+  background: var(--error-light);
+  color: var(--error);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Lila-Gradient in Log-Stats durch Grün-Gradient (`--primary` → `--primary-dark`) ersetzt
- Log-Level-Badges nutzen jetzt CSS-Variablen statt hardcoded Hex-Farben
- Dark Mode funktioniert automatisch über Theme-Variablen

## Test plan
- [x] 160 Tests bestanden
- [ ] Log-Seite visuell prüfen — grünes Farbschema statt Lila