### PR TITLE
fix: 11 CVEs beheben — tar, minimatch, picomatch, openssl, busybox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ WORKDIR /app
 
 # Update Alpine packages to fix known vulnerabilities
 # CVE-2025-60876 (busybox), CVE-2026-31790 & CVE-2026-2673 (openssl)
-RUN apk update && apk upgrade --no-cache && apk add --no-cache openssl
+RUN apk update && apk upgrade --no-cache \
+    && apk add --no-cache openssl busybox \
+    && apk info -v openssl busybox
 
 # Dependencies installieren
 # NPM_REGISTRY defaults to public npm; override for internal builds:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {
@@ -31,6 +31,9 @@
     "supertest": "^7.2.2"
   },
   "overrides": {
-    "brace-expansion": "^2.0.3"
+    "brace-expansion": "^2.0.3",
+    "tar": "^7.5.13",
+    "minimatch": "^10.2.5",
+    "picomatch": "^4.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- **tar 7.4.3** → Override ^7.5.13 — 5 High-CVEs (CVE-2026-23950, -24842, -23745, -29786, -31802)
- **minimatch 9.0.5** → Override ^10.2.5 — 3 High-CVEs (CVE-2026-26996, -27904, -27903)
- **picomatch 4.0.2** → Override ^4.0.4 — 1 High-CVE (CVE-2026-33671)
- **openssl 3.3.6-r0** → Explizites `apk add` im Dockerfile — CVE-2026-31790
- **busybox 1.37.0-r14** → Explizites `apk add` im Dockerfile — CVE-2025-60876

## Version
3.8.3 → 3.8.4