### PR TITLE
fix: 6 CVEs im Docker-Image beheben (#264)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Gartenplaner Docker Image
 # Node.js Express Server with REST API
 
-FROM node:22-alpine
+FROM node:22-alpine3.21
 
 # Metadaten
 LABEL maintainer="GardenPlanner"
@@ -9,8 +9,9 @@ LABEL description="Gartenplaner - Webanwendung mit REST API zur Verwaltung von G
 
 WORKDIR /app
 
-# Update Alpine packages to fix known vulnerabilities (CVE-2025-60876)
-RUN apk update && apk upgrade --no-cache
+# Update Alpine packages to fix known vulnerabilities
+# CVE-2025-60876 (busybox), CVE-2026-31790 & CVE-2026-2673 (openssl)
+RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl
 
 # Dependencies installieren
 # NPM_REGISTRY defaults to public npm; override for internal builds:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {
@@ -29,5 +29,8 @@
     "jest": "^30.3.0",
     "picomatch": "^4.0.4",
     "supertest": "^7.2.2"
+  },
+  "overrides": {
+    "brace-expansion": "^2.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- **CVE-2026-31790, CVE-2026-2673** (high) — Alpine OpenSSL 3.5.5-r0: Base-Image auf `node:22-alpine3.21` + explizites `apk add openssl`
- **CVE-2025-60876** (medium) — Alpine Busybox 1.37.0-r30: Behoben durch `node:22-alpine3.21`
- **CVE-2026-33671, CVE-2026-33672** (high/medium) — picomatch 4.0.3: Bereits auf ^4.0.4 in devDependencies
- **CVE-2026-33750** (medium) — brace-expansion 2.0.2: Override auf ^2.0.3 in package.json

## Version
3.8.2 → 3.8.3