### PR TITLE
fix: npm Overrides erzwingen — Lockfile komplett neu generieren

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,10 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: Sync lockfile
-        run: npm install --package-lock-only
+      - name: Sync lockfile (fresh resolve to apply overrides)
+        run: |
+          rm -f package-lock.json
+          npm install --package-lock-only
 
       - name: Install dependencies
         run: npm ci
@@ -118,8 +120,10 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Update lockfile
-        run: npm install --package-lock-only
+      - name: Update lockfile (fresh resolve to apply overrides)
+        run: |
+          rm -f package-lock.json
+          npm install --package-lock-only
 
       - name: Commit and push if changed
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,10 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Sync package-lock.json
-        run: npm install --package-lock-only
+      - name: Sync package-lock.json (fresh resolve to apply overrides)
+        run: |
+          rm -f package-lock.json
+          npm install --package-lock-only
 
       - name: Extract version from package.json
         id: pkg

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.11.5",
+  "version": "3.11.6",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "jest": "^30.3.0",
-    "picomatch": "^4.0.4",
     "supertest": "^7.2.2"
   },
   "overrides": {
@@ -36,6 +35,6 @@
     "brace-expansion": ">=2.0.3",
     "minimatch": ">=9.0.7",
     "glob": ">=10.5.0",
-    "picomatch": "$picomatch"
+    "picomatch": ">=4.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- Lockfile wird in CI/Publish komplett neu generiert (`rm package-lock.json && npm install --package-lock-only`) statt nur aktualisiert
- Das erzwingt, dass npm Overrides für minimatch, glob, picomatch, brace-expansion, tar greifen
- picomatch Override auf `>=4.0.4` geändert (statt `$picomatch` das nur mit devDeps funktioniert)
- picomatch als direkte devDependency entfernt (Override regelt alle Instanzen)

## Version
3.11.5 → 3.11.6