### PR TITLE
fix: npm aus Production-Image entfernen — eliminiert alle Base-Image CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,16 @@ LABEL description="Gartenplaner - Webanwendung mit REST API zur Verwaltung von G
 WORKDIR /app
 
 # Alpine-Packages aktualisieren (CVE-2025-60876, CVE-2026-28390, CVE-2026-31790)
+# npm/npx/corepack entfernen — wird zur Laufzeit nicht gebraucht,
+# bündelt intern verwundbare Pakete (tar, minimatch, glob, picomatch)
 RUN apk update \
     && apk upgrade --no-cache \
     && apk add --no-cache openssl \
-    && rm -rf /var/cache/apk/*
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /usr/local/lib/node_modules/npm \
+              /usr/local/lib/node_modules/corepack \
+              /usr/local/bin/npm /usr/local/bin/npx \
+              /usr/local/bin/corepack
 
 # Nur Production node_modules aus Builder kopieren (ohne Build-Tools)
 COPY --from=builder /app/node_modules ./node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.11.9",
+  "version": "3.11.10",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Problem
Docker Scout findet CVEs in `node:22-alpine` Base-Image — nicht in unserer App, sondern in npm selbst (`/usr/local/lib/node_modules/npm/`). npm bündelt intern verwundbare Versionen von tar, minimatch, glob, picomatch.

## Lösung
npm, npx und corepack werden im Production-Stage gelöscht. Sie werden zur Laufzeit nicht gebraucht (nur `node server.js`). Der Builder-Stage behält npm für `npm install`.

## Version
3.11.9 → 3.11.10