### PR TITLE
fix: zlib CVEs im Alpine-Image (CVE-2026-22184, CVE-2026-27171)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /app
 # bündelt intern verwundbare Pakete (tar, minimatch, glob, picomatch)
 RUN apk update \
     && apk upgrade --no-cache \
-    && apk add --no-cache openssl \
+    && apk add --no-cache openssl zlib \
     && rm -rf /var/cache/apk/* \
     && rm -rf /usr/local/lib/node_modules/npm \
               /usr/local/lib/node_modules/corepack \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gartenplaner",
-  "version": "3.11.10",
+  "version": "3.11.11",
   "description": "Gartenplaner - Webanwendung mit REST API zur Verwaltung von Gartenaufgaben",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
zlib explizit aktualisiert im Production-Stage. Version 3.11.10 → 3.11.11