### PR TITLE
feat: Display-Ansicht — Vollbild-Kiosk für TV/Monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.8.6",
+  "version": "3.9.0",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {

--- a/public/display.html
+++ b/public/display.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Display - Gartenplaner</title>
+    <meta
+      name="description"
+      content="Aufgaben-Display fuer TV/Monitor - Vollbildansicht offener Aufgaben"
+    />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌱</text></svg>"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../src/css/display.css" />
+  </head>
+  <body>
+    <div class="display-container">
+      <header class="display-header">
+        <div class="display-header-left">
+          <h1 class="display-title">Offene Aufgaben</h1>
+          <span class="display-counter" id="taskCounter">0</span>
+        </div>
+        <div class="display-header-right">
+          <span class="display-clock" id="clock"></span>
+        </div>
+      </header>
+
+      <main class="display-main" id="tasksGrid">
+        <!-- Aufgaben-Cards werden hier dynamisch eingefuegt -->
+      </main>
+
+      <div class="display-empty" id="emptyState" hidden>
+        <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+          <polyline points="22 4 12 14.01 9 11.01"/>
+        </svg>
+        <p>Keine offenen Aufgaben</p>
+      </div>
+
+      <footer class="display-footer">
+        <span class="display-last-update" id="lastUpdate"></span>
+      </footer>
+    </div>
+
+    <script nonce="__CSP_NONCE__" src="../src/js/display.js"></script>
+  </body>
+</html>

--- a/src/css/display.css
+++ b/src/css/display.css
@@ -1,0 +1,403 @@
+/* ===========================================
+   Display-Ansicht — TV/Monitor Vollbild
+   =========================================== */
+
+/* ---------- Reset & Base ---------- */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* ---------- CSS Custom Properties ---------- */
+:root {
+  /* Spacing */
+  --d-space-xs: 0.25rem;
+  --d-space-sm: 0.5rem;
+  --d-space-md: 1rem;
+  --d-space-lg: 1.5rem;
+  --d-space-xl: 2rem;
+
+  /* Typography */
+  --d-font-heading: "DM Serif Display", Georgia, serif;
+  --d-font-body: "Nunito", system-ui, sans-serif;
+
+  /* Radii */
+  --d-radius: 12px;
+  --d-radius-sm: 8px;
+  --d-radius-badge: 6px;
+
+  /* Durations */
+  --d-duration: 0.3s;
+
+  /* Priority colors */
+  --d-priority-high: #E11D48;
+  --d-priority-medium: #EA580C;
+  --d-priority-low: #16A34A;
+
+  /* Light theme (default) */
+  --d-bg: #F5F3EE;
+  --d-bg-card: #FFFFFF;
+  --d-text: #1C1917;
+  --d-text-secondary: #78716C;
+  --d-border: #E7E5E4;
+  --d-header-bg: #365E3D;
+  --d-header-text: #FFFFFF;
+  --d-badge-bg: rgba(0, 0, 0, 0.06);
+  --d-overdue-bg: rgba(225, 29, 72, 0.06);
+  --d-overdue-border: #E11D48;
+  --d-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --d-shadow-card: 0 1px 4px rgba(0, 0, 0, 0.06);
+  --d-empty-color: #A8A29E;
+}
+
+/* ---------- Dark Theme ---------- */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --d-bg: #0C0A09;
+    --d-bg-card: #1C1917;
+    --d-text: #F5F5F4;
+    --d-text-secondary: #A8A29E;
+    --d-border: #44403C;
+    --d-header-bg: #1C1917;
+    --d-header-text: #A8D5BA;
+    --d-badge-bg: rgba(255, 255, 255, 0.08);
+    --d-overdue-bg: rgba(225, 29, 72, 0.12);
+    --d-overdue-border: #f87171;
+    --d-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    --d-shadow-card: 0 1px 4px rgba(0, 0, 0, 0.2);
+    --d-empty-color: #57534E;
+
+    --d-priority-high: #f87171;
+    --d-priority-medium: #fb923c;
+    --d-priority-low: #4ade80;
+  }
+}
+
+/* ---------- Body ---------- */
+html, body {
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  font-family: var(--d-font-body);
+  background: var(--d-bg);
+  color: var(--d-text);
+  cursor: default;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  user-select: none;
+}
+
+/* ---------- Container ---------- */
+.display-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  padding: var(--d-space-lg);
+  gap: var(--d-space-lg);
+}
+
+/* ---------- Header ---------- */
+.display-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+  padding: var(--d-space-md) var(--d-space-xl);
+  background: var(--d-header-bg);
+  border-radius: var(--d-radius);
+  box-shadow: var(--d-shadow);
+}
+
+.display-header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--d-space-md);
+}
+
+.display-title {
+  font-family: var(--d-font-heading);
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--d-header-text);
+  line-height: 1.2;
+}
+
+.display-counter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.4rem;
+  height: 2.4rem;
+  padding: 0 var(--d-space-sm);
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--d-header-text);
+  font-family: var(--d-font-body);
+  font-size: 1.1rem;
+  font-weight: 700;
+  border-radius: 999px;
+  line-height: 1;
+}
+
+.display-header-right {
+  display: flex;
+  align-items: center;
+}
+
+.display-clock {
+  font-family: var(--d-font-body);
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--d-header-text);
+  letter-spacing: 0.02em;
+}
+
+/* ---------- Main Grid ---------- */
+.display-main {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: var(--d-space-lg);
+  align-content: start;
+  overflow-y: auto;
+  padding: var(--d-space-xs);
+}
+
+/* Dezenter Scrollbar */
+.display-main::-webkit-scrollbar {
+  width: 6px;
+}
+
+.display-main::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.display-main::-webkit-scrollbar-thumb {
+  background: var(--d-border);
+  border-radius: 3px;
+}
+
+/* ---------- Task Card ---------- */
+.display-card {
+  background: var(--d-bg-card);
+  border-radius: var(--d-radius);
+  padding: var(--d-space-lg);
+  border-left: 5px solid var(--d-priority-low);
+  box-shadow: var(--d-shadow-card);
+  transition: opacity var(--d-duration) ease;
+  display: flex;
+  flex-direction: column;
+  gap: var(--d-space-sm);
+}
+
+.display-card--priority-high {
+  border-left-color: var(--d-priority-high);
+}
+
+.display-card--priority-medium {
+  border-left-color: var(--d-priority-medium);
+}
+
+.display-card--priority-low {
+  border-left-color: var(--d-priority-low);
+}
+
+/* Overdue styling */
+.display-card--overdue {
+  background: var(--d-overdue-bg);
+  border-left-color: var(--d-overdue-border);
+  box-shadow: 0 0 0 1px var(--d-overdue-border), var(--d-shadow-card);
+}
+
+/* ---------- Card Title ---------- */
+.display-card__title {
+  font-family: var(--d-font-heading);
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--d-text);
+  line-height: 1.3;
+}
+
+/* ---------- Card Badges ---------- */
+.display-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--d-space-sm);
+  margin-top: var(--d-space-xs);
+}
+
+.display-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--d-radius-badge);
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+/* Priority badges */
+.display-badge--high {
+  background: rgba(225, 29, 72, 0.12);
+  color: var(--d-priority-high);
+}
+
+.display-badge--medium {
+  background: rgba(234, 88, 12, 0.12);
+  color: var(--d-priority-medium);
+}
+
+.display-badge--low {
+  background: rgba(22, 163, 74, 0.12);
+  color: var(--d-priority-low);
+}
+
+/* Status badges */
+.display-badge--pending {
+  background: var(--d-badge-bg);
+  color: var(--d-text-secondary);
+}
+
+.display-badge--in-progress {
+  background: rgba(124, 58, 237, 0.12);
+  color: #7C3AED;
+}
+
+@media (prefers-color-scheme: dark) {
+  .display-badge--in-progress {
+    color: #A78BFA;
+  }
+}
+
+/* ---------- Card Meta (location, date) ---------- */
+.display-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--d-space-sm) var(--d-space-lg);
+  margin-top: var(--d-space-xs);
+  color: var(--d-text-secondary);
+  font-size: 0.95rem;
+}
+
+.display-card__meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.display-card__meta-item svg {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.display-card__meta-item--overdue {
+  color: var(--d-priority-high);
+  font-weight: 600;
+}
+
+/* ---------- Empty State ---------- */
+.display-empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--d-space-lg);
+  color: var(--d-empty-color);
+}
+
+.display-empty svg {
+  opacity: 0.4;
+}
+
+.display-empty p {
+  font-family: var(--d-font-heading);
+  font-size: 1.6rem;
+}
+
+/* ---------- Footer ---------- */
+.display-footer {
+  flex-shrink: 0;
+  text-align: right;
+  padding: 0 var(--d-space-sm);
+}
+
+.display-last-update {
+  font-size: 0.8rem;
+  color: var(--d-text-secondary);
+  opacity: 0.6;
+}
+
+/* ---------- Fade animation for refresh ---------- */
+.display-fade-out {
+  opacity: 0.3;
+  transition: opacity 0.4s ease;
+}
+
+.display-fade-in {
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 800px) {
+  .display-container {
+    padding: var(--d-space-md);
+    gap: var(--d-space-md);
+  }
+
+  .display-title {
+    font-size: 1.4rem;
+  }
+
+  .display-clock {
+    font-size: 1.2rem;
+  }
+
+  .display-main {
+    grid-template-columns: 1fr;
+  }
+
+  .display-card__title {
+    font-size: 1.2rem;
+  }
+}
+
+@media (min-width: 1600px) {
+  .display-container {
+    padding: var(--d-space-xl) 3rem;
+  }
+
+  .display-title {
+    font-size: 2.2rem;
+  }
+
+  .display-clock {
+    font-size: 2rem;
+  }
+
+  .display-card__title {
+    font-size: 1.5rem;
+  }
+
+  .display-badge {
+    font-size: 0.95rem;
+  }
+
+  .display-card__meta {
+    font-size: 1.05rem;
+  }
+}
+
+@media (min-width: 2400px) {
+  .display-main {
+    grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));
+  }
+
+  .display-card__title {
+    font-size: 1.7rem;
+  }
+}

--- a/src/js/display.js
+++ b/src/js/display.js
@@ -1,0 +1,244 @@
+/**
+ * Display-Ansicht — TV/Monitor Vollbild
+ *
+ * Laedt offene Aufgaben von /api/v1/tasks und zeigt sie
+ * als nicht-interaktive Cards in einem responsiven Grid.
+ * Automatisches Refresh alle 5 Minuten.
+ */
+(function () {
+  'use strict';
+
+  // --- Konfiguration ---
+  var API_URL = '/api/v1/tasks';
+  var REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 Minuten
+  var CLOCK_INTERVAL_MS = 1000;
+
+  // --- DOM-Referenzen ---
+  var tasksGrid = document.getElementById('tasksGrid');
+  var emptyState = document.getElementById('emptyState');
+  var taskCounter = document.getElementById('taskCounter');
+  var clockEl = document.getElementById('clock');
+  var lastUpdateEl = document.getElementById('lastUpdate');
+
+  // --- Hilfsfunktionen ---
+
+  /**
+   * Gibt das heutige Datum als YYYY-MM-DD String zurueck (lokal).
+   */
+  function todayString() {
+    var d = new Date();
+    var y = d.getFullYear();
+    var m = String(d.getMonth() + 1).padStart(2, '0');
+    var day = String(d.getDate()).padStart(2, '0');
+    return y + '-' + m + '-' + day;
+  }
+
+  /**
+   * Prüft ob ein Datum ueberfaellig ist.
+   */
+  function isOverdue(dueDate) {
+    if (!dueDate) return false;
+    return dueDate < todayString();
+  }
+
+  /**
+   * Formatiert ein Datum als lesbaren deutschen String.
+   */
+  function formatDate(dateStr) {
+    if (!dateStr) return '';
+    try {
+      var parts = dateStr.split('-');
+      return parts[2] + '.' + parts[1] + '.' + parts[0];
+    } catch (e) {
+      return dateStr;
+    }
+  }
+
+  /**
+   * Formatiert die aktuelle Uhrzeit als HH:MM:SS.
+   */
+  function formatTime() {
+    var now = new Date();
+    var h = String(now.getHours()).padStart(2, '0');
+    var m = String(now.getMinutes()).padStart(2, '0');
+    var s = String(now.getSeconds()).padStart(2, '0');
+    return h + ':' + m + ':' + s;
+  }
+
+  /**
+   * Formatiert einen Timestamp fuer die letzte Aktualisierung.
+   */
+  function formatLastUpdate() {
+    var now = new Date();
+    var h = String(now.getHours()).padStart(2, '0');
+    var m = String(now.getMinutes()).padStart(2, '0');
+    return 'Letzte Aktualisierung: ' + h + ':' + m;
+  }
+
+  /**
+   * Escapet HTML-Zeichen.
+   */
+  function escapeHtml(str) {
+    if (!str) return '';
+    var div = document.createElement('div');
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+  }
+
+  /**
+   * Sortiert Tasks: Prioritaet (high > medium > low), dann Faelligkeitsdatum.
+   */
+  function sortTasks(tasks) {
+    var priorityOrder = { high: 0, medium: 1, low: 2 };
+    return tasks.slice().sort(function (a, b) {
+      var pa = priorityOrder[a.priority] !== undefined ? priorityOrder[a.priority] : 3;
+      var pb = priorityOrder[b.priority] !== undefined ? priorityOrder[b.priority] : 3;
+      if (pa !== pb) return pa - pb;
+      // Faelligkeitsdatum: fruehere zuerst, ohne Datum ans Ende
+      var da = a.dueDate || '9999-12-31';
+      var db = b.dueDate || '9999-12-31';
+      return da.localeCompare(db);
+    });
+  }
+
+  /**
+   * Filtert nur offene Tasks (pending, in-progress).
+   */
+  function filterOpenTasks(tasks) {
+    return tasks.filter(function (t) {
+      return t.status === 'pending' || t.status === 'in-progress';
+    });
+  }
+
+  // --- SVG Icons ---
+
+  var iconLocation = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>';
+
+  var iconCalendar = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>';
+
+  // --- Prioritaet & Status Labels ---
+
+  var priorityLabels = {
+    high: 'Hoch',
+    medium: 'Mittel',
+    low: 'Niedrig'
+  };
+
+  var statusLabels = {
+    pending: 'Offen',
+    'in-progress': 'In Bearbeitung'
+  };
+
+  // --- Card rendern ---
+
+  /**
+   * Erstellt das HTML fuer eine einzelne Task-Card.
+   */
+  function renderCard(task) {
+    var priority = task.priority || 'low';
+    var status = task.status || 'pending';
+    var overdue = isOverdue(task.dueDate);
+
+    var classes = ['display-card', 'display-card--priority-' + priority];
+    if (overdue) classes.push('display-card--overdue');
+
+    var html = '<article class="' + classes.join(' ') + '">';
+
+    // Titel
+    html += '<h2 class="display-card__title">' + escapeHtml(task.title) + '</h2>';
+
+    // Badges
+    html += '<div class="display-card__badges">';
+    html += '<span class="display-badge display-badge--' + priority + '">' + escapeHtml(priorityLabels[priority] || priority) + '</span>';
+    html += '<span class="display-badge display-badge--' + status + '">' + escapeHtml(statusLabels[status] || status) + '</span>';
+    html += '</div>';
+
+    // Meta (Standort, Datum)
+    var hasMeta = task.location || task.dueDate;
+    if (hasMeta) {
+      html += '<div class="display-card__meta">';
+      if (task.location) {
+        html += '<span class="display-card__meta-item">' + iconLocation + ' ' + escapeHtml(task.location) + '</span>';
+      }
+      if (task.dueDate) {
+        var dateClass = overdue ? ' display-card__meta-item--overdue' : '';
+        html += '<span class="display-card__meta-item' + dateClass + '">' + iconCalendar + ' ' + escapeHtml(formatDate(task.dueDate)) + '</span>';
+      }
+      html += '</div>';
+    }
+
+    html += '</article>';
+    return html;
+  }
+
+  // --- Daten laden und rendern ---
+
+  /**
+   * Laedt Tasks von der API und rendert das Grid.
+   */
+  function loadAndRender() {
+    fetch(API_URL, { credentials: 'same-origin' })
+      .then(function (res) {
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+      })
+      .then(function (data) {
+        // API kann { data: [...] } oder direkt [...] liefern
+        var tasks = Array.isArray(data) ? data : (data.data || []);
+        var openTasks = filterOpenTasks(tasks);
+        var sorted = sortTasks(openTasks);
+
+        // Counter aktualisieren
+        taskCounter.textContent = sorted.length;
+
+        if (sorted.length === 0) {
+          tasksGrid.innerHTML = '';
+          tasksGrid.hidden = true;
+          emptyState.hidden = false;
+        } else {
+          emptyState.hidden = true;
+          tasksGrid.hidden = false;
+
+          // Fade-Effekt
+          tasksGrid.classList.add('display-fade-out');
+
+          setTimeout(function () {
+            var html = '';
+            for (var i = 0; i < sorted.length; i++) {
+              html += renderCard(sorted[i]);
+            }
+            tasksGrid.innerHTML = html;
+            tasksGrid.classList.remove('display-fade-out');
+            tasksGrid.classList.add('display-fade-in');
+
+            setTimeout(function () {
+              tasksGrid.classList.remove('display-fade-in');
+            }, 500);
+          }, 400);
+        }
+
+        // Letzte Aktualisierung
+        lastUpdateEl.textContent = formatLastUpdate();
+      })
+      .catch(function (err) {
+        console.error('Display: Fehler beim Laden der Aufgaben', err);
+        // Bei Fehler bestehende Anzeige beibehalten, nur Timestamp aktualisieren
+        lastUpdateEl.textContent = 'Fehler beim Laden — ' + formatTime();
+      });
+  }
+
+  // --- Uhr aktualisieren ---
+  function updateClock() {
+    clockEl.textContent = formatTime();
+  }
+
+  // --- Initialisierung ---
+  updateClock();
+  setInterval(updateClock, CLOCK_INTERVAL_MS);
+
+  // Erster Datenladen
+  loadAndRender();
+
+  // Auto-Refresh alle 5 Minuten
+  setInterval(loadAndRender, REFRESH_INTERVAL_MS);
+})();

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -126,7 +126,7 @@ app.get('/api/version', (req, res) => {
 // In production with bundles, serve pre-processed HTML from dist/
 const HTML_ROOT = USE_BUNDLES ? DIST_DIR : path.join(PROJECT_ROOT, 'public');
 
-const pages = ['index', 'dashboard', 'statistics', 'logs', 'plants', 'garden', 'calendar', 'login', 'admin'];
+const pages = ['index', 'dashboard', 'statistics', 'logs', 'plants', 'garden', 'calendar', 'login', 'admin', 'display'];
 pages.forEach(page => {
     app.get(`/${page}`, (req, res) => {
         res.sendFile(path.join(HTML_ROOT, `${page}.html`));


### PR DESCRIPTION
## Summary
- Neue Seite `/display` — optimiert für Anzeige auf TV/Monitor an der Wand
- Nur offene Aufgaben (pending + in-progress), sortiert nach Priorität und Fälligkeit
- Pro Card: Titel, Priorität-Badge, Status, Standort, Fälligkeitsdatum
- Überfällige Tasks rot hervorgehoben
- Auto-Refresh alle 5 Minuten, Live-Uhrzeit
- Dark/Light Theme via System-Preference
- Keine Interaktionselemente (kein Edit, Delete, etc.)

## Version
3.8.6 → 3.9.0