### PR TITLE
feat(ci): Trivy CVE-Scanner in Docker-Publish Pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,11 +49,54 @@ jobs:
             echo "tags=${IMAGE}:beta,${IMAGE}:${VERSION}-beta,${IMAGE}:${VERSION}-beta.${BUILD}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build and push Docker image
+      - name: Build Docker image (lokal)
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ${{ steps.tags.outputs.tags }}
+          push: false
+          load: true
+          tags: gardenplanner:local
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Trivy Vulnerability Scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'gardenplanner:local'
+          format: 'table'
+          output: 'trivy-report.txt'
+          severity: 'MEDIUM,HIGH,CRITICAL'
+          exit-code: '0'
+          vuln-type: 'os,library'
+
+      - name: Trivy Scan Summary
+        if: always()
+        run: |
+          echo "## 🔍 Trivy Vulnerability Scan" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** gardenplanner:local" >> $GITHUB_STEP_SUMMARY
+          echo "**Severity-Filter:** MEDIUM, HIGH, CRITICAL" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -s trivy-report.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat trivy-report.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Keine Schwachstellen gefunden." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload Trivy Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-vulnerability-report
+          path: trivy-report.txt
+          retention-days: 30
+
+      - name: Docker Image taggen und pushen
+        run: |
+          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          for tag in "${TAG_ARRAY[@]}"; do
+            docker tag gardenplanner:local "$tag"
+            docker push "$tag"
+          done

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Zusammenfassung

- Trivy CVE-Scanner in die Docker-Publish CI-Pipeline integriert
- Docker-Build aufgeteilt: lokal bauen → scannen → pushen
- Scan-Report als GitHub Actions Artifact und Step-Summary verfügbar
- Nicht-blockierend (Warnung statt Fehler) für initiale Visibility

## Änderungen

### docker-publish.yml
- **Build-Split**: `docker/build-push-action` baut jetzt erst lokal (`push: false`, `load: true`) mit Tag `gardenplanner:local`
- **Trivy Scan**: Scannt OS-Packages (Alpine) und npm-Dependencies auf MEDIUM/HIGH/CRITICAL Schwachstellen
- **Step-Summary**: Vulnerability-Report direkt in der GitHub Actions UI sichtbar
- **Artifact Upload**: Scan-Report als `trivy-vulnerability-report` herunterladbar (30 Tage Aufbewahrung)
- **Push**: Nach dem Scan werden die Images manuell getaggt und zu Docker Hub gepusht

### package.json
- Version bump: 3.9.1 → 3.9.2

## Workflow-Ablauf (neu)

1. Checkout + Setup
2. Lockfile-Sync + Version extrahieren
3. Docker-Tags bestimmen
4. **Docker Image lokal bauen** (ohne Push)
5. **Trivy Vulnerability Scan** (nicht-blockierend)
6. **Scan-Report als Artifact hochladen**
7. **Image taggen und zu Docker Hub pushen**

## Testplan

- [ ] Workflow auf develop-Branch triggern und prüfen, ob der Trivy-Scan läuft
- [ ] Step-Summary in der Actions UI auf Vulnerability-Report prüfen
- [ ] Artifact `trivy-vulnerability-report` herunterladen und prüfen
- [ ] Sicherstellen, dass das Docker-Image trotz gefundener CVEs gepusht wird (nicht-blockierend)