### PR TITLE
refactor: Foto-Storage optimieren — Base64 → Datei (#240)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 # Node
 node_modules/
 
-# Data directory (runtime storage)
+# Data directory (runtime storage, includes photos and logs)
 data/
 
 # Build outputs

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY README.md ./
 RUN node scripts/build.js
 
 # Datenverzeichnis erstellen und Rechte setzen
-RUN mkdir -p /app/data /app/data/logs && chown -R node:node /app
+RUN mkdir -p /app/data /app/data/logs /app/data/photos /app/data/photos/thumbs && chown -R node:node /app
 
 # Non-root User verwenden
 USER node

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "node --watch server.js",
     "test": "jest --verbose --forceExit --detectOpenHandles",
     "migrate": "node scripts/migrate.js",
+    "migrate-photos": "node scripts/migrate-photos.js",
     "seed-admin": "node scripts/seed-admin.js",
     "build": "node scripts/build.js"
   },
@@ -17,9 +18,11 @@
     "express": "^4.21.0",
     "express-rate-limit": "^8.3.1",
     "jsonwebtoken": "^9.0.3",
+    "multer": "^1.4.5-lts.1",
     "pg": "^8.20.0",
     "pino": "^9.14.0",
     "pino-pretty": "^13.1.3",
+    "sharp": "^0.33.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/scripts/migrate-photos.js
+++ b/scripts/migrate-photos.js
@@ -1,0 +1,89 @@
+/**
+ * Migration script: Convert existing Base64 photos in the database to file-based storage.
+ *
+ * What it does:
+ * 1. Reads all tasks that have Base64 data URLs in their photos array
+ * 2. Extracts the Base64 data, writes it to data/photos/ as files
+ * 3. Generates thumbnails in data/photos/thumbs/
+ * 4. Updates the DB to store filenames instead of Base64 strings
+ *
+ * Usage: node scripts/migrate-photos.js
+ * Requires DATABASE_URL environment variable.
+ */
+
+const { query, close } = require('../src/server/storage/db');
+const { saveBase64Photo, ensureDirectories } = require('../src/server/services/photo-service');
+
+async function migratePhotos() {
+    if (!process.env.DATABASE_URL) {
+        console.error('DATABASE_URL environment variable is not set.');
+        process.exit(1);
+    }
+
+    ensureDirectories();
+
+    console.log('Migrating Base64 photos to file storage...');
+
+    // Find all tasks with photos that contain Base64 data URLs
+    const { rows } = await query(
+        "SELECT id, photos FROM tasks WHERE photos IS NOT NULL AND photos::text LIKE '%data:image/%'"
+    );
+
+    if (rows.length === 0) {
+        console.log('No tasks with Base64 photos found. Nothing to migrate.');
+        return;
+    }
+
+    console.log(`Found ${rows.length} task(s) with Base64 photos.`);
+
+    let totalConverted = 0;
+    let totalFailed = 0;
+
+    for (const row of rows) {
+        const photos = row.photos || [];
+        const newPhotos = [];
+        let changed = false;
+
+        for (const photo of photos) {
+            if (typeof photo === 'string' && photo.startsWith('data:image/')) {
+                // This is a Base64 photo - convert to file
+                const filename = await saveBase64Photo(photo);
+                if (filename) {
+                    newPhotos.push(filename);
+                    totalConverted++;
+                    changed = true;
+                } else {
+                    // Keep the original if conversion failed
+                    newPhotos.push(photo);
+                    totalFailed++;
+                    console.warn(`  Warning: Failed to convert a photo in task ${row.id}`);
+                }
+            } else {
+                // Already a filename reference - keep it
+                newPhotos.push(photo);
+            }
+        }
+
+        if (changed) {
+            await query('UPDATE tasks SET photos = $1, updated_at = NOW() WHERE id = $2', [
+                JSON.stringify(newPhotos),
+                row.id,
+            ]);
+            console.log(`  Task ${row.id}: converted ${newPhotos.length} photo(s)`);
+        }
+    }
+
+    console.log(`\nMigration complete: ${totalConverted} photo(s) converted, ${totalFailed} failed.`);
+}
+
+if (require.main === module) {
+    migratePhotos()
+        .then(() => close())
+        .catch(err => {
+            console.error('Photo migration failed:', err);
+            close();
+            process.exit(1);
+        });
+}
+
+module.exports = { migratePhotos };

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -43,12 +43,26 @@ async function migrate() {
             recurrence VARCHAR(20) DEFAULT 'none',
             subtasks JSONB DEFAULT '[]',
             history JSONB DEFAULT '[]',
+            photos JSONB DEFAULT '[]',
             sort_order BIGINT DEFAULT extract(epoch from now()) * 1000,
             completed_at TIMESTAMPTZ,
             archived_at TIMESTAMPTZ,
             created_at TIMESTAMPTZ DEFAULT NOW(),
             updated_at TIMESTAMPTZ DEFAULT NOW()
         )
+    `);
+
+    // Add photos column if it doesn't exist (for existing databases)
+    await query(`
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'tasks' AND column_name = 'photos'
+            ) THEN
+                ALTER TABLE tasks ADD COLUMN photos JSONB DEFAULT '[]';
+            END IF;
+        END $$
     `);
 
     console.log('Tables created.');

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -192,6 +192,63 @@ const TaskAPI = {
         }
     },
 
+    /**
+     * Upload photos for a task via multipart/form-data.
+     * @param {string} taskId - Task UUID
+     * @param {File[]} files - Array of File objects
+     * @returns {Promise<{photos: string[], uploaded: string[]}>}
+     */
+    async uploadPhotos(taskId, files) {
+        const formData = new FormData();
+        files.forEach(file => formData.append('photos', file));
+
+        const res = await fetch(`${this.baseUrl}/tasks/${encodeURIComponent(taskId)}/photos`, {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: formData,
+            // Note: Do NOT set Content-Type header - browser sets it with boundary
+        });
+        if (res.status === 401) {
+            window.location.href = '/login';
+            throw new Error('Authentication required');
+        }
+        if (!res.ok) {
+            const body = await res.json().catch(() => ({}));
+            throw new Error(body.message || `HTTP ${res.status}`);
+        }
+        return res.json();
+    },
+
+    /**
+     * Delete a photo from a task.
+     * @param {string} taskId - Task UUID
+     * @param {string} filename - Photo filename
+     * @returns {Promise<{photos: string[]}>}
+     */
+    async deletePhoto(taskId, filename) {
+        return this._fetch(`/tasks/${encodeURIComponent(taskId)}/photos/${encodeURIComponent(filename)}`, {
+            method: 'DELETE',
+        });
+    },
+
+    /**
+     * Get the URL for a photo thumbnail.
+     * @param {string} filename - Photo filename
+     * @returns {string} Thumbnail URL
+     */
+    getPhotoThumbUrl(filename) {
+        return `${this.baseUrl}/photos/${encodeURIComponent(filename)}/thumb`;
+    },
+
+    /**
+     * Get the URL for a full-size photo.
+     * @param {string} filename - Photo filename
+     * @returns {string} Full-size photo URL
+     */
+    getPhotoUrl(filename) {
+        return `${this.baseUrl}/photos/${encodeURIComponent(filename)}`;
+    },
+
     async archiveTask(id) {
         return this._fetch(`/tasks/${encodeURIComponent(id)}/archive`, { method: "POST" });
     },

--- a/src/js/task-renderer.js
+++ b/src/js/task-renderer.js
@@ -92,7 +92,7 @@ GartenPlaner.prototype.renderTasks = function () {
 			card.querySelectorAll(".task-photo-thumbnail").forEach((thumb) => {
 				thumb.addEventListener("click", (e) => {
 					e.stopPropagation();
-					this.openPhotoLightbox(thumb.src);
+					this.openPhotoLightbox(thumb.dataset.fullSrc || thumb.src);
 				});
 			});
 
@@ -877,13 +877,14 @@ GartenPlaner.prototype.renderPhotoThumbnails = function (task) {
 	}
 
 	var thumbnails = task.photos
-		.map(
-			(photo, index) =>
-				`<img src="${photo}" alt="Foto ${index + 1}" class="task-photo-thumbnail" data-task-id="${task.id}" data-photo-index="${index}" />`,
-		)
+		.map(function (photo, index) {
+			var src = photo.startsWith("data:") ? photo : TaskAPI.getPhotoThumbUrl(photo);
+			var fullSrc = photo.startsWith("data:") ? photo : TaskAPI.getPhotoUrl(photo);
+			return '<img src="' + src + '" alt="Foto ' + (index + 1) + '" class="task-photo-thumbnail" data-task-id="' + task.id + '" data-photo-index="' + index + '" data-full-src="' + fullSrc + '" />';
+		})
 		.join("");
 
-	return `<div class="task-photo-thumbnails">${thumbnails}</div>`;
+	return '<div class="task-photo-thumbnails">' + thumbnails + '</div>';
 };
 
 GartenPlaner.prototype.openPhotoLightbox = function (src) {
@@ -935,6 +936,31 @@ GartenPlaner.prototype.openPhotoLightbox = function (src) {
 	);
 };
 
+/**
+ * Validate a photo file (type and size check).
+ * @param {File} file
+ * @returns {boolean} true if valid
+ */
+GartenPlaner.prototype.validatePhotoFile = function (file) {
+	if (!file || !file.type.startsWith("image/")) {
+		return false;
+	}
+	var allowedTypes = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+	if (allowedTypes.indexOf(file.type) === -1) {
+		return false;
+	}
+	// 5 MB limit
+	if (file.size > 5 * 1024 * 1024) {
+		return false;
+	}
+	return true;
+};
+
+/**
+ * Process a photo file for local preview (still used for offline/local mode).
+ * @param {File} file
+ * @returns {Promise<string>} data URL
+ */
 GartenPlaner.prototype.processPhotoFile = function (file) {
 	return new Promise(function (resolve, reject) {
 		if (!file || !file.type.startsWith("image/")) {
@@ -999,13 +1025,16 @@ GartenPlaner.prototype.setupPhotoUploadCreate = function () {
 		}
 
 		for (var i = 0; i < files.length; i++) {
-			try {
-				var dataUrl = await self.processPhotoFile(files[i]);
-				if (!self.tempPhotos) self.tempPhotos = [];
-				self.tempPhotos.push(dataUrl);
-			} catch (err) {
-				self.showNotification("Fehler beim Verarbeiten: " + err.message, "error");
+			if (!self.validatePhotoFile(files[i])) {
+				self.showNotification("Ungueltige Datei: " + files[i].name + " (nur jpg, png, gif, webp bis 5 MB)", "error");
+				continue;
 			}
+			if (!self.tempPhotos) self.tempPhotos = [];
+			// Store the File object for multipart upload; keep a preview URL
+			self.tempPhotos.push({
+				file: files[i],
+				previewUrl: URL.createObjectURL(files[i]),
+			});
 		}
 
 		self.renderPhotoPreviewCreate();
@@ -1027,10 +1056,11 @@ GartenPlaner.prototype.renderPhotoPreviewCreate = function () {
 
 	var self = this;
 	container.innerHTML = this.tempPhotos
-		.map(function (photo, index) {
+		.map(function (item, index) {
+			var src = item.previewUrl || item;
 			return (
 				'<div class="photo-preview-item">' +
-				'<img src="' + photo + '" alt="Vorschau ' + (index + 1) + '" />' +
+				'<img src="' + src + '" alt="Vorschau ' + (index + 1) + '" />' +
 				'<button type="button" class="photo-remove-btn" data-photo-index="' + index + '" aria-label="Foto entfernen">&times;</button>' +
 				"</div>"
 			);
@@ -1046,6 +1076,10 @@ GartenPlaner.prototype.renderPhotoPreviewCreate = function () {
 	container.querySelectorAll(".photo-remove-btn").forEach(function (btn) {
 		btn.addEventListener("click", function () {
 			var idx = parseInt(btn.dataset.photoIndex);
+			// Revoke object URL to free memory
+			if (self.tempPhotos[idx] && self.tempPhotos[idx].previewUrl) {
+				URL.revokeObjectURL(self.tempPhotos[idx].previewUrl);
+			}
 			self.tempPhotos.splice(idx, 1);
 			self.renderPhotoPreviewCreate();
 		});
@@ -1057,8 +1091,16 @@ GartenPlaner.prototype.setupPhotoUploadEdit = function (task) {
 	var input = document.getElementById("photoInputEdit");
 	if (!input) return;
 
-	// Initialize edit photos from task
-	this.editPhotos = task.photos ? task.photos.slice() : [];
+	// Initialize edit photos from task: existing filenames as strings, new uploads as {file, previewUrl}
+	this.editPhotos = task.photos ? task.photos.map(function (p) {
+		if (typeof p === "string" && !p.startsWith("data:")) {
+			return { filename: p, previewUrl: TaskAPI.getPhotoThumbUrl(p) };
+		}
+		// Legacy Base64 or already an object
+		return { filename: null, previewUrl: p.previewUrl || p };
+	}) : [];
+	// Track which new File objects to upload
+	this.editPhotoNewFiles = [];
 
 	// Clone to remove old listeners
 	var newInput = input.cloneNode(true);
@@ -1077,12 +1119,17 @@ GartenPlaner.prototype.setupPhotoUploadEdit = function (task) {
 		}
 
 		for (var i = 0; i < files.length; i++) {
-			try {
-				var dataUrl = await self.processPhotoFile(files[i]);
-				self.editPhotos.push(dataUrl);
-			} catch (err) {
-				self.showNotification("Fehler beim Verarbeiten: " + err.message, "error");
+			if (!self.validatePhotoFile(files[i])) {
+				self.showNotification("Ungueltige Datei: " + files[i].name + " (nur jpg, png, gif, webp bis 5 MB)", "error");
+				continue;
 			}
+			var item = {
+				filename: null,
+				file: files[i],
+				previewUrl: URL.createObjectURL(files[i]),
+			};
+			self.editPhotos.push(item);
+			self.editPhotoNewFiles.push(item);
 		}
 
 		self.renderPhotoPreviewEdit();
@@ -1105,10 +1152,11 @@ GartenPlaner.prototype.renderPhotoPreviewEdit = function () {
 
 	var self = this;
 	container.innerHTML = this.editPhotos
-		.map(function (photo, index) {
+		.map(function (item, index) {
+			var src = item.previewUrl || item;
 			return (
 				'<div class="photo-preview-item">' +
-				'<img src="' + photo + '" alt="Foto ' + (index + 1) + '" />' +
+				'<img src="' + src + '" alt="Foto ' + (index + 1) + '" />' +
 				'<button type="button" class="photo-remove-btn" data-photo-index="' + index + '" aria-label="Foto entfernen">&times;</button>' +
 				"</div>"
 			);
@@ -1124,6 +1172,14 @@ GartenPlaner.prototype.renderPhotoPreviewEdit = function () {
 	container.querySelectorAll(".photo-remove-btn").forEach(function (btn) {
 		btn.addEventListener("click", function () {
 			var idx = parseInt(btn.dataset.photoIndex);
+			var removed = self.editPhotos[idx];
+			// Revoke object URL if it was a new file
+			if (removed && removed.file && removed.previewUrl) {
+				URL.revokeObjectURL(removed.previewUrl);
+				// Remove from new files list
+				var fileIdx = self.editPhotoNewFiles.indexOf(removed);
+				if (fileIdx !== -1) self.editPhotoNewFiles.splice(fileIdx, 1);
+			}
 			self.editPhotos.splice(idx, 1);
 			self.renderPhotoPreviewEdit();
 		});

--- a/src/js/task-state.js
+++ b/src/js/task-state.js
@@ -61,26 +61,54 @@ GartenPlaner.prototype.addTask = async function () {
 			return;
 		}
 
-		var photos = this.tempPhotos ? this.tempPhotos.slice() : [];
+		// Collect new photo File objects for upload
+		var photoFiles = [];
+		if (this.tempPhotos) {
+			for (var pi = 0; pi < this.tempPhotos.length; pi++) {
+				if (this.tempPhotos[pi] && this.tempPhotos[pi].file) {
+					photoFiles.push(this.tempPhotos[pi].file);
+				}
+			}
+		}
 
 		let task;
 		if (this.useAPI) {
+			// Create task first (without photos)
 			task = await TaskAPI.createTask({
 				...taskData,
 				subtasks: this.tempSubtasks.map((st) => ({
 					text: st.text,
 					completed: st.completed,
 				})),
-				photos: photos,
 			});
+			// Then upload photos via multipart endpoint
+			if (photoFiles.length > 0 && task && task.id) {
+				try {
+					var photoResult = await TaskAPI.uploadPhotos(task.id, photoFiles);
+					task.photos = photoResult.photos;
+				} catch (photoErr) {
+					console.error("Foto-Upload fehlgeschlagen:", photoErr);
+					this.showNotification("Aufgabe erstellt, aber Fotos konnten nicht hochgeladen werden.", "warning");
+				}
+			}
 		} else {
+			// Offline/local mode: use data URLs as before
+			var offlinePhotos = [];
+			if (this.tempPhotos) {
+				for (var opi = 0; opi < this.tempPhotos.length; opi++) {
+					var item = this.tempPhotos[opi];
+					if (item && item.previewUrl && item.previewUrl.startsWith("data:")) {
+						offlinePhotos.push(item.previewUrl);
+					}
+				}
+			}
 			task = {
 				id: Date.now(),
 				...taskData,
 				createdAt: new Date().toISOString(),
 				history: [],
 				subtasks: [...this.tempSubtasks],
-				photos: photos,
+				photos: offlinePhotos,
 			};
 			this.addHistoryEntry(task, "created", {
 				title: task.title,
@@ -97,6 +125,14 @@ GartenPlaner.prototype.addTask = async function () {
 		this.updateLocationFilter();
 
 		this.resetCreateForm();
+		// Revoke preview URLs and clear temp photos
+		if (this.tempPhotos) {
+			for (var rpi = 0; rpi < this.tempPhotos.length; rpi++) {
+				if (this.tempPhotos[rpi] && this.tempPhotos[rpi].previewUrl) {
+					URL.revokeObjectURL(this.tempPhotos[rpi].previewUrl);
+				}
+			}
+		}
 		this.tempPhotos = [];
 		if (typeof this.renderPhotoPreviewCreate === 'function') {
 			this.renderPhotoPreviewCreate();
@@ -297,10 +333,53 @@ GartenPlaner.prototype.saveEditedTask = async function (id) {
 		task.employee = taskData.employee;
 		task.location = taskData.location;
 		task.description = taskData.description;
-		// Update photos
-		if (this.editPhotos !== undefined) {
-			task.photos = this.editPhotos.slice();
+
+		// Handle photos: upload new files, collect existing filenames
+		if (this.editPhotos !== undefined && this.useAPI) {
+			// Upload new photo files first
+			var newFiles = this.editPhotoNewFiles || [];
+			if (newFiles.length > 0) {
+				var filesToUpload = newFiles.map(function (item) { return item.file; });
+				try {
+					var uploadResult = await TaskAPI.uploadPhotos(id, filesToUpload);
+					// Merge: existing filenames + newly uploaded filenames
+					// The server already handles the merge, so use the returned list
+					task.photos = uploadResult.photos;
+				} catch (uploadErr) {
+					console.error("Foto-Upload fehlgeschlagen:", uploadErr);
+					this.showNotification("Fotos konnten nicht hochgeladen werden.", "warning");
+				}
+			}
+			// Delete photos that were removed in the edit UI
+			var existingPhotos = Array.isArray(task.photos) ? task.photos : [];
+			var keptFilenames = this.editPhotos
+				.filter(function (item) { return item.filename; })
+				.map(function (item) { return item.filename; });
+			for (var dpi = 0; dpi < existingPhotos.length; dpi++) {
+				if (typeof existingPhotos[dpi] === "string" && !existingPhotos[dpi].startsWith("data:") && keptFilenames.indexOf(existingPhotos[dpi]) === -1) {
+					try {
+						await TaskAPI.deletePhoto(id, existingPhotos[dpi]);
+					} catch (delErr) {
+						console.error("Foto-Loeschung fehlgeschlagen:", delErr);
+					}
+				}
+			}
+			// Refresh task photos from what's remaining
+			task.photos = keptFilenames;
+			if (newFiles.length > 0 && task.photos) {
+				// Re-fetch task to get the final photo list
+				try {
+					var refreshed = await TaskAPI.getTask(id);
+					if (refreshed) task.photos = refreshed.photos;
+				} catch (_e) { /* ignore */ }
+			}
+		} else if (this.editPhotos !== undefined) {
+			// Offline mode: keep data URLs
+			task.photos = this.editPhotos.map(function (item) {
+				return item.previewUrl || item;
+			});
 		}
+
 		const changes = [];
 		if (oldTitle !== task.title)
 			changes.push(`Titel: "${oldTitle}" \u2192 "${task.title}"`);

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -15,6 +15,7 @@ const { listCategories } = require('./services/plant-service');
 const tasksRouter = require('./routes/tasks');
 const archiveRouter = require('./routes/archive');
 const plantsRouter = require('./routes/plants');
+const photosRouter = require('./routes/photos');
 const authRouter = require('./routes/auth');
 const adminRouter = require('./routes/admin');
 const { requireAdmin } = require('./middleware/require-admin');
@@ -144,12 +145,17 @@ app.delete('/api/v1/tasks/:id', writeLimiter);
 app.post('/api/v1/tasks/:id/archive', writeLimiter);
 app.post('/api/v1/tasks/:id/unarchive', writeLimiter);
 app.delete('/api/v1/archived-tasks/:id', writeLimiter);
+app.post('/api/tasks/:id/photos', writeLimiter);
+app.delete('/api/tasks/:id/photos/:filename', writeLimiter);
+app.post('/api/v1/tasks/:id/photos', writeLimiter);
+app.delete('/api/v1/tasks/:id/photos/:filename', writeLimiter);
 
 // --- API Routes ---
 
 app.use('/api/tasks', tasksRouter);
 app.use('/api', archiveRouter);
 app.use('/api/plants', plantsRouter);
+app.use('/api', photosRouter);
 
 // GET /api/plant-categories - List unique categories
 app.get('/api/plant-categories', (req, res) => {
@@ -161,6 +167,7 @@ app.get('/api/plant-categories', (req, res) => {
 app.use('/api/v1/tasks', tasksRouter);
 app.use('/api/v1', archiveRouter);
 app.use('/api/v1/plants', plantsRouter);
+app.use('/api/v1', photosRouter);
 
 // GET /api/v1/plant-categories - List unique categories (versioned)
 app.get('/api/v1/plant-categories', (req, res) => {

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -54,4 +54,20 @@ const STORAGE = {
     WRITE_RETRY_DELAY_MS: 50,
 };
 
-module.exports = { PAGINATION, FIELD_LIMITS, STORAGE };
+/**
+ * @typedef {Object} PhotoConfig
+ * @property {number} MAX_FILE_SIZE - Max file size in bytes (5 MB)
+ * @property {number} MAX_PHOTOS_PER_TASK - Max photos per task
+ * @property {number} THUMB_WIDTH - Thumbnail width in pixels
+ * @property {number} THUMB_HEIGHT - Thumbnail height in pixels
+ */
+
+/** @type {PhotoConfig} */
+const PHOTOS = {
+    MAX_FILE_SIZE: 5 * 1024 * 1024,
+    MAX_PHOTOS_PER_TASK: 3,
+    THUMB_WIDTH: 200,
+    THUMB_HEIGHT: 200,
+};
+
+module.exports = { PAGINATION, FIELD_LIMITS, STORAGE, PHOTOS };

--- a/src/server/routes/photos.js
+++ b/src/server/routes/photos.js
@@ -1,0 +1,152 @@
+/**
+ * @module routes/photos
+ * Express router for photo upload, serving, and deletion.
+ * - POST /api/v1/tasks/:id/photos - Upload photo(s) for a task
+ * - GET  /api/v1/photos/:filename - Serve a photo file
+ * - GET  /api/v1/photos/:filename/thumb - Serve a thumbnail
+ * - DELETE /api/v1/tasks/:id/photos/:filename - Remove a photo from a task
+ */
+
+const express = require('express');
+const multer = require('multer');
+const { validateIdParam } = require('../validation/task-validator');
+const store = require('../storage/postgres-store');
+const { audit } = require('../logger');
+const {
+    ALLOWED_MIMETYPES,
+    MAX_FILE_SIZE,
+    MAX_PHOTOS_PER_TASK,
+    savePhoto,
+    deletePhoto,
+    getPhotoPath,
+    getThumbPath,
+} = require('../services/photo-service');
+
+const router = express.Router();
+
+// --- Multer configuration: memory storage for processing before writing ---
+const upload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: MAX_FILE_SIZE },
+    fileFilter(req, file, cb) {
+        if (ALLOWED_MIMETYPES.includes(file.mimetype)) {
+            cb(null, true);
+        } else {
+            cb(new Error('Nur Bilddateien erlaubt (jpg, png, gif, webp)'));
+        }
+    },
+});
+
+/**
+ * POST /tasks/:id/photos - Upload one or more photos for a task.
+ * Accepts multipart/form-data with field name "photos".
+ */
+router.post('/tasks/:id/photos', validateIdParam, upload.array('photos', MAX_PHOTOS_PER_TASK), async (req, res) => {
+    const task = await store.getTaskById(req.params.id);
+    if (!task) {
+        return res.status(404).json({ error: true, status: 404, message: 'Task not found' });
+    }
+
+    const currentPhotos = Array.isArray(task.photos) ? task.photos : [];
+    const remaining = MAX_PHOTOS_PER_TASK - currentPhotos.length;
+
+    if (remaining <= 0) {
+        return res.status(400).json({
+            error: true,
+            status: 400,
+            message: `Maximal ${MAX_PHOTOS_PER_TASK} Fotos erlaubt. Keine weiteren moeglich.`,
+        });
+    }
+
+    const files = req.files || [];
+    if (files.length === 0) {
+        return res.status(400).json({ error: true, status: 400, message: 'Keine Dateien hochgeladen' });
+    }
+
+    const toProcess = files.slice(0, remaining);
+    const savedFilenames = [];
+
+    for (const file of toProcess) {
+        const filename = await savePhoto(file.buffer, file.mimetype);
+        savedFilenames.push(filename);
+    }
+
+    const updatedPhotos = [...currentPhotos, ...savedFilenames];
+    await store.updateTask(req.params.id, { photos: updatedPhotos });
+
+    audit('photos_uploaded', { taskId: req.params.id, count: savedFilenames.length, filenames: savedFilenames });
+
+    res.status(201).json({
+        photos: updatedPhotos,
+        uploaded: savedFilenames,
+    });
+});
+
+/**
+ * GET /photos/:filename - Serve a full-size photo.
+ */
+router.get('/photos/:filename', (req, res) => {
+    const filePath = getPhotoPath(req.params.filename);
+    if (!filePath) {
+        return res.status(404).json({ error: true, status: 404, message: 'Foto nicht gefunden' });
+    }
+    res.sendFile(filePath);
+});
+
+/**
+ * GET /photos/:filename/thumb - Serve a thumbnail.
+ */
+router.get('/photos/:filename/thumb', (req, res) => {
+    const filePath = getThumbPath(req.params.filename);
+    if (!filePath) {
+        return res.status(404).json({ error: true, status: 404, message: 'Thumbnail nicht gefunden' });
+    }
+    res.sendFile(filePath);
+});
+
+/**
+ * DELETE /tasks/:id/photos/:filename - Remove a photo from a task.
+ */
+router.delete('/tasks/:id/photos/:filename', validateIdParam, async (req, res) => {
+    const task = await store.getTaskById(req.params.id);
+    if (!task) {
+        return res.status(404).json({ error: true, status: 404, message: 'Task not found' });
+    }
+
+    const currentPhotos = Array.isArray(task.photos) ? task.photos : [];
+    const filename = req.params.filename;
+
+    if (!currentPhotos.includes(filename)) {
+        return res.status(404).json({ error: true, status: 404, message: 'Foto nicht in dieser Aufgabe' });
+    }
+
+    // Delete file from disk
+    deletePhoto(filename);
+
+    // Remove from task's photo list
+    const updatedPhotos = currentPhotos.filter(p => p !== filename);
+    await store.updateTask(req.params.id, { photos: updatedPhotos });
+
+    audit('photo_deleted', { taskId: req.params.id, filename });
+
+    res.status(200).json({ photos: updatedPhotos });
+});
+
+// --- Multer error handler ---
+router.use((err, req, res, _next) => {
+    if (err instanceof multer.MulterError) {
+        if (err.code === 'LIMIT_FILE_SIZE') {
+            return res.status(400).json({ error: true, status: 400, message: 'Datei zu gross (max. 5 MB)' });
+        }
+        if (err.code === 'LIMIT_UNEXPECTED_FILE') {
+            return res.status(400).json({ error: true, status: 400, message: 'Zu viele Dateien' });
+        }
+        return res.status(400).json({ error: true, status: 400, message: err.message });
+    }
+    if (err && err.message && err.message.includes('Nur Bilddateien')) {
+        return res.status(400).json({ error: true, status: 400, message: err.message });
+    }
+    _next(err);
+});
+
+module.exports = router;

--- a/src/server/services/photo-service.js
+++ b/src/server/services/photo-service.js
@@ -1,0 +1,192 @@
+/**
+ * @module services/photo-service
+ * File-based photo storage: upload, thumbnail generation, serving, and deletion.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+const sharp = require('sharp');
+const { logger } = require('../logger');
+
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, '..', '..', '..', 'data');
+const PHOTOS_DIR = path.join(DATA_DIR, 'photos');
+const THUMBS_DIR = path.join(PHOTOS_DIR, 'thumbs');
+
+const THUMB_WIDTH = 200;
+const THUMB_HEIGHT = 200;
+
+const ALLOWED_MIMETYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+const MAX_PHOTOS_PER_TASK = 3;
+
+/**
+ * Ensure photo directories exist.
+ */
+function ensureDirectories() {
+    if (!fs.existsSync(PHOTOS_DIR)) {
+        fs.mkdirSync(PHOTOS_DIR, { recursive: true });
+    }
+    if (!fs.existsSync(THUMBS_DIR)) {
+        fs.mkdirSync(THUMBS_DIR, { recursive: true });
+    }
+}
+
+// Create directories on module load
+ensureDirectories();
+
+/**
+ * Map mimetype to file extension.
+ * @param {string} mimetype
+ * @returns {string} file extension with dot
+ */
+function mimeToExt(mimetype) {
+    const map = {
+        'image/jpeg': '.jpg',
+        'image/png': '.png',
+        'image/gif': '.gif',
+        'image/webp': '.webp',
+    };
+    return map[mimetype] || '.jpg';
+}
+
+/**
+ * Generate a unique filename for a photo.
+ * @param {string} mimetype
+ * @returns {string} unique filename
+ */
+function generateFilename(mimetype) {
+    return uuidv4() + mimeToExt(mimetype);
+}
+
+/**
+ * Create a thumbnail for a given photo file.
+ * @param {string} filename - The photo filename
+ * @returns {Promise<void>}
+ */
+async function createThumbnail(filename) {
+    const inputPath = path.join(PHOTOS_DIR, filename);
+    const outputPath = path.join(THUMBS_DIR, filename);
+
+    try {
+        await sharp(inputPath)
+            .resize(THUMB_WIDTH, THUMB_HEIGHT, { fit: 'cover' })
+            .toFile(outputPath);
+    } catch (err) {
+        logger.error({ err: err.message, filename }, 'Failed to create thumbnail');
+        // Don't throw - thumbnail generation failure shouldn't block upload
+    }
+}
+
+/**
+ * Save an uploaded file buffer to disk and generate a thumbnail.
+ * @param {Buffer} buffer - File contents
+ * @param {string} mimetype - MIME type of the file
+ * @returns {Promise<string>} The generated filename
+ */
+async function savePhoto(buffer, mimetype) {
+    const filename = generateFilename(mimetype);
+    const filePath = path.join(PHOTOS_DIR, filename);
+
+    fs.writeFileSync(filePath, buffer);
+    await createThumbnail(filename);
+
+    logger.info({ filename, size: buffer.length }, 'Photo saved');
+    return filename;
+}
+
+/**
+ * Save a Base64 data URL as a file and generate a thumbnail.
+ * Used by the migration script and backwards-compatible create/update.
+ * @param {string} dataUrl - Base64 data URL (data:image/...;base64,...)
+ * @returns {Promise<string|null>} The generated filename or null on error
+ */
+async function saveBase64Photo(dataUrl) {
+    try {
+        const match = dataUrl.match(/^data:(image\/\w+);base64,(.+)$/);
+        if (!match) return null;
+
+        const mimetype = match[1];
+        if (!ALLOWED_MIMETYPES.includes(mimetype)) return null;
+
+        const buffer = Buffer.from(match[2], 'base64');
+        return await savePhoto(buffer, mimetype);
+    } catch (err) {
+        logger.error({ err: err.message }, 'Failed to save Base64 photo');
+        return null;
+    }
+}
+
+/**
+ * Delete a photo and its thumbnail from disk.
+ * @param {string} filename
+ * @returns {boolean} true if file was deleted
+ */
+function deletePhoto(filename) {
+    // Sanitize: only allow simple filenames (no path traversal)
+    if (!filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+        return false;
+    }
+
+    const filePath = path.join(PHOTOS_DIR, filename);
+    const thumbPath = path.join(THUMBS_DIR, filename);
+
+    let deleted = false;
+    if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+        deleted = true;
+    }
+    if (fs.existsSync(thumbPath)) {
+        fs.unlinkSync(thumbPath);
+    }
+
+    if (deleted) {
+        logger.info({ filename }, 'Photo deleted');
+    }
+    return deleted;
+}
+
+/**
+ * Get the full filesystem path for a photo.
+ * @param {string} filename
+ * @returns {string|null} Full path or null if not found
+ */
+function getPhotoPath(filename) {
+    if (!filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+        return null;
+    }
+    const filePath = path.join(PHOTOS_DIR, filename);
+    return fs.existsSync(filePath) ? filePath : null;
+}
+
+/**
+ * Get the full filesystem path for a thumbnail.
+ * Falls back to the original photo if thumbnail doesn't exist.
+ * @param {string} filename
+ * @returns {string|null} Full path or null if not found
+ */
+function getThumbPath(filename) {
+    if (!filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+        return null;
+    }
+    const thumbPath = path.join(THUMBS_DIR, filename);
+    if (fs.existsSync(thumbPath)) return thumbPath;
+
+    // Fallback to original
+    const filePath = path.join(PHOTOS_DIR, filename);
+    return fs.existsSync(filePath) ? filePath : null;
+}
+
+module.exports = {
+    PHOTOS_DIR,
+    THUMBS_DIR,
+    ALLOWED_MIMETYPES,
+    MAX_FILE_SIZE,
+    MAX_PHOTOS_PER_TASK,
+    ensureDirectories,
+    savePhoto,
+    saveBase64Photo,
+    deletePhoto,
+    getPhotoPath,
+    getThumbPath,
+};

--- a/src/server/services/task-service.js
+++ b/src/server/services/task-service.js
@@ -45,6 +45,7 @@ const { audit } = require('../logger');
 const { PAGINATION } = require('../config');
 const { validateTask, sanitizeTaskData } = require('../validation/task-validator');
 const store = require('../storage/postgres-store');
+const { saveBase64Photo, deletePhoto } = require('./photo-service');
 
 // --- Pagination helper ---
 
@@ -177,9 +178,22 @@ async function createTask(body) {
             text: typeof st === 'string' ? st : (st.text || ''),
             completed: typeof st === 'object' ? !!st.completed : false
         })) : [],
-        photos: Array.isArray(sanitized.photos) ? sanitized.photos.filter(p => typeof p === 'string' && p.startsWith('data:image/')).slice(0, 3) : [],
+        photos: [],
         sortOrder: Date.now()
     };
+
+    // Convert Base64 photos to file-based storage (backwards compatible)
+    if (Array.isArray(sanitized.photos)) {
+        for (const photo of sanitized.photos.slice(0, 3)) {
+            if (typeof photo === 'string' && photo.startsWith('data:image/')) {
+                const filename = await saveBase64Photo(photo);
+                if (filename) task.photos.push(filename);
+            } else if (typeof photo === 'string' && !photo.includes('/') && !photo.includes('\\')) {
+                // Already a filename reference
+                task.photos.push(photo);
+            }
+        }
+    }
 
     const created = await store.createTask(task);
     audit('task_created', { taskId: created.id, title: sanitized.title, employee: sanitized.employee });
@@ -269,7 +283,27 @@ async function updateTask(id, body) {
         })) : [];
     }
     if (sanitized.photos !== undefined) {
-        updatedFields.photos = Array.isArray(sanitized.photos) ? sanitized.photos.filter(p => typeof p === 'string' && p.startsWith('data:image/')).slice(0, 3) : [];
+        const newPhotos = [];
+        if (Array.isArray(sanitized.photos)) {
+            for (const photo of sanitized.photos.slice(0, 3)) {
+                if (typeof photo === 'string' && photo.startsWith('data:image/')) {
+                    // Convert Base64 to file (backwards compatible)
+                    const filename = await saveBase64Photo(photo);
+                    if (filename) newPhotos.push(filename);
+                } else if (typeof photo === 'string' && !photo.includes('/') && !photo.includes('\\')) {
+                    // Already a filename reference
+                    newPhotos.push(photo);
+                }
+            }
+        }
+        // Delete photos that were removed
+        const existingPhotos = Array.isArray(existing.photos) ? existing.photos : [];
+        for (const oldPhoto of existingPhotos) {
+            if (!newPhotos.includes(oldPhoto) && !oldPhoto.startsWith('data:')) {
+                deletePhoto(oldPhoto);
+            }
+        }
+        updatedFields.photos = newPhotos;
     }
 
     if (changes.length > 0) {
@@ -300,6 +334,15 @@ async function deleteTask(id) {
     const existing = await store.getTaskById(id);
     if (!existing) {
         return { error: true, status: 404, message: 'Task not found' };
+    }
+
+    // Clean up photo files
+    if (Array.isArray(existing.photos)) {
+        for (const photo of existing.photos) {
+            if (typeof photo === 'string' && !photo.startsWith('data:')) {
+                deletePhoto(photo);
+            }
+        }
     }
 
     await store.deleteTask(id);
@@ -364,6 +407,15 @@ async function deleteArchivedTask(id) {
     const existing = await store.getTaskById(id);
     if (!existing) {
         return { error: true, status: 404, message: 'Archived task not found' };
+    }
+
+    // Clean up photo files
+    if (Array.isArray(existing.photos)) {
+        for (const photo of existing.photos) {
+            if (typeof photo === 'string' && !photo.startsWith('data:')) {
+                deletePhoto(photo);
+            }
+        }
     }
 
     await store.deleteTask(id);

--- a/src/server/storage/postgres-store.js
+++ b/src/server/storage/postgres-store.js
@@ -23,6 +23,7 @@ function rowToTask(row) {
         recurrence: row.recurrence,
         subtasks: row.subtasks || [],
         history: row.history || [],
+        photos: row.photos || [],
         sortOrder: parseInt(row.sort_order),
         completedAt: row.completed_at,
         archivedAt: row.archived_at,
@@ -60,13 +61,14 @@ async function readArchivedTasks() {
  */
 async function createTask(task) {
     const { rows } = await query(`
-        INSERT INTO tasks (id, title, employee, location, description, notes, status, priority, recurrence, subtasks, history, sort_order, created_at)
-        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+        INSERT INTO tasks (id, title, employee, location, description, notes, status, priority, recurrence, subtasks, history, photos, sort_order, created_at)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
         RETURNING *
     `, [
         task.id, task.title, task.employee, task.location,
         task.description, task.notes, task.status, task.priority, task.recurrence,
         JSON.stringify(task.subtasks), JSON.stringify(task.history),
+        JSON.stringify(task.photos || []),
         task.sortOrder, task.createdAt
     ]);
     return rowToTask(rows[0]);
@@ -113,6 +115,10 @@ async function updateTask(id, fields) {
     if (fields.history !== undefined) {
         setClauses.push(`history = $${idx++}`);
         values.push(JSON.stringify(fields.history));
+    }
+    if (fields.photos !== undefined) {
+        setClauses.push(`photos = $${idx++}`);
+        values.push(JSON.stringify(fields.photos));
     }
 
     if (setClauses.length === 0) {

--- a/src/server/validation/task-validator.js
+++ b/src/server/validation/task-validator.js
@@ -116,12 +116,16 @@ function validateTask(taskData, partial = false) {
             }
             taskData.photos.forEach((photo, i) => {
                 if (typeof photo !== 'string') {
-                    errors.push(`Foto ${i + 1}: muss ein String (Data-URL) sein`);
-                } else if (!photo.startsWith('data:image/')) {
-                    errors.push(`Foto ${i + 1}: muss eine g\u00fcltige Bild-Data-URL sein`);
-                } else if (photo.length > 1500000) {
-                    errors.push(`Foto ${i + 1}: darf maximal ca. 1 MB gro\u00df sein`);
+                    errors.push(`Foto ${i + 1}: muss ein String sein`);
+                } else if (photo.startsWith('data:image/')) {
+                    // Legacy Base64 data URL (still accepted for backwards compatibility)
+                    if (photo.length > 1500000) {
+                        errors.push(`Foto ${i + 1}: darf maximal ca. 1 MB gro\u00df sein`);
+                    }
+                } else if (photo.includes('..') || photo.includes('/') || photo.includes('\\')) {
+                    errors.push(`Foto ${i + 1}: ungueltiger Dateiname`);
                 }
+                // else: valid filename reference — OK
             });
         }
     }

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -202,14 +202,25 @@ describe('validateTask', () => {
         expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('String')]));
     });
 
-    test('rejects photo without data:image/ prefix', () => {
-        const result = validateTask({ ...validTask, photos: ['not-a-data-url'] });
+    test('accepts photo filename reference', () => {
+        const result = validateTask({ ...validTask, photos: ['abc-123.jpg'] });
+        expect(result.valid).toBe(true);
+    });
+
+    test('rejects photo with path traversal', () => {
+        const result = validateTask({ ...validTask, photos: ['../etc/passwd'] });
         expect(result.valid).toBe(false);
-        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('Data-URL')]));
+        expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('Dateiname')]));
     });
 
     test('accepts exactly 3 photos', () => {
         const photos = Array.from({ length: 3 }, () => 'data:image/jpeg;base64,/9j/4AAQ');
+        const result = validateTask({ ...validTask, photos });
+        expect(result.valid).toBe(true);
+    });
+
+    test('accepts mix of Base64 and filename references', () => {
+        const photos = ['data:image/jpeg;base64,/9j/4AAQ', 'abc-123.jpg'];
         const result = validateTask({ ...validTask, photos });
         expect(result.valid).toBe(true);
     });
@@ -328,15 +339,17 @@ describeWithDB('API Endpoints', () => {
             expect(res.body).toHaveProperty('errors');
         });
 
-        test('creates a task with photos', async () => {
+        test('creates a task with Base64 photos (converted to filenames)', async () => {
             const photos = ['data:image/jpeg;base64,/9j/4AAQ', 'data:image/png;base64,iVBOR'];
             const res = await request(app)
                 .post('/api/tasks')
                 .send({ ...validTask, photos });
 
             expect(res.status).toBe(201);
+            // Photos are now stored as filenames (UUID-based), not Base64
             expect(res.body.photos).toHaveLength(2);
-            expect(res.body.photos[0]).toBe('data:image/jpeg;base64,/9j/4AAQ');
+            expect(res.body.photos[0]).toMatch(/\.jpg$/);
+            expect(res.body.photos[1]).toMatch(/\.png$/);
         });
 
         test('creates a task with empty photos array', async () => {
@@ -438,7 +451,7 @@ describeWithDB('API Endpoints', () => {
             expect(res.body.subtasks[1].completed).toBe(false);
         });
 
-        test('updates photos on a task', async () => {
+        test('updates photos on a task (Base64 converted to filename)', async () => {
             const created = await request(app).post('/api/tasks').send(validTask);
             const photos = ['data:image/jpeg;base64,/9j/4AAQ'];
             const res = await request(app)
@@ -447,7 +460,7 @@ describeWithDB('API Endpoints', () => {
 
             expect(res.status).toBe(200);
             expect(res.body.photos).toHaveLength(1);
-            expect(res.body.photos[0]).toBe('data:image/jpeg;base64,/9j/4AAQ');
+            expect(res.body.photos[0]).toMatch(/\.jpg$/);
         });
 
         test('rejects subtasks exceeding max count via PUT', async () => {


### PR DESCRIPTION
## Summary
- Fotos werden jetzt als Dateien in `data/photos/` gespeichert statt Base64 in der DB
- Multer-basierte Upload-Endpoints für multipart/form-data
- Automatische Thumbnail-Generierung via Sharp
- Migration-Script für bestehende Base64-Fotos

## Changes
- **New:** `src/server/services/photo-service.js` — Datei-Speicherung, Thumbnails, Löschung
- **New:** `src/server/routes/photos.js` — REST-Endpoints (POST/GET/DELETE)
- **New:** `scripts/migrate-photos.js` — Konvertiert Base64 → Dateien
- **Modified:** `src/server/services/task-service.js` — Base64→Datei bei Create/Update, Cleanup bei Delete
- **Modified:** `src/js/api.js` — `uploadPhotos()`, `deletePhoto()`, URL-Helper
- **Modified:** `src/js/task-renderer.js` — Thumbnails via URL statt Base64
- **Modified:** `src/js/task-state.js` — File-Upload-Flow statt Base64
- **Modified:** `scripts/migrate.js` — `photos JSONB` Column
- **Dependencies:** `multer`, `sharp`

## Deployment
1. `npm install` (multer, sharp)
2. `npm run migrate` (photos Column)
3. `npm run migrate-photos` (bestehende Base64 → Dateien)
4. Docker: Volume auf `/app/data` für persistente Fotos

## Test plan
- [ ] Foto-Upload via UI → Datei in `data/photos/` + Thumbnail in `data/photos/thumbs/`
- [ ] Foto-Anzeige in Task-Liste (Thumbnails) und Lightbox (Full-Size)
- [ ] Foto-Löschung entfernt Datei + DB-Referenz
- [ ] Migration-Script konvertiert bestehende Base64-Fotos
- [ ] Tests laufen

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)