### PR TITLE
fix: npm install statt npm ci — Overrides für Docker Hub CVEs erzwingen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ WORKDIR /app
 ARG NPM_REGISTRY=https://registry.npmjs.org/
 ARG NPM_STRICT_SSL=true
 
-COPY package.json package-lock.json* ./
+COPY package.json ./
 RUN npm config set strict-ssl ${NPM_STRICT_SSL} \
     && npm config set registry ${NPM_REGISTRY} \
-    && npm ci --omit=dev
+    && npm install --omit=dev
 
 # Anwendungsdateien kopieren
 COPY server.js ./

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.11.7",
+  "version": "3.11.8",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {
@@ -31,10 +31,10 @@
     "supertest": "^7.2.2"
   },
   "overrides": {
-    "tar": ">=7.5.13",
-    "brace-expansion": ">=2.0.3",
-    "minimatch": ">=9.0.7",
-    "glob": ">=10.5.0",
-    "picomatch": ">=4.0.4"
+    "tar": "7.5.13",
+    "brace-expansion": "2.0.3",
+    "minimatch": "9.0.7",
+    "glob": "10.5.0",
+    "picomatch": "4.0.4"
   }
 }


### PR DESCRIPTION
## Problem
`npm ci` ignoriert Overrides und installiert exakt die Lockfile-Versionen. Docker Hub Scanner (Docker Scout) findet weiterhin verwundbare Pakete.

## Lösung
- Dockerfile: `npm install --omit=dev` statt `npm ci --omit=dev`
- `npm install` wendet Overrides direkt an und löst Dependencies frisch auf
- Lockfile wird nicht mehr in den Builder kopiert (nur package.json)
- Overrides auf exakte Versionen: tar 7.5.13, minimatch 9.0.7, glob 10.5.0, picomatch 4.0.4, brace-expansion 2.0.3

## Version
3.11.7 → 3.11.8