### PR TITLE
feat: Fotos zu Aufgaben hinzufügen

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -84,7 +84,14 @@
       "Bash(node -e \"const p = require\\(''./package-lock.json''\\); const pkg = p.packages[''node_modules/picomatch'']; console.log\\(JSON.stringify\\(pkg, null, 2\\)\\);\")",
       "Bash(npm pack:*)",
       "Bash(cmd //c \"mklink /J \"\"C:\\\\Git\\\\GardenPlanner\\\\.claude\\\\worktrees\\\\agent-a2cf477e\\\\node_modules\"\" \"\"C:\\\\Git\\\\GardenPlanner\\\\.claude\\\\worktrees\\\\agent-a9c844b1\\\\node_modules\"\"\")",
-      "Bash(cmd.exe /c 'mklink /J node_modules \"\"C:\\\\Git\\\\GardenPlanner\\\\.claude\\\\worktrees\\\\agent-a9c844b1\\\\node_modules\"\"')"
+      "Bash(cmd.exe /c 'mklink /J node_modules \"\"C:\\\\Git\\\\GardenPlanner\\\\.claude\\\\worktrees\\\\agent-a9c844b1\\\\node_modules\"\"')",
+      "Bash(GIT_EDITOR=true git rebase --continue)",
+      "Bash(npm update:*)",
+      "Bash(sed -i 's|https://repo.inform-software.com/artifactory/api/npm/npmjs/|https://registry.npmjs.org/|g' package-lock.json)",
+      "Bash(sed -i 's|http://repo.inform-software.com/artifactory/api/npm/npmjs/|https://registry.npmjs.org/|g' package-lock.json)",
+      "Bash(grep -l:*)",
+      "Bash(echo \"exit: $?\")",
+      "Bash(node scripts/build.js)"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "1.0.0",
+  "version": "3.1.0",
   "description": "Gartenplaner - Garden task management with REST API",
   "main": "server.js",
   "scripts": {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -380,6 +380,31 @@
             </div>
           </div>
 
+          <!-- Photo Upload in Edit Modal -->
+          <div class="form-group">
+            <label>Fotos <span class="optional-label">(max. 3)</span></label>
+            <div class="photo-upload-area" id="photoUploadAreaEdit">
+              <div id="photoPreviewEdit" class="photo-preview-list"></div>
+              <input
+                type="file"
+                id="photoInputEdit"
+                accept="image/*"
+                capture="environment"
+                multiple
+                class="photo-input"
+                aria-label="Fotos hinzufuegen"
+              />
+              <label for="photoInputEdit" class="photo-upload-label" id="photoUploadLabelEdit">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+                  <circle cx="8.5" cy="8.5" r="1.5"/>
+                  <polyline points="21 15 16 10 5 21"/>
+                </svg>
+                <span>Foto hinzufuegen</span>
+              </label>
+            </div>
+          </div>
+
           <div class="modal-actions">
             <button type="button" class="btn btn-secondary" id="cancelEditBtn">
               Abbrechen
@@ -417,6 +442,12 @@
           </button>
         </div>
       </div>
+    </div>
+
+    <!-- Photo Lightbox -->
+    <div id="photoLightbox" class="photo-lightbox" role="dialog" aria-modal="true" aria-label="Foto-Ansicht" aria-hidden="true">
+      <button class="photo-lightbox-close" aria-label="Foto schliessen">&times;</button>
+      <img id="photoLightboxImg" class="photo-lightbox-img" src="" alt="Foto Grossansicht" />
     </div>
 
     <!-- Dark Mode Toggle -->

--- a/public/index.html
+++ b/public/index.html
@@ -96,6 +96,31 @@
               </div>
             </div>
 
+            <!-- Photo Upload -->
+            <div class="form-group">
+              <label>Fotos <span class="optional-label">(optional, max. 3)</span></label>
+              <div class="photo-upload-area" id="photoUploadAreaCreate">
+                <input
+                  type="file"
+                  id="photoInputCreate"
+                  accept="image/*"
+                  capture="environment"
+                  multiple
+                  class="photo-input"
+                  aria-label="Fotos hinzufuegen"
+                />
+                <label for="photoInputCreate" class="photo-upload-label">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+                    <circle cx="8.5" cy="8.5" r="1.5"/>
+                    <polyline points="21 15 16 10 5 21"/>
+                  </svg>
+                  <span>Fotos auswaehlen oder Kamera nutzen</span>
+                </label>
+                <div id="photoPreviewCreate" class="photo-preview-list"></div>
+              </div>
+            </div>
+
             <!-- Collapsible optional section -->
             <details class="form-options" id="formOptions">
               <summary class="form-options-toggle">

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -5140,3 +5140,216 @@ footer {
     width: 100%;
   }
 }
+
+/* ==========================================
+   Photo Upload & Thumbnails
+   ========================================== */
+
+.photo-upload-area {
+  border: 2px dashed var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.photo-upload-area:hover {
+  border-color: var(--primary);
+}
+
+[data-theme="dark"] .photo-upload-area {
+  border-color: var(--border-light);
+}
+
+[data-theme="dark"] .photo-upload-area:hover {
+  border-color: var(--primary);
+}
+
+.photo-input {
+  display: none;
+}
+
+.photo-upload-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  cursor: pointer;
+  color: var(--text-light);
+  font-size: var(--text-sm);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.photo-upload-label:hover {
+  color: var(--primary);
+  background: rgba(27, 94, 63, 0.06);
+}
+
+[data-theme="dark"] .photo-upload-label:hover {
+  background: rgba(74, 222, 128, 0.1);
+}
+
+.photo-upload-label svg {
+  flex-shrink: 0;
+}
+
+.photo-preview-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.photo-preview-list:empty {
+  margin-bottom: 0;
+}
+
+.photo-preview-item {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 2px solid var(--border);
+  flex-shrink: 0;
+}
+
+[data-theme="dark"] .photo-preview-item {
+  border-color: var(--border-light);
+}
+
+.photo-preview-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.photo-remove-btn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.65);
+  color: white;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: background-color 0.2s ease;
+}
+
+.photo-remove-btn:hover {
+  background: var(--error);
+}
+
+/* Task Card Photo Thumbnails */
+.task-photo-thumbnails {
+  display: flex;
+  gap: 6px;
+  margin-top: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.task-photo-thumbnail {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+  cursor: pointer;
+  border: 2px solid var(--border);
+  transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.task-photo-thumbnail:hover {
+  transform: scale(1.1);
+  border-color: var(--primary);
+  box-shadow: var(--shadow-md);
+}
+
+[data-theme="dark"] .task-photo-thumbnail {
+  border-color: var(--border-light);
+}
+
+[data-theme="dark"] .task-photo-thumbnail:hover {
+  border-color: var(--primary);
+}
+
+/* Photo Lightbox */
+.photo-lightbox {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.85);
+  z-index: 10001;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xl);
+}
+
+.photo-lightbox-close {
+  position: absolute;
+  top: var(--space-lg);
+  right: var(--space-lg);
+  width: 44px;
+  height: 44px;
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  font-size: 28px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease;
+  z-index: 1;
+}
+
+.photo-lightbox-close:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.photo-lightbox-img {
+  max-width: 90vw;
+  max-height: 85vh;
+  object-fit: contain;
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+/* Responsive Photo Adjustments */
+@media (max-width: 768px) {
+  .photo-preview-item {
+    width: 64px;
+    height: 64px;
+  }
+
+  .task-photo-thumbnail {
+    width: 40px;
+    height: 40px;
+  }
+
+  .photo-lightbox {
+    padding: var(--space-md);
+  }
+
+  .photo-lightbox-close {
+    top: var(--space-sm);
+    right: var(--space-sm);
+  }
+
+  .photo-lightbox-img {
+    max-width: 95vw;
+    max-height: 90vh;
+  }
+}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -18,6 +18,7 @@ class GartenPlaner {
 		this.selectedTasks = new Set();
 		this.bulkMode = false;
 		this.tempSubtasks = [];
+		this.tempPhotos = [];
 		this.useAPI = typeof window.TaskAPI !== "undefined";
 		this.undoStack = [];
 		this.undoTimeout = null;

--- a/src/js/task-events.js
+++ b/src/js/task-events.js
@@ -99,6 +99,10 @@ GartenPlaner.prototype.setupEventListeners = function () {
 	if (toggleArchiveBtn) {
 		toggleArchiveBtn.addEventListener("click", () => this.toggleArchiveView());
 	}
+
+	// Photo Upload (Create Form)
+	this.tempPhotos = [];
+	this.setupPhotoUploadCreate();
 };
 
 // Bulk Action Listeners
@@ -241,6 +245,9 @@ GartenPlaner.prototype.openEditModal = function (id) {
 
 	// Subtask Event Listeners (NACH dem replaceWith)
 	this.setupSubtaskListeners(task);
+
+	// Photo Upload im Edit-Modal einrichten
+	this.setupPhotoUploadEdit(task);
 
 	newCloseBtn.addEventListener("click", closeModal);
 	newCancelBtn.addEventListener("click", closeModal);

--- a/src/js/task-renderer.js
+++ b/src/js/task-renderer.js
@@ -88,6 +88,14 @@ GartenPlaner.prototype.renderTasks = function () {
 				}
 			});
 
+			// Photo thumbnail click handlers
+			card.querySelectorAll(".task-photo-thumbnail").forEach((thumb) => {
+				thumb.addEventListener("click", (e) => {
+					e.stopPropagation();
+					this.openPhotoLightbox(thumb.src);
+				});
+			});
+
 			// Drag & Drop Event Listeners (nur für aktive Aufgaben und nicht auf mobilen Geräten)
 			var isMobile = window.innerWidth <= 768;
 			if (!isMobile) {
@@ -152,6 +160,7 @@ GartenPlaner.prototype.createTaskCard = function (task) {
                 </div>
                 ${safeDescription ? `<div class="task-description">${safeDescription}</div>` : ""}
                 ${this.renderSubtasksProgress(task)}
+                ${this.renderPhotoThumbnails(task)}
             </div>
             <div class="task-actions" role="group" aria-label="Aufgaben-Aktionen">
                 ${
@@ -854,6 +863,267 @@ GartenPlaner.prototype.renderSubtasksProgress = function (task) {
             </div>
         </div>
     `;
+};
+
+// ===== PHOTO METHODS =====
+
+GartenPlaner.prototype.renderPhotoThumbnails = function (task) {
+	if (!task.photos || task.photos.length === 0) {
+		return "";
+	}
+
+	var thumbnails = task.photos
+		.map(
+			(photo, index) =>
+				`<img src="${photo}" alt="Foto ${index + 1}" class="task-photo-thumbnail" data-task-id="${task.id}" data-photo-index="${index}" />`,
+		)
+		.join("");
+
+	return `<div class="task-photo-thumbnails">${thumbnails}</div>`;
+};
+
+GartenPlaner.prototype.openPhotoLightbox = function (src) {
+	var lightbox = document.getElementById("photoLightbox");
+	var img = document.getElementById("photoLightboxImg");
+	if (!lightbox || !img) return;
+
+	img.src = src;
+	lightbox.style.display = "flex";
+	lightbox.setAttribute("aria-hidden", "false");
+
+	var closeBtn = lightbox.querySelector(".photo-lightbox-close");
+	var closeLightbox = function () {
+		lightbox.style.display = "none";
+		lightbox.setAttribute("aria-hidden", "true");
+		img.src = "";
+	};
+
+	// Remove old listeners by cloning
+	var newCloseBtn = closeBtn.cloneNode(true);
+	closeBtn.replaceWith(newCloseBtn);
+	newCloseBtn.addEventListener("click", closeLightbox);
+
+	lightbox.addEventListener(
+		"click",
+		function (e) {
+			if (e.target === lightbox) {
+				closeLightbox();
+			}
+		},
+		{ once: true },
+	);
+
+	var handleKey = function (e) {
+		if (e.key === "Escape") {
+			closeLightbox();
+			lightbox.removeEventListener("keydown", handleKey);
+		}
+	};
+	lightbox.addEventListener("keydown", handleKey);
+	document.addEventListener(
+		"keydown",
+		function (e) {
+			if (e.key === "Escape" && lightbox.style.display === "flex") {
+				closeLightbox();
+			}
+		},
+		{ once: true },
+	);
+};
+
+GartenPlaner.prototype.processPhotoFile = function (file) {
+	return new Promise(function (resolve, reject) {
+		if (!file || !file.type.startsWith("image/")) {
+			reject(new Error("Keine gueltige Bilddatei"));
+			return;
+		}
+
+		var reader = new FileReader();
+		reader.onload = function (e) {
+			var img = new Image();
+			img.onload = function () {
+				var canvas = document.createElement("canvas");
+				var maxWidth = 800;
+				var width = img.width;
+				var height = img.height;
+
+				if (width > maxWidth) {
+					height = Math.round((height * maxWidth) / width);
+					width = maxWidth;
+				}
+
+				canvas.width = width;
+				canvas.height = height;
+				var ctx = canvas.getContext("2d");
+				ctx.drawImage(img, 0, 0, width, height);
+
+				var dataUrl = canvas.toDataURL("image/jpeg", 0.7);
+				resolve(dataUrl);
+			};
+			img.onerror = function () {
+				reject(new Error("Bild konnte nicht geladen werden"));
+			};
+			img.src = e.target.result;
+		};
+		reader.onerror = function () {
+			reject(new Error("Datei konnte nicht gelesen werden"));
+		};
+		reader.readAsDataURL(file);
+	});
+};
+
+GartenPlaner.prototype.setupPhotoUploadCreate = function () {
+	var self = this;
+	var input = document.getElementById("photoInputCreate");
+	if (!input) return;
+
+	// Clone to remove old listeners
+	var newInput = input.cloneNode(true);
+	input.replaceWith(newInput);
+
+	newInput.addEventListener("change", async function (e) {
+		var files = Array.from(e.target.files);
+		var currentCount = self.tempPhotos ? self.tempPhotos.length : 0;
+		var remaining = 3 - currentCount;
+
+		if (files.length > remaining) {
+			self.showNotification(
+				"Maximal 3 Fotos erlaubt. " + remaining + " noch moeglich.",
+				"error",
+			);
+			files = files.slice(0, remaining);
+		}
+
+		for (var i = 0; i < files.length; i++) {
+			try {
+				var dataUrl = await self.processPhotoFile(files[i]);
+				if (!self.tempPhotos) self.tempPhotos = [];
+				self.tempPhotos.push(dataUrl);
+			} catch (err) {
+				self.showNotification("Fehler beim Verarbeiten: " + err.message, "error");
+			}
+		}
+
+		self.renderPhotoPreviewCreate();
+		newInput.value = "";
+	});
+};
+
+GartenPlaner.prototype.renderPhotoPreviewCreate = function () {
+	var container = document.getElementById("photoPreviewCreate");
+	if (!container) return;
+
+	if (!this.tempPhotos || this.tempPhotos.length === 0) {
+		container.innerHTML = "";
+		// Show upload label
+		var label = document.querySelector('label[for="photoInputCreate"]');
+		if (label) label.style.display = "";
+		return;
+	}
+
+	var self = this;
+	container.innerHTML = this.tempPhotos
+		.map(function (photo, index) {
+			return (
+				'<div class="photo-preview-item">' +
+				'<img src="' + photo + '" alt="Vorschau ' + (index + 1) + '" />' +
+				'<button type="button" class="photo-remove-btn" data-photo-index="' + index + '" aria-label="Foto entfernen">&times;</button>' +
+				"</div>"
+			);
+		})
+		.join("");
+
+	// Hide upload label if max reached
+	var label = document.querySelector('label[for="photoInputCreate"]');
+	if (label) {
+		label.style.display = this.tempPhotos.length >= 3 ? "none" : "";
+	}
+
+	container.querySelectorAll(".photo-remove-btn").forEach(function (btn) {
+		btn.addEventListener("click", function () {
+			var idx = parseInt(btn.dataset.photoIndex);
+			self.tempPhotos.splice(idx, 1);
+			self.renderPhotoPreviewCreate();
+		});
+	});
+};
+
+GartenPlaner.prototype.setupPhotoUploadEdit = function (task) {
+	var self = this;
+	var input = document.getElementById("photoInputEdit");
+	if (!input) return;
+
+	// Initialize edit photos from task
+	this.editPhotos = task.photos ? task.photos.slice() : [];
+
+	// Clone to remove old listeners
+	var newInput = input.cloneNode(true);
+	input.replaceWith(newInput);
+
+	newInput.addEventListener("change", async function (e) {
+		var files = Array.from(e.target.files);
+		var remaining = 3 - self.editPhotos.length;
+
+		if (files.length > remaining) {
+			self.showNotification(
+				"Maximal 3 Fotos erlaubt. " + remaining + " noch moeglich.",
+				"error",
+			);
+			files = files.slice(0, remaining);
+		}
+
+		for (var i = 0; i < files.length; i++) {
+			try {
+				var dataUrl = await self.processPhotoFile(files[i]);
+				self.editPhotos.push(dataUrl);
+			} catch (err) {
+				self.showNotification("Fehler beim Verarbeiten: " + err.message, "error");
+			}
+		}
+
+		self.renderPhotoPreviewEdit();
+		newInput.value = "";
+	});
+
+	this.renderPhotoPreviewEdit();
+};
+
+GartenPlaner.prototype.renderPhotoPreviewEdit = function () {
+	var container = document.getElementById("photoPreviewEdit");
+	if (!container) return;
+
+	if (!this.editPhotos || this.editPhotos.length === 0) {
+		container.innerHTML = "";
+		var label = document.getElementById("photoUploadLabelEdit");
+		if (label) label.style.display = "";
+		return;
+	}
+
+	var self = this;
+	container.innerHTML = this.editPhotos
+		.map(function (photo, index) {
+			return (
+				'<div class="photo-preview-item">' +
+				'<img src="' + photo + '" alt="Foto ' + (index + 1) + '" />' +
+				'<button type="button" class="photo-remove-btn" data-photo-index="' + index + '" aria-label="Foto entfernen">&times;</button>' +
+				"</div>"
+			);
+		})
+		.join("");
+
+	// Hide upload label if max reached
+	var label = document.getElementById("photoUploadLabelEdit");
+	if (label) {
+		label.style.display = this.editPhotos.length >= 3 ? "none" : "";
+	}
+
+	container.querySelectorAll(".photo-remove-btn").forEach(function (btn) {
+		btn.addEventListener("click", function () {
+			var idx = parseInt(btn.dataset.photoIndex);
+			self.editPhotos.splice(idx, 1);
+			self.renderPhotoPreviewEdit();
+		});
+	});
 };
 
 GartenPlaner.prototype.updateBulkToolbar = function () {

--- a/src/js/task-state.js
+++ b/src/js/task-state.js
@@ -61,6 +61,8 @@ GartenPlaner.prototype.addTask = async function () {
 			return;
 		}
 
+		var photos = this.tempPhotos ? this.tempPhotos.slice() : [];
+
 		let task;
 		if (this.useAPI) {
 			task = await TaskAPI.createTask({
@@ -69,6 +71,7 @@ GartenPlaner.prototype.addTask = async function () {
 					text: st.text,
 					completed: st.completed,
 				})),
+				photos: photos,
 			});
 		} else {
 			task = {
@@ -77,6 +80,7 @@ GartenPlaner.prototype.addTask = async function () {
 				createdAt: new Date().toISOString(),
 				history: [],
 				subtasks: [...this.tempSubtasks],
+				photos: photos,
 			};
 			this.addHistoryEntry(task, "created", {
 				title: task.title,
@@ -98,7 +102,9 @@ GartenPlaner.prototype.addTask = async function () {
 		}
 
 		this.tempSubtasks = [];
+		this.tempPhotos = [];
 		this.renderCreateSubtasksList();
+		this.renderPhotoPreviewCreate();
 
 		setTimeout(() => {
 			const newTaskElement = document.querySelector(
@@ -276,6 +282,10 @@ GartenPlaner.prototype.saveEditedTask = async function (id) {
 		task.employee = taskData.employee;
 		task.location = taskData.location;
 		task.description = taskData.description;
+		// Update photos
+		if (this.editPhotos !== undefined) {
+			task.photos = this.editPhotos.slice();
+		}
 		const changes = [];
 		if (oldTitle !== task.title)
 			changes.push(`Titel: "${oldTitle}" \u2192 "${task.title}"`);
@@ -286,7 +296,7 @@ GartenPlaner.prototype.saveEditedTask = async function (id) {
 		if (oldDescription !== task.description)
 			changes.push("Beschreibung ge\u00e4ndert");
 		if (this.useAPI) {
-			await TaskAPI.updateTask(id, taskData);
+			await TaskAPI.updateTask(id, { ...taskData, photos: task.photos });
 		} else if (changes.length > 0) {
 			this.addHistoryEntry(task, "edited", { changes: changes });
 		}

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -25,7 +25,7 @@ const PROJECT_ROOT = path.join(__dirname, '..', '..');
 // --- Middleware (order preserved exactly) ---
 
 app.use(compression());
-app.use(express.json({ limit: '100kb' }));
+app.use(express.json({ limit: '5mb' }));
 
 // Security headers
 app.use(securityHeaders);

--- a/src/server/services/task-service.js
+++ b/src/server/services/task-service.js
@@ -109,6 +109,7 @@ async function createTask(body) {
             text: typeof st === 'string' ? st : (st.text || ''),
             completed: typeof st === 'object' ? !!st.completed : false
         })) : [],
+        photos: Array.isArray(sanitized.photos) ? sanitized.photos.filter(p => typeof p === 'string' && p.startsWith('data:image/')).slice(0, 3) : [],
         sortOrder: Date.now()
     };
 
@@ -178,6 +179,9 @@ async function updateTask(id, body) {
                 text: typeof st === 'string' ? st : (st.text || ''),
                 completed: typeof st === 'object' ? !!st.completed : false
             })) : [];
+        }
+        if (sanitized.photos !== undefined) {
+            task.photos = Array.isArray(sanitized.photos) ? sanitized.photos.filter(p => typeof p === 'string' && p.startsWith('data:image/')).slice(0, 3) : [];
         }
 
         if (changes.length > 0) {

--- a/src/server/validation/task-validator.js
+++ b/src/server/validation/task-validator.js
@@ -82,6 +82,24 @@ function validateTask(taskData, partial = false) {
             });
         }
     }
+    if (taskData.photos !== undefined) {
+        if (!Array.isArray(taskData.photos)) {
+            errors.push('Fotos m\u00fcssen ein Array sein');
+        } else {
+            if (taskData.photos.length > 3) {
+                errors.push('Maximal 3 Fotos erlaubt');
+            }
+            taskData.photos.forEach((photo, i) => {
+                if (typeof photo !== 'string') {
+                    errors.push(`Foto ${i + 1}: muss ein String (Data-URL) sein`);
+                } else if (!photo.startsWith('data:image/')) {
+                    errors.push(`Foto ${i + 1}: muss eine g\u00fcltige Bild-Data-URL sein`);
+                } else if (photo.length > 1500000) {
+                    errors.push(`Foto ${i + 1}: darf maximal ca. 1 MB gro\u00df sein`);
+                }
+            });
+        }
+    }
 
     return { valid: errors.length === 0, errors };
 }
@@ -107,6 +125,7 @@ function sanitizeTaskData(data) {
     if (data.priority !== undefined) sanitized.priority = data.priority;
     if (data.recurrence !== undefined) sanitized.recurrence = data.recurrence;
     if (data.subtasks !== undefined) sanitized.subtasks = data.subtasks;
+    if (data.photos !== undefined) sanitized.photos = data.photos;
     return sanitized;
 }
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -158,6 +158,50 @@ describe('validateTask', () => {
         const result = validateTask({ ...validTask, subtasks });
         expect(result.valid).toBe(true);
     });
+
+    // --- Photo validation ---
+
+    test('accepts valid photos array', () => {
+        const photos = ['data:image/jpeg;base64,/9j/4AAQ'];
+        const result = validateTask({ ...validTask, photos });
+        expect(result.valid).toBe(true);
+    });
+
+    test('accepts empty photos array', () => {
+        const result = validateTask({ ...validTask, photos: [] });
+        expect(result.valid).toBe(true);
+    });
+
+    test('rejects photos that is not an array', () => {
+        const result = validateTask({ ...validTask, photos: 'not-an-array' });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('Array')]));
+    });
+
+    test('rejects more than 3 photos', () => {
+        const photos = Array.from({ length: 4 }, () => 'data:image/jpeg;base64,/9j/4AAQ');
+        const result = validateTask({ ...validTask, photos });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('3')]));
+    });
+
+    test('rejects photo that is not a string', () => {
+        const result = validateTask({ ...validTask, photos: [123] });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('String')]));
+    });
+
+    test('rejects photo without data:image/ prefix', () => {
+        const result = validateTask({ ...validTask, photos: ['not-a-data-url'] });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('Data-URL')]));
+    });
+
+    test('accepts exactly 3 photos', () => {
+        const photos = Array.from({ length: 3 }, () => 'data:image/jpeg;base64,/9j/4AAQ');
+        const result = validateTask({ ...validTask, photos });
+        expect(result.valid).toBe(true);
+    });
 });
 
 // --- Unit Tests: escapeHtml ---
@@ -227,6 +271,17 @@ describe('sanitizeTaskData', () => {
         expect(result.description).toBe('Use "quotes" & ampersands');
         expect(result.notes).toBe('<script>alert("xss")</script>');
     });
+
+    test('passes through photos array', () => {
+        const photos = ['data:image/jpeg;base64,/9j/4AAQ'];
+        const result = sanitizeTaskData({ photos });
+        expect(result.photos).toEqual(photos);
+    });
+
+    test('does not include photos when not provided', () => {
+        const result = sanitizeTaskData({ title: 'Test' });
+        expect(result).not.toHaveProperty('photos');
+    });
 });
 
 // --- Integration Tests: API Endpoints ---
@@ -258,6 +313,26 @@ describe('API Endpoints', () => {
 
             expect(res.status).toBe(400);
             expect(res.body).toHaveProperty('errors');
+        });
+
+        test('creates a task with photos', async () => {
+            const photos = ['data:image/jpeg;base64,/9j/4AAQ', 'data:image/png;base64,iVBOR'];
+            const res = await request(app)
+                .post('/api/tasks')
+                .send({ ...validTask, photos });
+
+            expect(res.status).toBe(201);
+            expect(res.body.photos).toHaveLength(2);
+            expect(res.body.photos[0]).toBe('data:image/jpeg;base64,/9j/4AAQ');
+        });
+
+        test('creates a task with empty photos array', async () => {
+            const res = await request(app)
+                .post('/api/tasks')
+                .send({ ...validTask, photos: [] });
+
+            expect(res.status).toBe(201);
+            expect(res.body.photos).toEqual([]);
         });
     });
 
@@ -346,6 +421,18 @@ describe('API Endpoints', () => {
             expect(res.body.subtasks[1]).toHaveProperty('id');
             expect(res.body.subtasks[1].text).toBe('String subtask');
             expect(res.body.subtasks[1].completed).toBe(false);
+        });
+
+        test('updates photos on a task', async () => {
+            const created = await request(app).post('/api/tasks').send(validTask);
+            const photos = ['data:image/jpeg;base64,/9j/4AAQ'];
+            const res = await request(app)
+                .put(`/api/tasks/${created.body.id}`)
+                .send({ photos });
+
+            expect(res.status).toBe(200);
+            expect(res.body.photos).toHaveLength(1);
+            expect(res.body.photos[0]).toBe('data:image/jpeg;base64,/9j/4AAQ');
         });
 
         test('rejects subtasks exceeding max count via PUT', async () => {


### PR DESCRIPTION
## Summary
- Foto-Upload bei Erstellung und Bearbeitung (max 3 Bilder)
- Automatische Kompression (800px, JPEG 0.7)
- Thumbnails in Task-Cards mit Lightbox-Ansicht
- Kamera-Support auf Mobilgeräten (capture="environment")
- Backend-Validierung + DB-Migration (photos als JSONB)
- Version 3.1.0

Closes #230

## Test plan
- [x] Tests für Validierung und API-Endpoints
- [ ] Foto hochladen bei neuer Aufgabe
- [ ] Foto nachträglich hinzufügen/entfernen
- [ ] Mobile: Kamera-Aufnahme testen
- [ ] Lightbox öffnen/schließen