### PR TITLE
fix: Async Error-Handling + JWT_SECRET Enforcement (#277, #278)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {
@@ -16,6 +16,7 @@
     "bcrypt": "^6.0.0",
     "compression": "^1.7.5",
     "express": "^4.21.0",
+    "express-async-errors": "^3.1.1",
     "express-rate-limit": "^8.3.1",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.1.1",

--- a/server.js
+++ b/server.js
@@ -7,7 +7,11 @@ const JWT_SECRET = process.env.JWT_SECRET || '';
 
 if (require.main === module) {
     if (process.env.NODE_ENV === 'production' && !JWT_SECRET) {
-        process.stderr.write('\u26a0\ufe0f  WARNUNG: JWT_SECRET ist nicht gesetzt \u2014 Authentifizierung ist deaktiviert!\n');
+        process.stderr.write('FATAL: JWT_SECRET ist nicht gesetzt. Server-Start in Production ohne JWT_SECRET ist nicht erlaubt (Auth-Bypass-Gefahr).\n');
+        process.exit(1);
+    }
+    if (!JWT_SECRET) {
+        process.stderr.write('WARNUNG: JWT_SECRET ist nicht gesetzt — Authentifizierung ist deaktiviert (nur fuer lokale Entwicklung).\n');
     }
 
     migrate().then(() => {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,3 +1,4 @@
+require('express-async-errors');
 const express = require('express');
 const compression = require('compression');
 const fs = require('fs');


### PR DESCRIPTION
## Summary
- **#277** `express-async-errors` installiert — async Fehler crashen nicht mehr den Prozess
- **#278** JWT_SECRET in Production erzwungen — Server startet nicht ohne Secret

## Version
3.10.1 → 3.10.2