### PR TITLE
fix(security): CVE-Overrides v2 — exakte Versionen fuer vollstaendige Abdeckung

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ ARG NPM_STRICT_SSL=true
 COPY package.json package-lock.json* ./
 RUN npm config set strict-ssl ${NPM_STRICT_SSL} \
     && npm config set registry ${NPM_REGISTRY} \
-    && npm ci --omit=dev
+    && npm ci --omit=dev \
+    && (npm audit fix --force || true)
 RUN npm audit --audit-level=high
 
 # Anwendungsdateien kopieren (#7: no tests/docs in production)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {
@@ -31,9 +31,10 @@
     "supertest": "^7.2.2"
   },
   "overrides": {
-    "brace-expansion": "^2.0.3",
-    "tar": "^7.5.13",
-    "minimatch": "^10.2.5",
-    "picomatch": "^4.0.4"
+    "tar": "7.5.13",
+    "brace-expansion": "2.0.3",
+    "minimatch": "10.2.5",
+    "picomatch": "4.0.4",
+    "glob": "11.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- **npm overrides auf exakte Versionen (ohne ^) umgestellt**, damit ALLE Instanzen im Dependency-Tree ersetzt werden — nicht nur die gleiche Major-Version
- **glob@11.0.2 Override hinzugefuegt** gegen CVE-2025-64756
- **Dockerfile: `npm audit fix --force` als Safety-Net** nach `npm ci --omit=dev`
- Version bump 3.8.5 -> 3.8.6

## Problem
Die bisherigen Overrides mit Caret (`^`) griffen nicht vollstaendig:
| Paket | Scanner sah | Override alt | Warum es nicht griff |
|-------|-------------|-------------|---------------------|
| tar | 6.2.1 | `^7.5.13` | Nur tar@7.x wurde ersetzt, nicht tar@6.x |
| minimatch | 9.0.5 | `^10.2.5` | Nur minimatch@10.x wurde ersetzt, nicht 9.x |
| picomatch | 4.0.2 | `^4.0.4` | Sollte greifen, aber exakte Version ist sicherer |
| glob | 10.4.5 | — | Kein Override vorhanden |

## Loesung
Exakte Versionen ohne Caret zwingen npm, ALLE Instanzen zu ersetzen:
```json
"overrides": {
    "tar": "7.5.13",
    "brace-expansion": "2.0.3",
    "minimatch": "10.2.5",
    "picomatch": "4.0.4",
    "glob": "11.0.2"
}
```

Zusaetzlich: `npm audit fix --force` im Dockerfile als Safety-Net fuer Faelle, die Overrides allein nicht abdecken.

## Test plan
- [ ] CI-Pipeline baut Docker-Image erfolgreich
- [ ] `npm audit` im Docker-Build zeigt keine High/Critical CVEs
- [ ] Docker Hub Scanner zeigt keine verwundbaren Versionen von tar, minimatch, picomatch, glob
- [ ] Anwendung startet und funktioniert korrekt im Container