### PR TITLE
feat: Script-Bundling — 14-16 JS-Requests → 2 pro Seite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Desktop.ini
 *.tmp
 *.temp
 .cache/
+dist/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -50,6 +50,10 @@ const cssBundles = {
     'logs.css': [
         'src/css/styles.css',
         'src/css/logs.css'
+    ],
+    'garden.css': [
+        'src/css/styles.css',
+        'src/css/garden.css'
     ]
 };
 
@@ -146,33 +150,118 @@ const jsBundles = {
         ...sharedJs,
         'src/js/confirm-dialog.js',
         'src/js/app.js'
+    ],
+    // garden.html
+    'garden-bundle.js': [
+        'src/js/garden-planner.js'
     ]
+};
+
+// ── Page → bundle mapping (for HTML rewriting) ─────────────────────
+
+const pageBundleMap = {
+    'index':      { js: 'index-bundle.js',      css: 'styles.css' },
+    'dashboard':  { js: 'dashboard-bundle.js',   css: 'styles.css' },
+    'statistics': { js: 'statistics-bundle.js',   css: 'styles.css' },
+    'plants':     { js: 'plants-bundle.js',       css: 'plants.css' },
+    'logs':       { js: 'logs-bundle.js',         css: 'logs.css' },
+    'login':      { js: 'login-bundle.js',        css: 'styles.css' },
+    'admin':      { js: 'admin-bundle.js',        css: 'styles.css' },
+    'garden':     { js: 'garden-bundle.js',       css: 'garden.css' },
 };
 
 // ── Build ────────────────────────────────────────────────────────────
 
 console.log('Building bundles...\n');
 ensureDir(DIST);
+ensureDir(path.join(DIST, 'js'));
+ensureDir(path.join(DIST, 'css'));
 
 // CSS
 console.log('CSS bundles:');
 for (const [name, files] of Object.entries(cssBundles)) {
     const content = files.map(readSource).join('\n');
-    writeBundle(name, content);
+    writeBundle(path.join('css', name), content);
 }
 
 // JS — concatenate with semicolons between files to avoid ASI issues
 console.log('\nJS bundles:');
 for (const [name, files] of Object.entries(jsBundles)) {
     const content = files.map(readSource).join('\n;\n');
-    writeBundle(name, content);
+    writeBundle(path.join('js', name), content);
+}
+
+// Copy auth-check.js (loaded separately at top of body)
+const authCheckContent = readSource('src/js/auth-check.js');
+if (authCheckContent) writeBundle(path.join('js', 'auth-check.js'), authCheckContent);
+
+// ── HTML processing ─────────────────────────────────────────────────
+// Replace individual <script>/<link> tags with bundled references.
+
+console.log('\nHTML pages:');
+const publicDir = path.join(ROOT, 'public');
+const htmlFiles = fs.readdirSync(publicDir).filter(f => f.endsWith('.html'));
+
+for (const file of htmlFiles) {
+    const pageName = file.replace('.html', '');
+    const mapping = pageBundleMap[pageName];
+    if (!mapping) {
+        // Unknown page — copy as-is
+        const content = fs.readFileSync(path.join(publicDir, file), 'utf8');
+        writeBundle(file, content);
+        continue;
+    }
+
+    let html = fs.readFileSync(path.join(publicDir, file), 'utf8');
+
+    // Replace CSS: ../src/css/styles.css (and page-specific CSS) → /dist/css/bundle.css
+    html = html.replace(
+        /\s*<link\s+rel="stylesheet"\s+href="\.\.\/src\/css\/[^"]+"\s*\/?>[ \t]*/g,
+        ''
+    );
+    // Insert bundled CSS before </head>
+    html = html.replace(
+        '</head>',
+        `    <link rel="stylesheet" href="/dist/css/${mapping.css}">\n  </head>`
+    );
+
+    // Replace JS: ../src/js/auth-check.js → /dist/js/auth-check.js
+    html = html.replace(
+        /(<script\s+src=")\.\.\/src\/js\/auth-check\.js(">\s*<\/script>)/g,
+        '$1/dist/js/auth-check.js$2'
+    );
+
+    // Replace all other ../src/js/*.js script tags with single bundle
+    // Find the FIRST and LAST src/js script tag, replace the whole block
+    const scriptPattern = /^[ \t]*<script\s+src="\.\.\/src\/js\/[^"]+"><\/script>[ \t]*\n?/gm;
+    const matches = [...html.matchAll(scriptPattern)];
+    if (matches.length > 0) {
+        const firstIdx = matches[0].index;
+        const lastMatch = matches[matches.length - 1];
+        const lastIdx = lastMatch.index + lastMatch[0].length;
+        const before = html.slice(0, firstIdx);
+        const after = html.slice(lastIdx);
+        html = before + `    <script src="/dist/js/${mapping.js}"></script>\n` + after;
+    }
+
+    writeBundle(file, html);
 }
 
 // ── Summary ──────────────────────────────────────────────────────────
 
-const allFiles = fs.readdirSync(DIST);
-const totalSize = allFiles.reduce((sum, f) => {
-    return sum + fs.statSync(path.join(DIST, f)).size;
-}, 0);
+const countFiles = (dir) => {
+    if (!fs.existsSync(dir)) return [];
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    let files = [];
+    for (const e of entries) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) files.push(...countFiles(full));
+        else files.push(full);
+    }
+    return files;
+};
+
+const allFiles = countFiles(DIST);
+const totalSize = allFiles.reduce((sum, f) => sum + fs.statSync(f).size, 0);
 
 console.log(`\nBuild complete: ${allFiles.length} files, ${(totalSize / 1024).toFixed(1)} KB total`);

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -23,6 +23,8 @@ const app = express();
 
 // --- Project root for static files ---
 const PROJECT_ROOT = path.join(__dirname, '..', '..');
+const DIST_DIR = path.join(PROJECT_ROOT, 'dist');
+const USE_BUNDLES = process.env.NODE_ENV === 'production' && fs.existsSync(DIST_DIR);
 
 // --- Middleware (order preserved exactly) ---
 
@@ -70,9 +72,14 @@ app.use('/api/v1', generalLimiter);
 
 // --- Static file serving (replaces nginx) ---
 
+// Serve bundled assets from dist/ in production (long cache — content is versioned by build)
+if (USE_BUNDLES) {
+    app.use('/dist', express.static(DIST_DIR, { maxAge: '7d' }));
+}
+
 app.use('/public', express.static(path.join(PROJECT_ROOT, 'public'), { maxAge: '1d' }));
 
-// Serve /src (CSS/JS needed in production since HTML references ../src/)
+// Serve /src (CSS/JS needed in dev since HTML references ../src/)
 app.use('/src', express.static(path.join(PROJECT_ROOT, 'src'), { maxAge: '1d' }));
 
 // #115: /tests and /docs only in development
@@ -82,19 +89,22 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 // HTML page routes (with and without .html extension)
+// In production with bundles, serve pre-processed HTML from dist/
+const HTML_ROOT = USE_BUNDLES ? DIST_DIR : path.join(PROJECT_ROOT, 'public');
+
 const pages = ['index', 'dashboard', 'statistics', 'logs', 'plants', 'garden', 'login', 'admin'];
 pages.forEach(page => {
     app.get(`/${page}`, (req, res) => {
-        res.sendFile(path.join(PROJECT_ROOT, 'public', `${page}.html`));
+        res.sendFile(path.join(HTML_ROOT, `${page}.html`));
     });
     app.get(`/${page}.html`, (req, res) => {
-        res.sendFile(path.join(PROJECT_ROOT, 'public', `${page}.html`));
+        res.sendFile(path.join(HTML_ROOT, `${page}.html`));
     });
 });
 
 // Root -> index.html
 app.get('/', (req, res) => {
-    res.sendFile(path.join(PROJECT_ROOT, 'public', 'index.html'));
+    res.sendFile(path.join(HTML_ROOT, 'index.html'));
 });
 
 // Stricter rate limit on write operations


### PR DESCRIPTION
## Summary
- `build.js` erzeugt jetzt JS/CSS-Bundles + verarbeitete HTML-Dateien in `dist/`
- In Production: 2 Script-Tags (auth-check + page-bundle) statt 14-16
- In Dev: Keine Änderung, weiterhin Einzeldateien für einfaches Debugging
- Server erkennt automatisch ob `dist/` vorhanden ist
- Garden-Bundle + CSS-Bundle ergänzt

**Vorher:** Dashboard lädt 16 JS-Dateien (16 HTTP-Requests)
**Nachher:** Dashboard lädt 2 JS-Dateien (auth-check.js + dashboard-bundle.js)

Closes #206

## Test plan
- [x] Tests bestanden
- [x] `node scripts/build.js` erzeugt 31 Dateien (8 HTML, 9 JS, 4 CSS + Unterordner)
- [x] Generierte HTML-Dateien haben korrekte Bundle-Referenzen
- [ ] Docker-Build testen: `docker build .` + App starten