### PR TITLE
fix: Console.log durch Debug-Modus ersetzen (#281)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2,6 +2,9 @@
 // Orchestrator: Defines class, constructor, init, and Weather integration.
 // Methods are added by module files via prototype extension:
 //   task-state.js, task-filters.js, task-renderer.js, task-events.js, task-export.js
+
+// Debug-Logging: nur aktiv wenn localStorage.debug === 'true'
+var debug = (localStorage.getItem('debug') === 'true') ? console.log.bind(console) : function() {};
 class GartenPlaner {
 	constructor() {
 		this.tasks = [];
@@ -588,19 +591,19 @@ document.addEventListener("DOMContentLoaded", () => {
 	window.announcer = announcer;
 	window.GP.announcer = announcer;
 
-	console.log("🌱 Gartenplaner erfolgreich gestartet!");
-	console.log(
+	debug("🌱 Gartenplaner erfolgreich gestartet!");
+	debug(
 		"💾 Alle Änderungen werden automatisch im Browser gespeichert (LocalStorage)",
 	);
-	console.log("🖱️ Drag & Drop aktiviert - Ziehe Aufgaben zum Sortieren!");
-	console.log(
+	debug("🖱️ Drag & Drop aktiviert - Ziehe Aufgaben zum Sortieren!");
+	debug(
 		"✓ Bulk-Aktionen aktiviert - Mehrere Aufgaben gleichzeitig bearbeiten!",
 	);
-	console.log("🌙 Dark Mode verfügbar - Klick auf den Button unten rechts!");
-	console.log(
+	debug("🌙 Dark Mode verfügbar - Klick auf den Button unten rechts!");
+	debug(
 		"🖨️ Print-Stylesheet aktiviert - Optimierte Druckansicht verfügbar!",
 	);
-	console.log(
+	debug(
 		"♿ Accessibility verbessert - ARIA-Labels und Keyboard-Navigation!",
 	);
 

--- a/src/js/dashboard-init.js
+++ b/src/js/dashboard-init.js
@@ -1,7 +1,10 @@
 // Dashboard-spezifische Initialisierung (#71)
+// Debug-Logging: nur aktiv wenn localStorage.debug === 'true'
+var debug = (localStorage.getItem('debug') === 'true') ? console.log.bind(console) : function() {};
+
 document.addEventListener('DOMContentLoaded', function () {
     if (window.gartenPlaner) {
-        console.log('📊 Dashboard geladen');
+        debug('📊 Dashboard geladen');
     }
 
     // View Toggle: Liste / Kacheln (#238)

--- a/src/js/pwa-register.js
+++ b/src/js/pwa-register.js
@@ -1,4 +1,7 @@
 // PWA Service Worker Registration
+// Debug-Logging: nur aktiv wenn localStorage.debug === 'true'
+var debug = (localStorage.getItem('debug') === 'true') ? console.log.bind(console) : function() {};
+
 (function() {
     if ('serviceWorker' in navigator) {
         window.addEventListener('load', function() {
@@ -8,11 +11,11 @@
                         var newWorker = registration.installing;
                         newWorker.addEventListener('statechange', function() {
                             if (newWorker.state === 'activated') {
-                                console.log('[PWA] Neuer Service Worker aktiviert');
+                                debug('[PWA] Neuer Service Worker aktiviert');
                             }
                         });
                     });
-                    console.log('[PWA] Service Worker registriert:', registration.scope);
+                    debug('[PWA] Service Worker registriert:', registration.scope);
                 })
                 .catch(function(error) {
                     console.warn('[PWA] Service Worker Registration fehlgeschlagen:', error);


### PR DESCRIPTION
## Summary
- Console.log-Ausgaben in Production-Frontend-Code durch Debug-Modus ersetzt
- Debug-Logging nur aktiv wenn `localStorage.debug === 'true'`
- `console.error` und `console.warn` bleiben unveraendert (Error-Handling)

## Aenderungen
- **src/js/app.js**: 7 informative console.log durch `debug()` ersetzt, Debug-Helper hinzugefuegt
- **src/js/dashboard-init.js**: Dashboard-Lademeldung durch `debug()` ersetzt
- **src/js/pwa-register.js**: Service-Worker-Registrierungs-Logs durch `debug()` ersetzt
- **package.json**: Version bump 3.10.1 -> 3.10.2

## Debug-Modus aktivieren
```js
localStorage.setItem('debug', 'true');
// Seite neu laden
```

## Nicht geaendert (bewusst)
- `src/js/encryption.js` — Security-relevante Logs
- `src/js/error-handler.js` — Error-Logs
- `src/js/logger.js` — Ist selbst der Logger
- Backend-Code — Nutzt bereits pino Logger

## Test plan
- [ ] App starten ohne Debug-Modus: keine console.log-Ausgaben in DevTools
- [ ] `localStorage.setItem('debug', 'true')` setzen und neu laden: alle Debug-Meldungen sichtbar
- [ ] console.error und console.warn erscheinen weiterhin immer (z.B. Wetter-Fehler)
- [ ] PWA-Registrierung funktioniert weiterhin korrekt
- [ ] Dashboard laedt ohne Fehler

Closes #281