### PR TITLE
fix: Dockerfile Build-Fehler — apk Version-Pinning korrigiert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ LABEL description="Gartenplaner - Webanwendung mit REST API zur Verwaltung von G
 WORKDIR /app
 
 # Update Alpine packages to fix known vulnerabilities
-# CVE-2025-60876 (busybox), CVE-2026-28390, CVE-2026-31790 & CVE-2026-2673 (openssl)
-ARG CACHE_BUST=1
-RUN apk update && apk upgrade --no-cache \
-    && apk add --no-cache 'openssl>=3.3.7' 'busybox>=1.37.0-r15' \
+# CVE-2025-60876 (busybox), CVE-2026-28390, CVE-2026-31790 (openssl)
+RUN apk update \
+    && apk upgrade --no-cache \
+    && apk add --no-cache openssl \
     && apk info -v openssl busybox
 
 # Dependencies installieren
@@ -25,7 +25,6 @@ COPY package.json package-lock.json* ./
 RUN npm config set strict-ssl ${NPM_STRICT_SSL} \
     && npm config set registry ${NPM_REGISTRY} \
     && npm ci --omit=dev \
-    && npm update tar minimatch glob picomatch brace-expansion 2>/dev/null || true \
     && (npm audit fix --force || true)
 RUN npm audit --audit-level=high --omit=dev || echo "WARN: npm audit found vulnerabilities (non-blocking)"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- `openssl>=3.3.7` existiert nicht in Alpine 3.21 Repos — Version-Pinning entfernt
- `npm update` nach `npm ci` entfernt (bricht Lockfile-Integrität)
- `apk upgrade` allein aktualisiert auf neueste verfügbare Pakete

## Version
3.11.2 → 3.11.3